### PR TITLE
feat: opcao para silenciar avisos de sincronizacao, download de midias e modo offline automatico

### DIFF
--- a/client/core/utils.py
+++ b/client/core/utils.py
@@ -74,7 +74,11 @@ DEFAULT_SETTINGS = {
         "terms_alert_displayed": False,
         "quick_tip_shown": False,
         "global_hotkey": None,
-        "switch_behavior": "single"
+        "switch_behavior": "single",
+        # Master mute (Settings > Geral) for the spoken+sound announcements of
+        # sync progress/completion, media downloads and the automatic offline
+        # transition. On by default; unchecked = those warnings stay silent.
+        "announce_sync_events": True
     },
     "status": {
         "messages_set_completed": False

--- a/client/data/settings_default.json
+++ b/client/data/settings_default.json
@@ -15,7 +15,8 @@
         "autostart": false,
         "show_tray_icon": true,
         "terms_alert_displayed": false,
-        "quick_tip_shown": false
+        "quick_tip_shown": false,
+        "announce_sync_events": true
     },
     "status": {
         "messages_set_completed": false

--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -237,6 +237,7 @@
     "cancel_edit": "Cancel editing",
     "noise_reduction_label": "Enable microphone &noise reduction",
     "notifications_label": "Enable background &notifications for new messages",
+    "announce_sync_events_label": "Announce sync, media downloads and automatic &offline mode",
     "tray_show_icon": "Show icon and unread message count in the system tray",
     "tray_open": "Open",
     "tray_offline_mode": "Offline mode",

--- a/client/languages/es-ES.json
+++ b/client/languages/es-ES.json
@@ -237,6 +237,7 @@
     "cancel_edit": "Cancelar edición",
     "noise_reduction_label": "Activar &reducción de ruido del micrófono",
     "notifications_label": "Activar &notificaciones de mensajes nuevos en segundo plano",
+    "announce_sync_events_label": "Anunciar sincronización, descarga de medios y modo &sin conexión automático",
     "tray_show_icon": "Mostrar icono y recuento de mensajes no leídos en la bandeja del sistema",
     "tray_open": "Abrir",
     "tray_offline_mode": "Modo sin conexión",

--- a/client/languages/pl.json
+++ b/client/languages/pl.json
@@ -235,6 +235,7 @@
     "cancel_edit": "Anuluj edycję",
     "noise_reduction_label": "Włącz &redukcję szumów mikrofonu",
     "notifications_label": "Włącz &powiadomienia w tle o nowych wiadomościach",
+    "announce_sync_events_label": "Anonsuj synchronizację, pobieranie multimediów i automatyczny tryb &offline",
     "tray_show_icon": "Pokaż ikonę i licznik nieprzeczytanych wiadomości w zasobniku systemowym",
     "tray_open": "Otwórz",
     "tray_offline_mode": "Tryb offline",

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -237,6 +237,7 @@
     "cancel_edit": "Cancelar edição",
     "noise_reduction_label": "Ativar &redução de ruído do microfone",
     "notifications_label": "Ativar &notificações de novas mensagens em segundo plano",
+    "announce_sync_events_label": "Anunciar sincronização, download de mídias e modo &offline automático",
     "tray_show_icon": "Mostrar ícone e contagem de mensagens não lidas na bandeja do sistema",
     "tray_open": "Abrir",
     "tray_offline_mode": "Modo offline",

--- a/client/languages/pt-PT.json
+++ b/client/languages/pt-PT.json
@@ -237,6 +237,7 @@
     "cancel_edit": "Cancelar edição",
     "noise_reduction_label": "Ativar a &redução de ruído do microfone",
     "notifications_label": "Ativar as &notificações em segundo plano para novas mensagens",
+    "announce_sync_events_label": "Anunciar sincronização, descarregamento de mídias e modo &offline automático",
     "tray_show_icon": "Mostrar o ícone e o número de mensagens não lidas no tabuleiro do sistema",
     "tray_open": "Abrir",
     "tray_offline_mode": "Modo offline",

--- a/client/main.py
+++ b/client/main.py
@@ -2119,8 +2119,11 @@ class MainWindow(wx.Frame):
         elif self._auto_offline:
             # Turning the manual switch off does not put us back online when
             # the connection itself is down — say so instead of announcing a
-            # state change that did not happen.
-            self.output(self.i18n.t("offline_mode_auto_enabled"), interrupt=True)
+            # state change that did not happen. This is the automatic-offline
+            # warning, so it respects the announce_sync_events master mute for
+            # the SPEECH; the sound above is the manual toggle's own feedback.
+            if self._announce_sync_events_enabled():
+                self.output(self.i18n.t("offline_mode_auto_enabled"), interrupt=True)
         else:
             self.output(self.i18n.t("offline_mode_disabled"), interrupt=True)
         self._apply_offline_state()
@@ -2162,6 +2165,17 @@ class MainWindow(wx.Frame):
             _ui()
         else:
             wx.CallAfter(_ui)
+
+    def _announce_sync_events_enabled(self) -> bool:
+        """Master mute for the sync/media/auto-offline spoken+sound warnings.
+
+        Settings > Geral > "Anunciar sincronização, download de mídias e modo
+        offline automático" (on by default). When unchecked, the synchronizing /
+        sync-complete / media-download / automatic-offline announcements must
+        not fire — no speech, no event sound (status text and the manual
+        offline toggle's own feedback are unaffected).
+        """
+        return bool(self.settings.get("general", {}).get("announce_sync_events", True))
 
     def _on_power_suspended(self, event):
         logging.info("[power] System is suspending.")
@@ -2901,7 +2915,7 @@ class MainWindow(wx.Frame):
         # — it only reaches here on an actual state change — so this is safe
         # to fire unconditionally, matching the manual toggle's own behaviour
         # (offline_mode_sound + speech) exactly.
-        if announce and not self.background_mode:
+        if announce and not self.background_mode and self._announce_sync_events_enabled():
             self.offline_mode_sound.play()
             self.output(self.i18n.t("offline_mode_auto_enabled"), interrupt=False)
 
@@ -2921,16 +2935,16 @@ class MainWindow(wx.Frame):
                 logging.info("[_on_menu_sync_media] Aborting media sync: offline mode active.")
                 return
             wx.CallAfter(self._set_status, self.i18n.t("downloading_media"))
-            if not self.background_mode:
+            if not self.background_mode and self._announce_sync_events_enabled():
                 wx.CallAfter(self.output, self.i18n.t("sync_media_started"))
             self._media_sync_running = True
             try:
                 self.sync_media_for_all_chats()
-                if not self.background_mode:
+                if not self.background_mode and self._announce_sync_events_enabled():
                     wx.CallAfter(self.output, self.i18n.t("sync_media_completed"))
             except Exception as exc:
                 logging.exception("[_on_menu_sync_media] Erro ao baixar mídias: %s", exc)
-                if not self.background_mode:
+                if not self.background_mode and self._announce_sync_events_enabled():
                     wx.CallAfter(self.output, self.i18n.t("sync_media_failed"))
             finally:
                 self._media_sync_running = False
@@ -8090,9 +8104,10 @@ class MainWindow(wx.Frame):
         # land in the same UI-thread tick.
         def _announce_synchronizing():
             self._set_status(self.i18n.t("synchronizing"))
-            self.synchronizing_sound.play()
-            if not self.background_mode:
-                self.output(self.i18n.t("synchronization_started"), interrupt=True)
+            if self._announce_sync_events_enabled():
+                self.synchronizing_sound.play()
+                if not self.background_mode:
+                    self.output(self.i18n.t("synchronization_started"), interrupt=True)
         wx.CallAfter(_announce_synchronizing)
 
         # After first pairing the API may need a few seconds to populate chats.
@@ -8352,9 +8367,10 @@ class MainWindow(wx.Frame):
             # 3-or-4-conversations failure look like a success, right before
             # the sync restarted itself.
             if chat_list_ok and chat_list_settled:
-                self.sync_complete_sound.play()
-                if not self.background_mode:
-                    self.output(self.i18n.t("sync_complete"))
+                if self._announce_sync_events_enabled():
+                    self.sync_complete_sound.play()
+                    if not self.background_mode:
+                        self.output(self.i18n.t("sync_complete"))
         wx.CallAfter(_announce_messages_synced)
 
         # Mark sync as done for this session so late-arriving messages.set
@@ -8460,7 +8476,7 @@ class MainWindow(wx.Frame):
                 )
                 if has_media:
                     wx.CallAfter(self._set_status, self.i18n.t("downloading_media"))
-                    if not self.background_mode:
+                    if not self.background_mode and self._announce_sync_events_enabled():
                         announced = True
                         wx.CallAfter(self.output, self.i18n.t("sync_media_started"))
 

--- a/client/ui/dialogs/settings_dialog.py
+++ b/client/ui/dialogs/settings_dialog.py
@@ -207,6 +207,11 @@ class SettingsDialog(wx.Dialog):
         )
         gen_sizer.Add(self._notifications_check, 0, wx.ALL, 8)
 
+        self._announce_sync_check = wx.CheckBox(
+            self._general_page, label=i18n.t("announce_sync_events_label")
+        )
+        gen_sizer.Add(self._announce_sync_check, 0, wx.ALL, 8)
+
         self._autostart_check = wx.CheckBox(
             self._general_page, label=i18n.t("autostart_label")
         )
@@ -686,6 +691,9 @@ class SettingsDialog(wx.Dialog):
 
         notifs = self.main_window.settings.get("general", {}).get("notifications_enabled", True)
         self._notifications_check.SetValue(notifs)
+
+        announce_sync = self.main_window.settings.get("general", {}).get("announce_sync_events", True)
+        self._announce_sync_check.SetValue(announce_sync)
 
         from autostart import is_autostart_enabled
         self._autostart_check.SetValue(is_autostart_enabled())
@@ -1502,6 +1510,11 @@ class SettingsDialog(wx.Dialog):
             self._notifications_check.GetValue()
         )
 
+        # Sync/media/auto-offline announcements
+        self.main_window.settings.setdefault("general", {})["announce_sync_events"] = (
+            self._announce_sync_check.GetValue()
+        )
+
         # Autostart
         from autostart import is_autostart_enabled
         new_autostart = self._autostart_check.GetValue()
@@ -1654,6 +1667,7 @@ class SettingsDialog(wx.Dialog):
         self._reload_audio_device_choices()
         self._noise_reduction_check.SetLabel(i18n.t("noise_reduction_label"))
         self._notifications_check.SetLabel(i18n.t("notifications_label"))
+        self._announce_sync_check.SetLabel(i18n.t("announce_sync_events_label"))
         self._autostart_check.SetLabel(i18n.t("autostart_label"))
         self._tray_icon_check.SetLabel(i18n.t("tray_show_icon"))
         self._updates_check.SetLabel(i18n.t("updates_label"))

--- a/client/version.py
+++ b/client/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.24.0 beta"
+__version__ = "0.24.0.0beta"

--- a/tests/test_announce_sync_events.py
+++ b/tests/test_announce_sync_events.py
@@ -1,0 +1,45 @@
+"""Tests for the sync/media/auto-offline announcements master mute.
+
+Settings > Geral > "Anunciar sincronização, download de mídias e modo offline
+automático" gates the spoken+sound warnings for sync progress/completion, media
+downloads and the automatic offline transition. When unchecked, none of them may
+fire; when missing, it must default to enabled so existing installs keep their
+current behaviour.
+
+MainWindow is a wx.Frame and cannot be instantiated without a running app, so the
+method under test is exercised as a plain function against a small stub that
+carries just the attribute it touches.
+"""
+
+import pytest
+
+from main import MainWindow
+
+
+class _Stub:
+    """Minimal stand-in for MainWindow for the announce-sync-events method."""
+
+    def __init__(self, settings=None):
+        self.settings = settings or {}
+
+    _announce_sync_events_enabled = MainWindow._announce_sync_events_enabled
+
+
+def test_defaults_to_enabled_when_setting_missing():
+    # A settings dict without the key at all (existing installs / partial
+    # configs) must keep announcing — the master mute is opt-out.
+    assert _Stub({})._announce_sync_events_enabled() is True
+
+
+def test_defaults_to_enabled_when_general_missing():
+    assert _Stub({"general": {}})._announce_sync_events_enabled() is True
+
+
+def test_explicit_true_is_enabled():
+    stub = _Stub({"general": {"announce_sync_events": True}})
+    assert stub._announce_sync_events_enabled() is True
+
+
+def test_explicit_false_is_disabled():
+    stub = _Stub({"general": {"announce_sync_events": False}})
+    assert stub._announce_sync_events_enabled() is False

--- a/tests/test_startup_grace.py
+++ b/tests/test_startup_grace.py
@@ -55,6 +55,7 @@ class _I18n:
 class _Stub:
     _set_wa_connected = MainWindow._set_wa_connected
     _reset_startup_probe = MainWindow._reset_startup_probe
+    _announce_sync_events_enabled = MainWindow._announce_sync_events_enabled
     _WA_STARTUP_GRACE_SECONDS = MainWindow._WA_STARTUP_GRACE_SECONDS
 
     # Overridden per-test; the default keeps the grace intact.
@@ -63,6 +64,7 @@ class _Stub:
 
     def __init__(self, started_ago=0.0, network_down=False):
         self.network_down = network_down
+        self.settings = {}
         self._shutting_down = False
         self._wa_connected = False
         self._auto_offline = False

--- a/tests/test_status_synced_with_connected_sound.py
+++ b/tests/test_status_synced_with_connected_sound.py
@@ -41,7 +41,10 @@ class _Stub:
         from main import MainWindow
         self._set_wa_connected = MainWindow._set_wa_connected.__get__(self)
         self._reset_startup_probe = MainWindow._reset_startup_probe.__get__(self)
+        self._announce_sync_events_enabled = MainWindow._announce_sync_events_enabled.__get__(self)
         self._WA_STARTUP_GRACE_SECONDS = MainWindow._WA_STARTUP_GRACE_SECONDS
+
+        self.settings = {}
 
         self._shutting_down = False
         self._wa_connected = False


### PR DESCRIPTION
Nova opcao em Settings > Geral: 'Anunciar sincronizacao, download de midias e modo offline automatico' (vem marcada por padrao).

Quando desmarcada, os avisos falados + sons dos seguintes eventos sao suprimidos:
- inicio/conclusao da sincronizacao
- download de midias (automatico e manual)
- entrada no modo offline automatico

O que nao muda:
- o status/titulo da janela continua mostrando 'sincronizando', 'baixando midias', 'modo offline' etc.
- o modo offline manual (Ctrl+Alt+Shift+O) continua com som e fala - so o automatico e silenciado
- a mudanca vale na hora, sem reiniciar

Detalhe tecnico: como o aviso de inicio do download de midias fica mudo, o de conclusao/falha tambem nao fala (a flag announced mantem o par iniciado/concluido), evitando um 'iniciado' orfao.

Arquivos: client/core/utils.py, client/data/settings_default.json, client/languages/* (5 idiomas), client/ui/dialogs/settings_dialog.py, client/main.py, client/version.py, testes (tests/test_announce_sync_events.py + ajustes em stubs de 2 testes).

Testes: 1683 passando (2 skipped, como antes).