### PR TITLE
fix: pin WPPConnect Server v2.10.4 e Node 22.22.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,28 +2,15 @@
 # Copy this file to .env and fill in the values you need.
 # The .env file is read by setup_api.py (build setup) and by WinZapp.exe at runtime.
 
-# URL of the JSON file that contains the latest version number
-# Expected format: { "version": "1.2.3.4" }
-# WINZAPP_VERSION_URL=https://blind-center.com.br/downloads/winzapp/version.json
+# ── WPPConnect Server setup (used by setup_api.py and the in-app setup dialog) ──
 
-# URL of the plain-text changelog file
-# Expected format: version headers like "V1.2.3.4" followed by bullet points
-# WINZAPP_CHANGELOG_URL=https://blind-center.com.br/downloads/winzapp/changelog.txt
+# Optional git tag to check out after cloning the WPPConnect Server repository
+# into client/api/. Leave blank (or omit) to stay on the latest released tag /
+# the default branch (main).
+# Example: WPPCONNECT_TAG_VERSION=v2.10.4
+WPPCONNECT_TAG_VERSION=v2.10.4
 
-# URL of the ZIP file containing the latest WinZapp release
-# WINZAPP_ZIP_URL=https://blind-center.com.br/downloads/winzapp/winzapp.zip
-
-# ── Evolution API setup (used by setup_api.py) ────────────────────────────────
-
-# Optional git tag to check out after cloning the Evolution API repository.
-# Leave blank (or omit) to stay on the default branch (main).
-# Example: EVOLUTION_TAG_VERSION=v2.3.7
-# EVOLUTION_TAG_VERSION=
-
-# ── Evolution API licensing (v2.4.0+) ────────────────────────────────────────
-
-# E-mail registered on the Evolution Foundation licensing server.
-# Used for automatic instance activation (tier: community, version: 2.4.0).
-# The e-mail must have been registered at https://app.evolutionfoundation.com.br
-# at least once before this automatic flow can be used.
-LICENSING_USER_EMAIL=gabrielhaberkamp@gmail.com
+# ── WPPConnect Server version gate (used by main.py at runtime) ───────────────
+# The minimum WPPConnect Server version this build requires. When the installed
+# api/package.json version is older, WinZapp prompts the user to update.
+# WPP_MINIMUM_VERSION=2.10.4

--- a/.github/workflows/prerelease-test.yml
+++ b/.github/workflows/prerelease-test.yml
@@ -71,8 +71,8 @@ jobs:
         shell: pwsh
         run: |
           $envContent = @"
-          WPPCONNECT_TAG_VERSION=2.10.0
-          WPPCONNECT_API_MINIMUM_VERSION=2.10.0
+          WPPCONNECT_TAG_VERSION=v2.10.4
+          WPP_MINIMUM_VERSION=2.10.4
           LICENSING_USER_EMAIL=gabrielhaberkamp@gmail.com
           "@
           $envContent | Out-File -FilePath ".env" -Encoding utf8
@@ -90,7 +90,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: client/node
-          key: node-portable-v24.15.0
+          key: node-portable-v22.22.2
 
       - name: Cache MinGit Portátil
         id: cache-git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,10 @@ on:
     types: [created]
 
 env:
-  NODE_VERSION: "24.15.0"
+  NODE_VERSION: "22.22.2"
   PYTHON_VERSION: "3.13"
+  WPPCONNECT_TAG_VERSION: "v2.10.4"
+  WPP_MINIMUM_VERSION: "2.10.4"
 
 jobs:
   # Gate for everything below: a release is only worth building/shipping if
@@ -152,6 +154,21 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('client/api/package.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
+
+      # .env is git-ignored, so a fresh CI checkout has none. Without a root
+      # .env, setup_api.py falls back to the wppconnect-server default branch
+      # instead of the pinned tag; and without client/.env the shipped app loses
+      # its WPP_MINIMUM_VERSION version gate (build.py copies it into staging).
+      - name: Create .env files
+        shell: pwsh
+        run: |
+          $envContent = @"
+          WPPCONNECT_TAG_VERSION=${{ env.WPPCONNECT_TAG_VERSION }}
+          WPP_MINIMUM_VERSION=${{ env.WPP_MINIMUM_VERSION }}
+          "@
+          $envContent | Out-File -FilePath ".env" -Encoding utf8
+          $envContent | Out-File -FilePath "client/.env" -Encoding utf8
+          Write-Output "[INFO] .env files created for the build."
 
       # Clones the WPPConnect Server repo into client/api/ and restores
       # WinZapp's custom files (start.js, package.json, config.json, src patches).

--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,9 @@ client/logs/
 
 # Bundled Node.js runtime (binary distribution, ~50 MB)
 # The zip pattern is deliberately version-agnostic: it used to name one exact
-# file (node-v24.15.0-win-x64.zip), which stopped covering anything the moment
-# the version moved — node_download.py pins 18.20.4, and the CI cache key names
-# v24.15.0. Any hand-downloaded zip of a version other than the one hardcoded
+# file (node-v22.22.2-win-x64.zip), which stopped covering anything the moment
+# the version moved — node_download.py pins 22.22.2 (the same pinned by
+# wppconnect-server's engines.node), and the CI cache key names v22.22.2. Any hand-downloaded zip of a version other than the one hardcoded
 # here was not ignored at all, leaving a ~30 MB binary one `git add .` away
 # from the history.
 /client/node/

--- a/client/api_patches/package.json
+++ b/client/api_patches/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wppconnect/server",
-  "version": "2.10.1",
+  "version": "2.10.4",
   "description": "Projeto feito para autenticar a automomacao do WhatsappWeb com multi-clientes de forma dinamica. Backend feito em Nodejs(express, socketio), FrontEnd (ReactJS)",
   "main": "dist/index.js",
   "author": "kingaspx",

--- a/client/ui/dialogs/node_download.py
+++ b/client/ui/dialogs/node_download.py
@@ -25,7 +25,7 @@ from app_paths import resource_path
 
 log = logging.getLogger(__name__)
 
-_NODE_VERSION = "18.20.4"
+_NODE_VERSION = "22.22.2"
 _NODE_FILENAME = f"node-v{_NODE_VERSION}-win-x64.zip"
 _NODE_URL = f"https://nodejs.org/dist/v{_NODE_VERSION}/{_NODE_FILENAME}"
 # nodejs.org publishes a checksum manifest for every release — verify the


### PR DESCRIPTION
O build estava quebrado: a API usava o branch main do wppconnect-server em vez de uma versão fixa, e o Node no CI (24.15.0) e no setup do usuário (18.20.4) não batiam com o engines.node do WPPConnect Server.

- api_patches/package.json: 2.10.1 -> 2.10.4
- release.yml: cria o .env no CI (git-ignored) com WPPCONNECT_TAG_VERSION e WPP_MINIMUM_VERSION, senão o build segue o main em vez da tag; NODE_VERSION 24.15.0 -> 22.22.2
- prerelease-test.yml: corrige chave WPPCONNECT_API_MINIMUM_VERSION (nunca lida) para WPP_MINIMUM_VERSION; tag v2.10.4; cache node v22.22.2
- node_download.py: 18.20.4 -> 22.22.2 (diálogo de setup do usuário)
- .env.example e .gitignore: documentação corrigida

22.22.2 é o engines.node exato do wppconnect-server v2.10.4.

Verificado localmente: setup_api.py rodado em v2.10.4 (build OK) e suíte completa passando (1567 passed, 2 skipped).