### PR TITLE
fix: correcao do envio de audio e logica de apagar mensagens

### DIFF
--- a/build.py
+++ b/build.py
@@ -234,6 +234,43 @@ def _find_opus_dll():
 
 OPUS_DLL = _find_opus_dll()
 
+
+def _prepare_ffmpeg():
+    """Find or download ffmpeg.exe and place it in client/lib/ for bundling."""
+    lib_dir = os.path.join(CLIENT_DIR, "lib")
+    os.makedirs(lib_dir, exist_ok=True)
+    dst = os.path.join(lib_dir, "ffmpeg.exe")
+    if os.path.isfile(dst):
+        return dst
+
+    import glob as _glob
+    installer_root = os.path.join(CLIENT_DIR, "api", "node_modules", "@ffmpeg-installer")
+    hits = _glob.glob(os.path.join(installer_root, "**", "ffmpeg.exe"), recursive=True)
+    if not hits:
+        hits = _glob.glob(os.path.join(installer_root, "**", "ffmpeg"), recursive=True)
+    ffmpeg_src = hits[0] if hits else shutil.which("ffmpeg")
+
+    if not (ffmpeg_src and os.path.isfile(ffmpeg_src)):
+        try:
+            print("  [INFO] Downloading portable ffmpeg.exe for release bundle...")
+            import zipfile, tempfile, urllib.request
+            dl_url = "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.4.1/ffmpeg-4.4.1-win-64.zip"
+            temp_zip = os.path.join(tempfile.gettempdir(), "ffmpeg_build_win.zip")
+            urllib.request.urlretrieve(dl_url, temp_zip)
+            with zipfile.ZipFile(temp_zip, "r") as zf:
+                zf.extract("ffmpeg.exe", lib_dir)
+            if os.path.isfile(dst):
+                return dst
+        except Exception as dl_err:
+            print(f"  [WARN] Failed to download prebuilt ffmpeg: {dl_err}")
+
+    if ffmpeg_src and os.path.isfile(ffmpeg_src):
+        shutil.copy2(ffmpeg_src, dst)
+        return dst
+    return None
+
+FFMPEG_EXE = _prepare_ffmpeg()
+
 # Directories inside api/ that must NOT be copied
 API_EXCLUDE_DIRS  = {
     "wppconnect_tokens", "userDataDir", ".git", "__pycache__", "node_modules",
@@ -443,6 +480,8 @@ def pyinstaller_compile():
         # libopus DLL must be bundled as a binary so ctypes can load it at runtime
         if OPUS_DLL:
             cmd += ["--add-binary", f"{OPUS_DLL};lib"]
+        if FFMPEG_EXE:
+            cmd += ["--add-binary", f"{FFMPEG_EXE};lib"]
 
     cmd.append(os.path.join(CLIENT_DIR, "main.py"))
 
@@ -523,38 +562,10 @@ def assemble_staging():
         print("  [WARN] bassopus.dll not found in client/lib — OGG Opus audio playback will fail")
 
     # Copy ffmpeg binary to staging/lib/ to support audio conversion on remote API setups
-    import glob as _glob
-    installer_root = os.path.join(CLIENT_DIR, "api", "node_modules", "@ffmpeg-installer")
-    hits = _glob.glob(os.path.join(installer_root, "**", "ffmpeg.exe"), recursive=True)
-    if not hits:
-        hits = _glob.glob(os.path.join(installer_root, "**", "ffmpeg"), recursive=True)
-
-    ffmpeg_src = hits[0] if hits else shutil.which("ffmpeg")
-
-    if not (ffmpeg_src and os.path.isfile(ffmpeg_src)):
-        try:
-            print("  [INFO] Downloading portable ffmpeg.exe for release bundle...")
-            import zipfile
-            import tempfile
-            import urllib.request
-            dl_url = "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.4.1/ffmpeg-4.4.1-win-64.zip"
-            temp_zip = os.path.join(tempfile.gettempdir(), "ffmpeg_build_win.zip")
-            urllib.request.urlretrieve(dl_url, temp_zip)
-            with zipfile.ZipFile(temp_zip, "r") as zf:
-                zf.extract("ffmpeg.exe", lib_dir)
-            ffmpeg_dst = os.path.join(lib_dir, "ffmpeg.exe")
-            if os.path.isfile(ffmpeg_dst):
-                ffmpeg_src = ffmpeg_dst
-                print(f"  -> lib/ffmpeg.exe (downloaded prebuilt binary)")
-        except Exception as dl_err:
-            print(f"  [WARN] Failed to download prebuilt ffmpeg: {dl_err}")
-
-    if ffmpeg_src and os.path.isfile(ffmpeg_src) and ffmpeg_src != os.path.join(lib_dir, "ffmpeg.exe"):
-        ext = ".exe" if sys.platform == "win32" or ffmpeg_src.lower().endswith(".exe") else ""
-        ffmpeg_dst = os.path.join(lib_dir, f"ffmpeg{ext}")
-        shutil.copy2(ffmpeg_src, ffmpeg_dst)
-        print(f"  -> lib/ffmpeg{ext} (from {ffmpeg_src})")
-    elif not (ffmpeg_src and os.path.isfile(ffmpeg_src)):
+    if FFMPEG_EXE:
+        shutil.copy2(FFMPEG_EXE, os.path.join(lib_dir, "ffmpeg.exe"))
+        print(f"  -> lib/ffmpeg.exe")
+    else:
         print("  [WARN] ffmpeg binary not found — remote API setups will not be able to convert audio messages")
 
     print(f"  -> lib/  ({dll_count} DLLs total)")

--- a/client/main.py
+++ b/client/main.py
@@ -10658,14 +10658,10 @@ class MainWindow(wx.Frame):
                         pass
 
             if ogg_bytes is None:
-                # If conversion failed, try reading WAV directly as a fallback (may fail at API level)
-                logging.warning("[send_audio_message] FFmpeg conversion failed or OGG empty, trying raw WAV fallback")
-                try:
-                    with open(wav_path, "rb") as fh:
-                        ogg_bytes = fh.read()
-                except Exception as exc:
-                    logging.error("[send_audio_message] cannot read WAV %s: %s", wav_path, exc)
-                    return {"ok": False, "error": str(exc)[:200], "retry": False}
+                # If conversion failed, do not send raw WAV as it breaks WhatsApp (silent failure)
+                err_msg = "Falha ao converter áudio. FFmpeg ausente ou indisponível no sistema."
+                logging.error("[send_audio_message] %s", err_msg)
+                return {"ok": False, "error": err_msg, "retry": False}
             logging.info("[VOICE_TIMING] fallback encode+read done in %.3fs",
                          _time.perf_counter() - _t_fallback)
 

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -6303,6 +6303,35 @@ class ConversationsPanel(wx.Panel):
         msg_id = msg.get("key", {}).get("id", "")
         i18n   = self.main_window.i18n
 
+        msg_key = msg.get("key", {})
+        from_me = msg_key.get("fromMe", False)
+        can_delete_for_all = from_me
+
+        if not can_delete_for_all and self.conversation:
+            conv_jid = self.conversation.get("remoteJid", "")
+            if conv_jid.endswith("@g.us"):
+                group_meta = self.conversation.get("groupMetadata", {})
+                participants = group_meta.get("participants") or self.conversation.get("participants") or []
+
+                def _phone_part(j: str) -> str:
+                    return j.rsplit("@", 1)[0].split(":")[0] if isinstance(j, str) else ""
+
+                my_phone = _phone_part(getattr(self.main_window, "my_jid", ""))
+                my_lid   = _phone_part(getattr(self.main_window, "my_lid", ""))
+
+                for p in participants:
+                    if isinstance(p, dict):
+                        p_id = p.get("id", "")
+                        if isinstance(p_id, dict):
+                            p_id = p_id.get("_serialized", "")
+                        p_digits = _phone_part(p_id)
+                        if p_digits:
+                            is_me = (my_phone and self.main_window._phone_digits_equivalent(p_digits, my_phone)) or (my_lid and p_digits == my_lid)
+                            if is_me:
+                                if p.get("admin") or p.get("isAdmin"):
+                                    can_delete_for_all = True
+                                break
+
         # ── Ask the user: delete for me only, or for everyone ─────────────────
         dlg = wx.Dialog(
             self,
@@ -6312,11 +6341,14 @@ class ConversationsPanel(wx.Panel):
         panel  = wx.Panel(dlg)
         sizer  = wx.BoxSizer(wx.VERTICAL)
 
-        rb_me  = wx.RadioButton(panel, label=i18n.t("delete_for_me"),    style=wx.RB_GROUP)
-        rb_all = wx.RadioButton(panel, label=i18n.t("delete_for_everyone"))
+        rb_me  = wx.RadioButton(panel, label=i18n.t("delete_for_me"), style=wx.RB_GROUP)
         rb_me.SetValue(True)
-        sizer.Add(rb_me,  0, wx.ALL, 8)
-        sizer.Add(rb_all, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 8)
+        sizer.Add(rb_me, 0, wx.ALL, 8)
+
+        rb_all = None
+        if can_delete_for_all:
+            rb_all = wx.RadioButton(panel, label=i18n.t("delete_for_everyone"))
+            sizer.Add(rb_all, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 8)
 
         btn_sizer = wx.StdDialogButtonSizer()
         ok_btn     = wx.Button(panel, wx.ID_OK,     label=i18n.t("delete_message"))
@@ -6333,8 +6365,8 @@ class ConversationsPanel(wx.Panel):
         dlg.Fit()
         dlg.CentreOnParent()
 
-        result     = dlg.ShowModal()
-        for_everyone = rb_all.GetValue()
+        result       = dlg.ShowModal()
+        for_everyone = rb_all.GetValue() if rb_all else False
         dlg.Destroy()
 
         if result != wx.ID_OK:


### PR DESCRIPTION
1. Correcao de Audio: Resolvido bug de falha silenciosa onde o FFmpeg nao era empacotado corretamente. O build.py foi refatorado para garantir o download/copia do ffmpeg.exe em todas as rotas de build (onedir/onefile). O main.py agora aborta o envio corretamente ao inves de mandar raw WAV como Opus caso falhe.

2. Apagar Mensagens: Ajustada a interface em conversations.py para ocultar a opcao 'Apagar para todos' caso a mensagem nao seja do usuario e ele nao seja administrador do grupo,