### PR TITLE
chore: bump version para 0.24.0 beta

### DIFF
--- a/client/version.py
+++ b/client/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.23.1.0beta"
+__version__ = "0.24.0 beta"


### PR DESCRIPTION
Atualiza client/version.py para 0.24.0 beta (a release 0.24.0 já foi lançada, mas o version.py ainda estava em 0.23.1.0beta).