### PR TITLE
Correcoes dialogos lid

### DIFF
--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -58,11 +58,17 @@ class WebSocketClient:
             # I/O thread triggers COM cross-thread errors and can freeze the app.
             def _show_error():
                 self.main_window.error_sound.play()
-                parent_dialog = (
-                    self.connect.pairing_dial
-                    if hasattr(self.connect, 'pairing_dial')
-                    else self.connect.connection_dial
-                )
+                parent_dialog = None
+                for name in ('pairing_dial', 'connection_dial'):
+                    dial = getattr(self.connect, name, None)
+                    if dial:
+                        try:
+                            if not wx.IsDestroyed(dial):
+                                parent_dialog = dial
+                                break
+                        except Exception:
+                            pass
+
                 wx.MessageBox(
                     self.i18n.t("instance_state_changed"),
                     self.i18n.t("error").format(app_name=self.main_window.app_name),

--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -382,5 +382,8 @@
     "conv_filter_all": "All",
     "conv_filter_unread": "Unread",
     "conv_filter_groups": "Groups",
-    "conv_filter_individual": "Individual"
+    "conv_filter_individual": "Individual",
+    "unknown_contact": "Unnamed contact",
+    "unknown_group": "Unnamed group",
+    "unnamed_participant": "Unnamed participant"
 }

--- a/client/languages/es-ES.json
+++ b/client/languages/es-ES.json
@@ -372,9 +372,6 @@
     "ui_voice_record_focus_discard": "Botón descartar",
     "invalid_messages_page_size": "El número de mensajes por página debe ser un entero positivo.",
     "forward_search_label": "&Buscar",
-    "menu_file": "&Archivo",
-    "menu_mark_all_read": "Marcar todas las conversaciones como leídas",
-    "menu_shortcuts": "Atajos de teclado",
     "global_hotkey_label": "Atajo global para abrir WinZapp",
     "global_hotkey_hint": "Presiona un atajo (Delete o Retroceso para eliminar)",
     "hotkey_first_run_title": "WinZapp | Atajo global",
@@ -385,5 +382,8 @@
     "conv_filter_all": "Todo",
     "conv_filter_unread": "Sin leer",
     "conv_filter_groups": "Grupos",
-    "conv_filter_individual": "Individuales"
+    "conv_filter_individual": "Individuales",
+    "unknown_contact": "Contacto sin nombre",
+    "unknown_group": "Grupo sin nombre",
+    "unnamed_participant": "Participante sin nombre"
 }

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -382,5 +382,8 @@
     "conv_filter_all": "Tudo",
     "conv_filter_unread": "Não lidas",
     "conv_filter_groups": "Grupos",
-    "conv_filter_individual": "Individuais"
+    "conv_filter_individual": "Individuais",
+    "unknown_contact": "Contato sem nome",
+    "unknown_group": "Grupo sem nome",
+    "unnamed_participant": "Participante sem nome"
 }

--- a/client/main.py
+++ b/client/main.py
@@ -1,4 +1,4 @@
-﻿import os
+import os
 import sys
 import time
 import shutil
@@ -1998,8 +1998,13 @@ class MainWindow(wx.Frame):
                 or chat.get("name", "")
                 or chat.get("pushName", "")
                 or self.find_jid_through_messages(chat)
-                or (format_number(jid) if not jid.endswith("@lid") else "")
+                or (format_number(jid) if not jid.endswith("@lid") and not jid.endswith("@g.us") else "")
             )
+            if not name or not name.strip():
+                if jid.endswith("@g.us"):
+                    name = self.i18n.t("unknown_group")
+                else:
+                    name = self.i18n.t("unknown_contact")
             if my_jid and not jid.endswith("@g.us") and self._is_self_jid(jid):
                 name = self.i18n.t("self_chat_name")
             if jid in archived:
@@ -2230,7 +2235,7 @@ class MainWindow(wx.Frame):
                 if alt and alt.endswith("@s.whatsapp.net"):
                     return format_number(alt)
                 jid = key.get("remoteJid", "")
-                if jid and not jid.endswith("@lid"):
+                if jid and not jid.endswith("@lid") and not jid.endswith("@g.us"):
                     return format_number(jid)
         return None
 
@@ -3243,7 +3248,9 @@ class MainWindow(wx.Frame):
                 return name
         if jid.endswith("@lid"):
             phone_jid = getattr(self, "_lid_to_phone", {}).get(jid, "")
-            return format_number(phone_jid) if phone_jid else ""
+            return format_number(phone_jid) if phone_jid else self.i18n.t("unnamed_participant")
+        if jid.endswith("@g.us"):
+            return self.i18n.t("unknown_group")
         return format_number(jid)
 
     def _last_msg_preview(self, chat: dict) -> str:


### PR DESCRIPTION
Este Pull Request corrige dois problemas críticos relacionados à identificação de contatos/grupos e à estabilidade da aplicação durante a desconexão do WebSocket.

### 🛠️ Correções Aplicadas

#### 1. Correção de Nomes Vazios em Conversas (Contatos LID e Grupos)
* **O problema:** Contatos que utilizavam JIDs finalizados em `@lid` ou grupos (`@g.us`) acabavam caindo na função de formatação de número de telefone (`format_number`), resultando em nomes de exibição vazios (chats sem nome) na lista de conversas.
* **A solução:**
  * Ajustada a lógica em `client/main.py` (`_compute_chat_lists`, `find_jid_through_messages` e `_preview_sender_from_jid`) para ignorar a formatação numérica em JIDs do tipo `@lid` e `@g.us`.
  * Adicionados fallbacks de tradução para contatos e grupos sem nome em Português (`pt-BR.json`), Inglês (`en-US.json`) e Espanhol (`es-ES.json`) utilizando as novas chaves: `unknown_contact`, `unknown_group` e `unnamed_participant`.

#### 2. Correção de AttributeError no Desacoplamento do WebSocket
* **O problema:** Ao desconectar, a thread de I/O do WebSocket tentava acessar os atributos `pairing_dial` ou `connection_dial` do objeto de conexão. Se esses atributos não existissem ou a tela estivesse em processo de destruição, a aplicação quebrava silenciosamente ou gerava um erro de thread com `AttributeError`.
* **A solução:**
  * Refatorada a função interna `_show_error` em `client/core/websocket_client.py`.
  * Adicionada uma verificação segura utilizando `getattr()` para os diálogos `pairing_dial` e `connection_dial`.
  * Implementada verificação de segurança com `wx.IsDestroyed(dial)` para garantir que a janela ainda é válida antes de associar o diálogo pai, prevenindo falhas de concorrência entre threads.
