### PR TITLE
Correção de Bugs: Encaminhamento de Legendas e Leitura de Contatos

### DIFF
--- a/client/core/notification_manager.py
+++ b/client/core/notification_manager.py
@@ -245,8 +245,27 @@ def format_notification_body(msg: dict, main_window, i18n) -> str:
     # ── Contact ───────────────────────────────────────────────────────────────
     if msg_type == "contactMessage":
         contact = msg_obj.get("contactMessage") or {}
-        name    = contact.get("displayName") or ""
+        name = contact.get("displayName") or ""
+        vcard = contact.get("vcard") or ""
+        
+        if not name or "BEGIN:VCARD" in name:
+            vcard_to_parse = name if "BEGIN:VCARD" in name else vcard
+            parsed_name = ""
+            for line in vcard_to_parse.splitlines():
+                if line.startswith("FN:"):
+                    parsed_name = line[3:].strip()
+                    break
+            if parsed_name:
+                name = parsed_name
+            else:
+                name = "Desconhecido"
+
         return i18n.t("contact_message").format(name=name)
+
+    if msg_type == "contactsArrayMessage":
+        arr = msg_obj.get("contactsArrayMessage") or {}
+        contacts = arr.get("contacts") or []
+        return i18n.t("contact_message").format(name=f"{len(contacts)} contatos")
 
     # ── Location ──────────────────────────────────────────────────────────────
     if msg_type in ("locationMessage", "liveLocationMessage"):

--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -198,6 +198,7 @@
     "copy_file": "Copy file",
     "delete_message": "Delete message",
     "forward_message": "Forward",
+    "forward_keep_caption": "Keep media caption",
     "star_message": "Star",
     "unstar_message": "Unstar",
     "pin_message": "&Pin message",

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -198,6 +198,7 @@
     "copy_file": "Copiar arquivo",
     "delete_message": "Apagar mensagem",
     "forward_message": "Encaminhar",
+    "forward_keep_caption": "Manter legenda da mídia",
     "star_message": "Favoritar",
     "unstar_message": "Desfavoritar",
     "pin_message": "&Fixar mensagem",

--- a/client/main.py
+++ b/client/main.py
@@ -16487,6 +16487,81 @@ class MainWindow(wx.Frame):
             logging.error("[forward_message] exception for %s -> %s: %s", full_id, target_phone, exc)
             return False
 
+    def resend_media_message_with_caption(self, msg: dict, target_jid: str) -> bool:
+        """Forward a media message by re-sending it as a new file upload, 
+        in order to preserve its caption which WPPConnect's native forward drops.
+        """
+        import os
+        import json
+        from core.utils import decrypt_bytes
+        
+        msg_key = msg.get("key", {}) or {}
+        msg_id = msg_key.get("id", "")
+        if not msg_id:
+            return False
+        
+        if "_" in msg_id:
+            parts = msg_id.split("_")
+            msg_id = parts[2] if len(parts) > 2 else parts[-1]
+            
+        msg_inner = msg.get("message", {})
+        if isinstance(msg_inner, str):
+            try:
+                msg_inner = json.loads(msg_inner)
+            except Exception:
+                msg_inner = {}
+                
+        original_caption = ""
+        media_type = ""
+        for key in ["imageMessage", "videoMessage", "documentMessage"]:
+            if key in msg_inner and isinstance(msg_inner[key], dict):
+                original_caption = msg_inner[key].get("caption", "").strip()
+                if key == "imageMessage": media_type = "image"
+                elif key == "videoMessage": media_type = "video"
+                elif key == "documentMessage": media_type = "document"
+                break
+                
+        if not media_type:
+            return self.forward_message(msg_key.get("remoteJid", ""), msg_key, target_jid)
+
+        media_path = data_path("media", f"{msg_id}.wzmedia")
+        if not os.path.isfile(media_path):
+            self.output(self.i18n.t("downloading_media"))
+            success = self.handle_media_message(msg)
+            if not success and not os.path.isfile(media_path):
+                logging.error(f"[resend_media] Failed to download media for {msg_id}")
+                return False
+
+        try:
+            with open(media_path, "rb") as f:
+                encrypted_data = f.read()
+            decrypted_data = decrypt_bytes(encrypted_data, self.key)
+            
+            ext = ".bin"
+            if media_type == "image": ext = ".jpg"
+            elif media_type == "video": ext = ".mp4"
+            elif media_type == "document":
+                fname = msg_inner.get("documentMessage", {}).get("fileName", "")
+                if fname:
+                    _, ext2 = os.path.splitext(fname)
+                    if ext2: ext = ext2
+            
+            temp_path = data_path("media", f"temp_{msg_id}{ext}")
+            with open(temp_path, "wb") as f:
+                f.write(decrypted_data)
+                
+            success = self.send_media_attachment(target_jid, temp_path, media_type, caption=original_caption)
+            
+            try:
+                os.remove(temp_path)
+            except Exception:
+                pass
+                
+            return success
+        except Exception as exc:
+            logging.error(f"[resend_media] Error decrypting or sending {msg_id}: {exc}")
+            return False
+
     def mark_audio_message_played(self, msg: dict):
         """Mark a received voice message as played, both locally (the
         status icon in the message list, same as a "played" receipt
@@ -16887,9 +16962,26 @@ class MainWindow(wx.Frame):
             content = i18n.t("sticker")
         elif msg_type == "contactMessage":
             contact = msg_obj.get("contactMessage") or {}
-            content = i18n.t("contact_message").format(
-                name=contact.get("displayName") or ""
-            )
+            name = contact.get("displayName") or ""
+            vcard = contact.get("vcard") or ""
+            
+            if not name or "BEGIN:VCARD" in name:
+                vcard_to_parse = name if "BEGIN:VCARD" in name else vcard
+                parsed_name = ""
+                for line in vcard_to_parse.splitlines():
+                    if line.startswith("FN:"):
+                        parsed_name = line[3:].strip()
+                        break
+                if parsed_name:
+                    name = parsed_name
+                else:
+                    name = "Desconhecido"
+
+            content = i18n.t("contact_message").format(name=name)
+        elif msg_type == "contactsArrayMessage":
+            arr = msg_obj.get("contactsArrayMessage") or {}
+            contacts = arr.get("contacts") or []
+            content = i18n.t("contact_message").format(name=f"{len(contacts)} contatos")
         elif msg_type == "locationMessage":
             content = i18n.t("notif_location")
         elif msg_type == "pollCreationMessage":

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -5345,7 +5345,26 @@ class ConversationsPanel(wx.Panel):
         if msg_type == "contactMessage":
             contact = msg_obj.get("contactMessage") or {}
             name    = contact.get("displayName") or ""
+            vcard   = contact.get("vcard") or ""
+            
+            if not name or "BEGIN:VCARD" in name:
+                vcard_to_parse = name if "BEGIN:VCARD" in name else vcard
+                parsed_name = ""
+                for line in vcard_to_parse.splitlines():
+                    if line.startswith("FN:"):
+                        parsed_name = line[3:].strip()
+                        break
+                if parsed_name:
+                    name = parsed_name
+                else:
+                    name = "Desconhecido"
+            
             return i18n.t("contact_message").format(name=name)
+
+        if msg_type == "contactsArrayMessage":
+            arr = msg_obj.get("contactsArrayMessage") or {}
+            contacts = arr.get("contacts") or []
+            return i18n.t("contact_message").format(name=f"{len(contacts)} contatos")
 
         # ── Poll ─────────────────────────────────────────────────────────────
         if msg_type in ("pollCreationMessage", "pollCreationMessageV2", "pollCreationMessageV3", "pollUpdateMessage"):
@@ -6900,6 +6919,28 @@ class ConversationsPanel(wx.Panel):
             0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6,
         )
 
+        msg_inner = msg.get("message", {})
+        if isinstance(msg_inner, str):
+            import json
+            try:
+                msg_inner = json.loads(msg_inner)
+            except Exception:
+                msg_inner = {}
+        
+        original_caption = ""
+        for key in ["imageMessage", "videoMessage", "documentMessage"]:
+            if key in msg_inner and isinstance(msg_inner[key], dict):
+                cap = msg_inner[key].get("caption", "").strip()
+                if cap:
+                    original_caption = cap
+                break
+
+        chk_keep_caption = None
+        if original_caption:
+            chk_keep_caption = wx.CheckBox(p, label=i18n.t("forward_keep_caption"))
+            chk_keep_caption.SetValue(True)
+            vsz.Add(chk_keep_caption, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
+
         # ── Custom arrow/selection keyboard handling ────────────────────────
         # Native wx.LB_EXTENDED semantics: a plain Up/Down both moves focus
         # AND collapses selection down to just the newly-focused item — there
@@ -7071,9 +7112,11 @@ class ConversationsPanel(wx.Panel):
             return
 
         targets = list(zip(target_jids, target_names))
+        
+        keep_caption = chk_keep_caption.GetValue() if chk_keep_caption else False
 
         def _do_forward():
-            failed_names = self._forward_message_to_targets(source_jid, msg_key, targets)
+            failed_names = self._forward_message_to_targets(msg, targets, keep_caption=keep_caption)
             if failed_names:
                 wx.CallAfter(mw.error_sound.play)
                 if len(targets) == 1:
@@ -7086,18 +7129,24 @@ class ConversationsPanel(wx.Panel):
 
         threading.Thread(target=_do_forward, daemon=True).start()
 
-    def _forward_message_to_targets(self, source_jid: str, msg_key: dict, targets: list) -> list:
+    def _forward_message_to_targets(self, msg: dict, targets: list, keep_caption: bool = False) -> list:
         """Forward one message to each (jid, name) pair in *targets*, one at
         a time — so one failing recipient (e.g. a stale JID) doesn't abort
-        delivery to the rest, since each main_window.forward_message() call
-        already reports its own success/failure independently. Returns the
-        display names of whichever targets failed (empty if all succeeded).
+        delivery to the rest. If keep_caption is True, uses resend_media_message_with_caption.
         """
         mw = self.main_window
-        return [
-            name for jid, name in targets
-            if not mw.forward_message(source_jid, msg_key, jid)
-        ]
+        failed = []
+        msg_key = msg.get("key", {}) or {}
+        source_jid = msg_key.get("remoteJid") or ""
+        
+        for jid, name in targets:
+            if keep_caption:
+                success = mw.resend_media_message_with_caption(msg, jid)
+            else:
+                success = mw.forward_message(source_jid, msg_key, jid)
+            if not success:
+                failed.append(name)
+        return failed
 
     def _on_menu_star(self, msg: dict):
         msg["starred"] = not msg.get("starred")


### PR DESCRIPTION
• Corrigido bug: O encaminhamento de mídias agora preserva a legenda quando a nova caixa de seleção é marcada. O WinZapp contorna a limitação do WPPConnect processando e reenviando a mídia localmente com a legenda original anexada.
• Corrigido bug: O leitor de telas não lê mais o código-fonte bruto (vCard) ao receber mensagens de contato. Agora ele extrai e anuncia apenas o nome limpo e amigável da pessoa, refletindo isso na tela de mensagens, na lista geral de conversas e nas notificações flutuantes.