### PR TITLE
fix: normaliza separadores de linha Unicode (U+2028/U+2029) na colagem e no envio

### DIFF
--- a/client/core/message_queue.py
+++ b/client/core/message_queue.py
@@ -140,8 +140,10 @@ class MessageQueue:
                     retryable_failure = False
                     disconnected      = False
                     ambiguous         = False
+                    quote_lost        = False
                     if isinstance(real_id, dict):
                         if real_id.get("ok"):
+                            quote_lost = bool(real_id.get("quote_lost", False))
                             real_id = real_id.get("id") or True
                         else:
                             msg.last_error = real_id.get("error") or ""
@@ -200,6 +202,7 @@ class MessageQueue:
                             msg.audio_path,
                             real_id if isinstance(real_id, str) else None,
                             msg.jid,
+                            quote_lost,
                         )
                     else:
                         msg.fail_count += 1

--- a/client/core/utils.py
+++ b/client/core/utils.py
@@ -68,6 +68,35 @@ def normalize_for_search(text: str, mode="off") -> str:
     )
 
 
+_UNICODE_LINE_SEPARATORS = {
+    "\u2028",  # LINE SEPARATOR
+    "\u2029",  # PARAGRAPH SEPARATOR
+    "\u0085",  # NEXT LINE (NEL)
+    "\x0b",    # VERTICAL TAB
+    "\x0c",    # FORM FEED
+    "\r",      # lone CR (CRLF handled below, before this set applies)
+}
+
+
+def normalize_line_separators(text) -> str:
+    """Collapse every Unicode line/paragraph separator into plain ``\\n``.
+
+    Rich clipboard sources — Google Docs, Word, websites, Apple apps — copy
+    U+2028 LINE SEPARATOR / U+2029 PARAGRAPH SEPARATOR (and the rarer NEL,
+    VT, FF) where a plain editor stores ``\\n``. A ``wx.TextCtrl`` keeps them
+    verbatim: the native control does not render them as breaks (a paste
+    looks like a single line, and NVDA reads it as one), yet WhatsApp
+    renders U+2029 as a paragraph break on the receiving side. The result is
+    the classic "it looks fine here but arrives full of weird breaks"
+    report. Normalizing to ``\\n`` makes the field, the screen reader and
+    the recipient all agree on the same line structure.
+    """
+    text = (text or "").replace("\r\n", "\n")
+    for sep in _UNICODE_LINE_SEPARATORS:
+        text = text.replace(sep, "\n")
+    return text
+
+
 def get_downloads_folder() -> str:
     """Return the current user's Downloads folder.
 

--- a/client/main.py
+++ b/client/main.py
@@ -486,6 +486,33 @@ def is_countable_message(msg: dict) -> bool:
     return msg.get("messageType") not in _PREVIEW_ONLY_MESSAGE_TYPES
 
 
+def _discount_non_countable_unread(records: list, unread_count: int) -> int:
+    """Discount from a server-reported unread count the tail messages that
+    must never count toward the badge: our own (fromMe) sends — WhatsApp Web
+    sometimes counts those — and system events (groupNotification,
+    protocolMessage, e2e_notification, ...) that is_countable_message()
+    excludes.
+
+    This is the mirror of the app's own counting rule: on_new_message()
+    only ever increments the badge for countable messages, so a server that
+    counts a promote/join/leave (or any other system event) toward unread
+    would otherwise mint a phantom badge on a chat that has no real unread
+    message in it — observed live with a group promote that appeared as "1
+    não lida" while the conversation held nothing new. The tail inspected is
+    the locally-stored record list, which keeps the exact shape the
+    on_new_message() increment logic itself saw.
+    """
+    if unread_count <= 0 or not records:
+        return unread_count
+    tail = records[-unread_count:] if unread_count <= len(records) else records
+    discount = sum(
+        1 for m in tail
+        if (isinstance(m, dict) and (m.get("key") or {}).get("fromMe"))
+        or not is_countable_message(m)
+    )
+    return max(0, unread_count - discount)
+
+
 def _message_ts(msg: dict) -> int:
     """The timestamp of a message record, whichever key it arrived under."""
     if not isinstance(msg, dict):
@@ -9311,6 +9338,20 @@ class MainWindow(wx.Frame):
                             if k == "unreadCount":
                                 server_val = int(v or 0)
                                 local_val = int(chats[jid].get("unreadCount") or 0)
+                                # The server counts system events (promote/join/leave
+                                # group notifications, protocolMessage revokes) and
+                                # sometimes own (fromMe) sends toward unread. Discount
+                                # the same tail is_countable_message() excludes in
+                                # on_new_message(), so a snapshot that reports e.g.
+                                # "1 unread" for a chat whose only new record is a
+                                # group promote doesn't mint a phantom badge here
+                                # either. Same correction as on_chat_unread_update().
+                                server_val = _discount_non_countable_unread(
+                                    (chats[jid].get("messages") or {})
+                                    .get("messages", {})
+                                    .get("records", []),
+                                    server_val,
+                                )
                                 # Never resurrect unread count for the conversation the
                                 # user has open right now — mark_conversation_as_read()
                                 # already set it to 0 locally, and this snapshot can be
@@ -14507,8 +14548,9 @@ class MainWindow(wx.Frame):
         old_count = int(chat.get("unreadCount") or 0)
         if old_count == unread_count:
             return  # no actual change — skip expensive rebuild + save
-        # The server sometimes counts own (fromMe) messages as unread. Correct
-        # for that by inspecting the tail of the locally-stored message list.
+        # The server sometimes counts own (fromMe) messages — and system events
+        # (group promotes, joins/leaves, revokes) — as unread. Correct for both
+        # by inspecting the tail of the locally-stored message list.
         if unread_count > 0:
             records = (
                 (chat.get("messages") or {})
@@ -14516,9 +14558,7 @@ class MainWindow(wx.Frame):
                 .get("records", [])
             )
             if records:
-                tail = records[-unread_count:] if unread_count <= len(records) else records
-                own_count = sum(1 for m in tail if (m.get("key") or {}).get("fromMe"))
-                unread_count = max(0, unread_count - own_count)
+                unread_count = _discount_non_countable_unread(records, unread_count)
         old_count = int(chat.get("unreadCount") or 0)
         if old_count == unread_count:
             return

--- a/client/main.py
+++ b/client/main.py
@@ -13377,6 +13377,7 @@ class MainWindow(wx.Frame):
         }
 
         quoted_id = None
+        quote_stripped = False
 
         if mentioned_jids:
             url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/send-mentioned"
@@ -13491,6 +13492,7 @@ class MainWindow(wx.Frame):
                     logging.warning("[send_text_message] Quoted send failed (HTTP %s). Retrying without quote on %s...",
                                     response.status_code, active_dest)
                     wx.CallAfter(self.output, self.i18n.t("reply_quote_lost"))
+                    quote_stripped = True
                     url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/send-message"
                     payload = {
                         "phone": [active_dest],
@@ -13530,9 +13532,15 @@ class MainWindow(wx.Frame):
                         msg_id = msg_id.get("_serialized", "")
                     parts = msg_id.split("_") if msg_id else []
                     clean_id = parts[2] if len(parts) > 2 else (parts[-1] if parts else msg_id)
+                    if quote_stripped:
+                        return {"ok": True, "id": clean_id, "quote_lost": True}
                     return clean_id or True
+                if quote_stripped:
+                    return {"ok": True, "quote_lost": True}
                 return True
             except Exception:
+                if quote_stripped:
+                    return {"ok": True, "quote_lost": True}
                 return True
         except Exception as exc:
             return self._classify_send_exception(exc, "send_text_message")
@@ -13898,12 +13906,15 @@ class MainWindow(wx.Frame):
             logging.error("[pin_message] exception: %s", exc)
             return False
 
-    def _on_message_sent(self, local_id: str, audio_path: str = None, real_id: str = None, remote_jid: str = None):
+    def _on_message_sent(self, local_id: str, audio_path: str = None, real_id: str = None, remote_jid: str = None, quote_lost: bool = False):
         """
         Called on the main thread after a queued message is successfully sent.
         Updates the UI status label and cleans up any temporary audio file.
         real_id is the WhatsApp message ID returned by the API; it replaces the
         local UUID in the virtual message so playback can find the message in the DB.
+        quote_lost is True when the original send-with-quote failed and the message
+        went out as a plain send instead (see send_text_message's fallback) — the
+        UI must then drop the reply contextInfo so the row stops reading as a reply.
         """
         import time as _time
         logging.info("[VOICE_TIMING] _on_message_sent — message LEFT pending state. local_id=%s real_id=%s",
@@ -13951,7 +13962,7 @@ class MainWindow(wx.Frame):
             self.message_sent_sound.play()
 
         if hasattr(self, "conversations_panel"):
-            self.conversations_panel._mark_message_sent(local_id, real_id=real_id)
+            self.conversations_panel._mark_message_sent(local_id, real_id=real_id, quote_lost=quote_lost)
 
     def _on_message_unconfirmed(self, local_id: str):
         """Called when a send timed out and its outcome cannot be determined.

--- a/client/status_panel.py
+++ b/client/status_panel.py
@@ -11,7 +11,7 @@ from ui.accessible import (
     AccessibleRecordVoiceMessage, AccessibleDiscardVoiceMessage, AccessiblePauseResumeRecording,
     AccessibleSendVoiceMessage,
 )
-from core.utils import format_number, get_downloads_folder
+from core.utils import format_number, get_downloads_folder, normalize_line_separators
 from core.video_player import VideoPlayer
 from core.audio_devices import find_input_device_index, RECORDING_SAMPLE_CONFIGS
 
@@ -1680,7 +1680,7 @@ class StatusPanel(wx.Panel):
             return
         if status.get("key", {}).get("fromMe"):
             return  # no reply UI for own statuses — see _show_current_status()
-        text = self._reply_field.GetValue().strip()
+        text = normalize_line_separators(self._reply_field.GetValue()).strip()
         if not text:
             return
         poster_jid = entry.get("jid", "")
@@ -2067,8 +2067,8 @@ class StatusPanel(wx.Panel):
     # ── Send text status ─────────────────────────────────────────────────────
 
     def _on_send_text_status(self, event):
-        text    = self._post_text_field.GetValue().strip()
-        caption = self._caption_field.GetValue().strip()
+        text    = normalize_line_separators(self._post_text_field.GetValue()).strip()
+        caption = normalize_line_separators(self._caption_field.GetValue()).strip()
         if not text and not caption:
             return
         content = text or caption
@@ -2189,7 +2189,7 @@ class StatusPanel(wx.Panel):
     def _on_send_media_status(self, event):
         if not self._selected_media_paths:
             return
-        caption = self._media_caption_field.GetValue().strip()
+        caption = normalize_line_separators(self._media_caption_field.GetValue()).strip()
         paths = list(self._selected_media_paths)
         threading.Thread(
             target=self._send_all_media_statuses_bg,

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -40,7 +40,7 @@ from ui.accessible import (
     AccessibleReadMoreButton,
     CompatListBoxMessagesCtrl,
 )
-from core.utils import format_number, decrypt_bytes, is_phone_like, encrypt, effective_unread_count, first_unread_index, paginated_window, db_fetch_limit, looks_like_binary_blob, get_downloads_folder, normalize_for_search, parse_bool_flag as _parse_bool_flag
+from core.utils import format_number, decrypt_bytes, is_phone_like, encrypt, effective_unread_count, first_unread_index, paginated_window, db_fetch_limit, looks_like_binary_blob, get_downloads_folder, normalize_for_search, normalize_line_separators, parse_bool_flag as _parse_bool_flag
 from core.locale_format import get_date_format, get_time_format, get_datetime_format
 from core.video_player import VideoPlayer
 from app_paths import data_path
@@ -561,6 +561,7 @@ class ConversationsPanel(wx.Panel):
         self.message_field.Bind(wx.EVT_TEXT,       self.on_change_message_field)
         self.message_field.Bind(wx.EVT_TEXT_ENTER, self.on_send_message)
         self.message_field.Bind(wx.EVT_KEY_DOWN,   self._on_message_field_key_down)
+        self.message_field.Bind(wx.EVT_TEXT_PASTE, self._on_message_field_paste)
         conv_sizer.Add(self.message_field, 0, wx.EXPAND | wx.ALL, 5)
 
         self._cancel_edit_btn = wx.Button(
@@ -1375,7 +1376,7 @@ class ConversationsPanel(wx.Panel):
         If in edit mode, instead calls the edit API and updates the existing message."""
         if self.conversation is None:
             return
-        text = self.message_field.GetValue().strip()
+        text = normalize_line_separators(self.message_field.GetValue()).strip()
         if not text:
             return
         remote_jid = self.conversation.get("remoteJid", "")
@@ -3420,6 +3421,40 @@ class ConversationsPanel(wx.Panel):
             self.message_field.SetInsertionPoint(pos + 1)
             self.on_change_message_field(None)
             return  # consume — don't send and don't double-insert
+        event.Skip()
+
+    def _on_message_field_paste(self, event):
+        """Intercept pastes so Unicode line/paragraph separators become \n.
+
+        Rich clipboard sources — Google Docs, Word, websites, Apple apps —
+        put U+2028 LINE SEPARATOR / U+2029 PARAGRAPH SEPARATOR where a plain
+        editor stores \n. A wx.TextCtrl keeps them verbatim: the native
+        control does not render them as breaks (a paste looks like a single
+        long line), yet WhatsApp renders U+2029 as a paragraph break on the
+        receiving side. The result is the "it looks fine here but arrives
+        with weird breaks" report. Normalizing the pasted text here makes the
+        field, the screen reader and the recipient all agree.
+        """
+        if not wx.TheClipboard.Open():
+            event.Skip()
+            return
+        try:
+            if not wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_UNICODETEXT)):
+                event.Skip()
+                return
+            data = wx.TextDataObject()
+            if not wx.TheClipboard.GetData(data):
+                event.Skip()
+                return
+            text = data.GetText()
+        finally:
+            wx.TheClipboard.Close()
+        normalized = normalize_line_separators(text)
+        if normalized != text:
+            # WriteText() replaces the current selection and fires EVT_TEXT,
+            # keeping the mention check / send-button logic in sync.
+            self.message_field.WriteText(normalized)
+            return  # consume — the native paste must not run on top of this
         event.Skip()
 
     def _on_mention_list_key_down(self, event):

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -561,7 +561,7 @@ class ConversationsPanel(wx.Panel):
         self.message_field.Bind(wx.EVT_TEXT,       self.on_change_message_field)
         self.message_field.Bind(wx.EVT_TEXT_ENTER, self.on_send_message)
         self.message_field.Bind(wx.EVT_KEY_DOWN,   self._on_message_field_key_down)
-        self.message_field.Bind(wx.EVT_TEXT_PASTE, self._on_message_field_paste)
+        self.message_field.Bind(wx.EVT_TEXT_PASTE, self._on_text_field_paste)
         conv_sizer.Add(self.message_field, 0, wx.EXPAND | wx.ALL, 5)
 
         self._cancel_edit_btn = wx.Button(
@@ -637,6 +637,7 @@ class ConversationsPanel(wx.Panel):
             style=wx.TE_DONTWRAP | wx.TE_PROCESS_ENTER,
         )
         self._caption_field.SetHint(i18n.t("attachment_caption_hint"))
+        self._caption_field.Bind(wx.EVT_TEXT_PASTE, self._on_text_field_paste)
         self._caption_field.Bind(wx.EVT_TEXT_ENTER, self._on_send_attachment)
         attach_sizer.Add(self._caption_field, 0, wx.EXPAND | wx.ALL, 5)
 
@@ -3423,8 +3424,12 @@ class ConversationsPanel(wx.Panel):
             return  # consume — don't send and don't double-insert
         event.Skip()
 
-    def _on_message_field_paste(self, event):
+    def _on_text_field_paste(self, event):
         """Intercept pastes so Unicode line/paragraph separators become \n.
+
+        Bound to every field here whose text ends up on WhatsApp — the
+        message field and the attachment caption — and works off the control
+        that raised the event, so adding another one is a single Bind().
 
         Rich clipboard sources — Google Docs, Word, websites, Apple apps —
         put U+2028 LINE SEPARATOR / U+2029 PARAGRAPH SEPARATOR where a plain
@@ -3450,10 +3455,11 @@ class ConversationsPanel(wx.Panel):
         finally:
             wx.TheClipboard.Close()
         normalized = normalize_line_separators(text)
-        if normalized != text:
+        target = event.GetEventObject()
+        if normalized != text and target is not None:
             # WriteText() replaces the current selection and fires EVT_TEXT,
             # keeping the mention check / send-button logic in sync.
-            self.message_field.WriteText(normalized)
+            target.WriteText(normalized)
             return  # consume — the native paste must not run on top of this
         event.Skip()
 
@@ -9169,7 +9175,10 @@ class ConversationsPanel(wx.Panel):
         remote_jid = self.conversation.get("remoteJid", "")
         if not remote_jid:
             return
-        caption = self._caption_field.GetValue().strip()
+        # Same reason as on_send_message(): a caption pasted from a rich
+        # source carries U+2028/U+2029, which look like nothing here and
+        # arrive as paragraph breaks on the recipient's side.
+        caption = normalize_line_separators(self._caption_field.GetValue()).strip()
 
         _VTYPE = {
             "image":    "imageMessage",

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -1636,7 +1636,7 @@ class ConversationsPanel(wx.Panel):
         if msg_ts > current_t:
             chat["t"] = msg_ts
 
-    def _mark_message_sent(self, local_id: str, real_id: str = None):
+    def _mark_message_sent(self, local_id: str, real_id: str = None, quote_lost: bool = False):
         """
         Called on the main thread when a queued message is successfully delivered.
         Clears the _local_pending flag, refreshes the list item, plays the
@@ -1644,6 +1644,10 @@ class ConversationsPanel(wx.Panel):
         real_id (the WhatsApp message ID returned by the API) replaces the local
         UUID in the virtual message's key so that media playback can later look
         up the message in the WPPConnect API database.
+        quote_lost=True means the quoted send failed server-side and the message
+        went out as a plain send (send_text_message's fallback): the virtual
+        message's reply contextInfo is dropped so the row stops reading as a
+        reply — the quote never actually reached the recipient.
         """
         # Panel-level guard: survive _sorted_messages rebuilds that replace dict
         # objects, keeping the per-dict _ui_sent flag from being seen by both callers.
@@ -1663,6 +1667,11 @@ class ConversationsPanel(wx.Panel):
                     return  # Already marked sent on the UI, ignore to prevent duplicate sound and actions
                 msg["_ui_sent"] = True
                 msg["_local_pending"] = False
+                # The quoted send failed and the message went out as a plain
+                # send: drop the reply contextInfo so the row no longer reads
+                # as "respondendo a …". The quote never reached the recipient.
+                if quote_lost:
+                    msg.pop("contextInfo", None)
                 # Replace the local UUID with the real WhatsApp message ID so
                 # get_base64_from_media can find the message in the DB later.
                 if real_id and isinstance(real_id, str):

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -6946,6 +6946,15 @@ class ConversationsPanel(wx.Panel):
 
     def _on_menu_reply(self, msg: dict):
         """Enter reply mode: change field label, store quoted message, focus field."""
+        if self._is_system_event(msg):
+            # System events ("Fulano tornou Sicrano administrador do grupo",
+            # joins/leaves, revokes) carry no quotable content — WhatsApp
+            # rejects a quoted reply to them (HTTP 500), so entering reply
+            # mode then watching the quote fall back on send is confusing.
+            # Announce the same message the send path already uses for a
+            # lost quote and stay out of reply mode entirely.
+            self.main_window.output(self.main_window.i18n.t("reply_quote_lost"))
+            return
         self._quoted_message = msg
         i18n      = self.main_window.i18n
         sender    = self._sender_label(msg)
@@ -7081,6 +7090,12 @@ class ConversationsPanel(wx.Panel):
 
     def _on_menu_reply_private(self, msg: dict, participant_jid: str):
         """Open a private conversation with the group participant and cite their message."""
+        if self._is_system_event(msg):
+            # Same guard as _on_menu_reply: a system event has no quotable
+            # content, and navigating away from the group to a private chat
+            # to quote it would leave the user stranded on the wrong chat.
+            self.main_window.output(self.main_window.i18n.t("reply_quote_lost"))
+            return
         mw = self.main_window
         chat = mw.get_chat(participant_jid)
         if chat is None:

--- a/client/ui/dialogs/new_conversation.py
+++ b/client/ui/dialogs/new_conversation.py
@@ -12,7 +12,7 @@ import re
 import threading
 import wx
 
-from core.utils import format_number
+from core.utils import format_number, is_phone_like, looks_like_binary_blob
 
 
 class NewConversationDialog(wx.Dialog):
@@ -28,6 +28,7 @@ class NewConversationDialog(wx.Dialog):
         )
         self._results: list = []  # list of (display_name, jid, chat_or_None)
         self._build_ui(i18n)
+        self._do_search("")  # populate the list immediately, before any typing
         self.SetMinSize((440, 380))
         self.SetSize((440, 480))
         self.CentreOnParent()
@@ -97,11 +98,55 @@ class NewConversationDialog(wx.Dialog):
             self._results_list.Select(0)
             self._results_list.SetFocus()
 
+    def _dedup_key(self, jid: str) -> str:
+        """Canonical key identifying *the same person* across JID formats.
+
+        The same contact can be stored under @lid, @c.us or @s.whatsapp.net
+        (and with the Brazilian 8- vs 9-digit mobile variant), so keying a
+        results dedup on the raw JID string lets the same person appear
+        twice. Collapse all the formats the app already knows how to unify:
+        device suffix stripped, @c.us → @s.whatsapp.net, @lid bridged to its
+        phone number, and the 55-prefixed 9th-digit dropped. Groups keep
+        their full unique JID.
+        """
+        mw = self._mw
+        normalize_jid = getattr(mw, "_normalize_jid", None)
+        norm = normalize_jid(jid) if normalize_jid else jid
+        if norm.endswith("@g.us"):
+            return norm
+        if norm.endswith("@lid"):
+            lid_map = getattr(mw, "_lid_to_phone", {}) or {}
+            phone = lid_map.get(norm, "")
+            if phone:
+                norm = phone
+        local = norm.split("@", 1)[0]
+        # Brazilian mobile 8/9-digit interchangeability: 5511999999999 ↔ 551199999999
+        if local.startswith("55") and len(local) == 13 and local[4] == "9":
+            local = local[:4] + local[5:]
+        return local
+
+    def _name_is_usable(self, name) -> bool:
+        """Whether a resolved name is a real display name.
+
+        Raw JIDs and phone-number fallbacks (nameless groups resolving to
+        their 18-digit id, contacts with only a number) must not appear in
+        the list — NVDA would read out the raw digits and they are useless
+        as a pick-this-contact label. Reuses MainWindow._is_bad_contact_name
+        when available (groups/private chats follow the same rules as
+        everywhere else in the app), with a local fallback otherwise.
+        """
+        if not name or not isinstance(name, str):
+            return False
+        is_bad = getattr(self._mw, "_is_bad_contact_name", None)
+        if is_bad is not None:
+            return not is_bad(name)
+        name = name.strip()
+        return bool(name) and not name.isdigit() and not is_phone_like(name) \
+            and not looks_like_binary_blob(name)
+
     def _do_search(self, query: str):
         self._results = []
         self._results_list.DeleteAllItems()
-        if not query:
-            return
 
         mw       = self._mw
         i18n     = mw.i18n
@@ -110,6 +155,13 @@ class NewConversationDialog(wx.Dialog):
 
         def _name_for_chat(chat):
             jid = chat.get("remoteJid", "")
+            if jid.endswith("@g.us"):
+                # Groups carry their name under name/subject/groupMetadata
+                # subject — not in the contact store — so resolve it there
+                # first, or a named group would fall through to its raw JID.
+                group_name = mw._group_name_from_chat_dict(chat)
+                if group_name:
+                    return group_name
             return (
                 mw._resolve_contact_name(chat)
                 or mw.find_name_through_messages(chat)
@@ -121,30 +173,37 @@ class NewConversationDialog(wx.Dialog):
         # ── Search existing chats ─────────────────────────────────────────────
         for jid, chat in mw.chats.items():
             name = _name_for_chat(chat)
+            if not self._name_is_usable(name):
+                continue
             if qlow in name.lower() or qlow in format_number(jid).lower():
-                if jid not in seen:
-                    seen.add(jid)
+                if self._dedup_key(jid) not in seen:
+                    seen.add(self._dedup_key(jid))
                     self._results.append((name, jid, chat))
-                    self._results_list.Append((name,))
 
         # ── Search contacts not yet in chats ──────────────────────────────────
         for jid, contact in mw.contacts.items():
-            if jid in seen:
+            if self._dedup_key(jid) in seen:
                 continue
             name = contact.get("name") or contact.get("pushName") or format_number(jid)
-            if qlow in (name or "").lower() or qlow in format_number(jid).lower():
-                seen.add(jid)
-                self._results.append((name or format_number(jid), jid, None))
-                self._results_list.Append((name or format_number(jid),))
+            if not self._name_is_usable(name):
+                continue
+            if qlow in name.lower() or qlow in format_number(jid).lower():
+                seen.add(self._dedup_key(jid))
+                self._results.append((name, jid, None))
 
         # ── If query looks like a phone number, add direct option ─────────────
         digits = re.sub(r"\D", "", query)
         if len(digits) >= 7:
             direct_jid = digits + "@s.whatsapp.net"
-            if direct_jid not in seen:
+            if self._dedup_key(direct_jid) not in seen:
                 display = format_number(direct_jid)
                 self._results.append((display, direct_jid, None))
-                self._results_list.Append((display,))
+
+        # Sort alphabetically, case-insensitively, so the list is predictable
+        # for keyboard/screen-reader navigation instead of dict-insertion order.
+        self._results.sort(key=lambda r: r[0].lower())
+        for name, jid, chat in self._results:
+            self._results_list.Append((name,))
 
         if not self._results:
             self._results_list.Append((self._mw.i18n.t("no_results"),))

--- a/tests/test_line_separator_normalization.py
+++ b/tests/test_line_separator_normalization.py
@@ -1,0 +1,134 @@
+"""Tests for Unicode line/paragraph separator normalization.
+
+The "artificial line breaks" report: pasting text from rich sources — Google
+Docs, Word, websites, Apple apps — copies U+2028 LINE SEPARATOR / U+2029
+PARAGRAPH SEPARATOR into the clipboard where a plain editor stores \n. The
+native wx TextCtrl keeps them verbatim: it neither renders them as breaks
+(a paste looks like a single long line) nor counts them in
+GetNumberOfLines(), yet WhatsApp renders U+2029 as a paragraph break for the
+recipient. So the same text looks fine (or collapses to one line) in the
+field and arrives on the other side full of weird breaks.
+
+The fix normalizes these to plain \n in two places: when pasting into the
+message field (_on_message_field_paste) and again at send time
+(on_send_message) as a safety net for text that reaches the field by any
+other route. normalize_line_separators() in core/utils.py does the actual
+mapping; the paste handler is exercised with a real wx.TextCtrl (WriteText
+is what inserts the normalized text), same approach as
+tests/test_shift_enter_newline.py.
+"""
+
+import pytest
+import wx
+
+from core.utils import normalize_line_separators
+from ui.conversations import ConversationsPanel
+
+
+class TestNormalizeLineSeparators:
+    @pytest.mark.parametrize("sep", ["\u2028", "\u2029", "\u0085", "\x0b", "\x0c"])
+    def test_every_unicode_separator_becomes_a_newline(self, sep):
+        assert normalize_line_separators(f"A{sep}B") == "A\nB"
+
+    def test_paragraph_separator_map_is_the_reported_bug(self):
+        # The actual reproduction from the report: a multi-paragraph paste.
+        text = "Primeiro par\u00e1grafo.\u2029Segundo par\u00e1grafo."
+        assert normalize_line_separators(text) == (
+            "Primeiro par\u00e1grafo.\nSegundo par\u00e1grafo."
+        )
+
+    def test_plain_newlines_are_left_alone(self):
+        assert normalize_line_separators("a\nb\nc") == "a\nb\nc"
+
+    def test_crlf_and_lone_cr_are_normalized(self):
+        assert normalize_line_separators("a\r\nb") == "a\nb"
+        assert normalize_line_separators("a\rb") == "a\nb"
+
+    def test_mixed_separators_collapse_to_newlines(self):
+        assert normalize_line_separators("a\u2028b\r\nc\u2029d") == "a\nb\nc\nd"
+
+    def test_empty_and_none_are_safe(self):
+        assert normalize_line_separators("") == ""
+        assert normalize_line_separators(None) == ""
+
+    def test_normal_text_is_unchanged(self):
+        text = "Ol\u00e1, como vai? Tudo bem."
+        assert normalize_line_separators(text) == text
+
+
+class TestSendPathCallsNormalization:
+    def test_on_send_message_normalizes_before_sending(self):
+        """The paste handler fixes the common entry point, but text can also
+        reach the field by other routes (drag-and-drop, scripts). The send
+        path is the final gate and must normalize whatever it reads. Checked
+        at source level because driving on_send_message whole needs a live
+        wx.App and a WhatsApp session."""
+        import inspect
+
+        src = inspect.getsource(ConversationsPanel.on_send_message)
+        assert "normalize_line_separators(self.message_field.GetValue())" in src, (
+            "on_send_message reads the field without normalizing Unicode "
+            "line/paragraph separators first"
+        )
+
+
+class _FakeKeyEvent:
+    def __init__(self):
+        self.skipped = False
+
+    def Skip(self):
+        self.skipped = True
+
+
+class _FakeMentionPanel:
+    def IsShown(self):
+        return False
+
+
+class _Stub:
+    _on_message_field_paste = ConversationsPanel._on_message_field_paste
+
+    def __init__(self, frame):
+        self.message_field = wx.TextCtrl(
+            frame, style=wx.TE_MULTILINE | wx.TE_PROCESS_ENTER | wx.TE_DONTWRAP
+        )
+
+
+class TestPasteNormalization:
+    def test_paste_of_paragraph_separator_text_is_normalized(self, wx_app):
+        frame = wx.Frame(None)
+        try:
+            stub = _Stub(frame)
+            if wx.TheClipboard.Open():
+                wx.TheClipboard.SetData(wx.TextDataObject("A\u2029B\u2029C"))
+                wx.TheClipboard.Close()
+            else:
+                pytest.skip("clipboard unavailable")
+
+            stub._on_message_field_paste(_FakeKeyEvent())
+
+            assert stub.message_field.GetValue() == "A\nB\nC"
+            assert stub.message_field.GetNumberOfLines() == 3
+        finally:
+            frame.Destroy()
+
+    def test_paste_of_plain_text_is_left_alone(self, wx_app):
+        frame = wx.Frame(None)
+        try:
+            stub = _Stub(frame)
+            if wx.TheClipboard.Open():
+                wx.TheClipboard.SetData(wx.TextDataObject("hello\nworld"))
+                wx.TheClipboard.Close()
+            else:
+                pytest.skip("clipboard unavailable")
+
+            event = _FakeKeyEvent()
+            stub._on_message_field_paste(event)
+
+            # Plain text is delegated to the native paste (Skip), which the
+            # handler must not itself touch — the assertion is the delegation
+            # itself, since no real paste event is being processed here.
+            assert event.skipped
+            assert stub.message_field.GetValue() == ""
+        finally:
+            frame.Destroy()

--- a/tests/test_line_separator_normalization.py
+++ b/tests/test_line_separator_normalization.py
@@ -10,7 +10,7 @@ recipient. So the same text looks fine (or collapses to one line) in the
 field and arrives on the other side full of weird breaks.
 
 The fix normalizes these to plain \n in two places: when pasting into the
-message field (_on_message_field_paste) and again at send time
+message field (_on_text_field_paste) and again at send time
 (on_send_message) as a safety net for text that reaches the field by any
 other route. normalize_line_separators() in core/utils.py does the actual
 mapping; the paste handler is exercised with a real wx.TextCtrl (WriteText
@@ -73,11 +73,19 @@ class TestSendPathCallsNormalization:
 
 
 class _FakeKeyEvent:
-    def __init__(self):
+    """The handler now works off the control that raised the event, so the
+    fake has to carry one — that is what lets a single handler serve the
+    message field and the attachment caption."""
+
+    def __init__(self, target=None):
         self.skipped = False
+        self._target = target
 
     def Skip(self):
         self.skipped = True
+
+    def GetEventObject(self):
+        return self._target
 
 
 class _FakeMentionPanel:
@@ -86,12 +94,13 @@ class _FakeMentionPanel:
 
 
 class _Stub:
-    _on_message_field_paste = ConversationsPanel._on_message_field_paste
+    _on_text_field_paste = ConversationsPanel._on_text_field_paste
 
     def __init__(self, frame):
         self.message_field = wx.TextCtrl(
             frame, style=wx.TE_MULTILINE | wx.TE_PROCESS_ENTER | wx.TE_DONTWRAP
         )
+        self._caption_field = wx.TextCtrl(frame, style=wx.TE_PROCESS_ENTER)
 
 
 class TestPasteNormalization:
@@ -105,7 +114,7 @@ class TestPasteNormalization:
             else:
                 pytest.skip("clipboard unavailable")
 
-            stub._on_message_field_paste(_FakeKeyEvent())
+            stub._on_text_field_paste(_FakeKeyEvent(stub.message_field))
 
             assert stub.message_field.GetValue() == "A\nB\nC"
             assert stub.message_field.GetNumberOfLines() == 3
@@ -122,8 +131,8 @@ class TestPasteNormalization:
             else:
                 pytest.skip("clipboard unavailable")
 
-            event = _FakeKeyEvent()
-            stub._on_message_field_paste(event)
+            event = _FakeKeyEvent(stub.message_field)
+            stub._on_text_field_paste(event)
 
             # Plain text is delegated to the native paste (Skip), which the
             # handler must not itself touch — the assertion is the delegation
@@ -132,3 +141,73 @@ class TestPasteNormalization:
             assert stub.message_field.GetValue() == ""
         finally:
             frame.Destroy()
+
+
+class TestEveryOtherFieldThatReachesWhatsApp:
+    """The message field was only the first of five.
+
+    Anything typed or pasted into these also arrives on someone else's
+    WhatsApp, so a caption or a status pasted from Word reproduced the exact
+    same report the message field had. Checked at source level because
+    driving these whole needs a live wx.App and a WhatsApp session.
+    """
+
+    @pytest.mark.parametrize("module,method,expression", [
+        ("ui.conversations", "ConversationsPanel._on_send_attachment",
+         "normalize_line_separators(self._caption_field.GetValue())"),
+        ("status_panel", "StatusPanel._on_send_status_reply",
+         "normalize_line_separators(self._reply_field.GetValue())"),
+        ("status_panel", "StatusPanel._on_send_text_status",
+         "normalize_line_separators(self._post_text_field.GetValue())"),
+        ("status_panel", "StatusPanel._on_send_text_status",
+         "normalize_line_separators(self._caption_field.GetValue())"),
+    ])
+    def test_send_path_normalizes_before_sending(self, module, method, expression):
+        import importlib
+        import inspect
+
+        cls_name, attr = method.split(".")
+        cls = getattr(importlib.import_module(module), cls_name)
+        src = inspect.getsource(getattr(cls, attr))
+        assert expression in src, (
+            f"{method} reads a field that ends up on WhatsApp without "
+            f"normalizing Unicode line/paragraph separators first"
+        )
+
+    def test_media_status_caption_is_normalized_too(self):
+        import inspect
+        from status_panel import StatusPanel
+
+        src = inspect.getsource(StatusPanel)
+        assert "normalize_line_separators(self._media_caption_field.GetValue())" in src
+
+
+class TestPasteHandlerIsGeneric:
+    def test_it_writes_to_the_control_that_raised_the_event(self, wx_app):
+        """The generalization that lets one handler serve every field: the
+        text goes to the control the paste came from, not to a hardcoded
+        message_field."""
+        frame = wx.Frame(None)
+        try:
+            stub = _Stub(frame)
+            if wx.TheClipboard.Open():
+                wx.TheClipboard.SetData(wx.TextDataObject("A\u2029B"))
+                wx.TheClipboard.Close()
+            else:
+                pytest.skip("clipboard unavailable")
+
+            stub._on_text_field_paste(_FakeKeyEvent(stub._caption_field))
+
+            assert stub._caption_field.GetValue() == "A\nB"
+            assert stub.message_field.GetValue() == "", "escreveu no campo errado"
+        finally:
+            frame.Destroy()
+
+    def test_the_caption_field_is_bound_to_the_handler(self):
+        """Binding is what makes the fix reach the field at paste time; the
+        send path alone would fix the recipient but still show (and read
+        aloud) a single run-on line while composing."""
+        import inspect
+
+        src = inspect.getsource(ConversationsPanel)
+        assert "self._caption_field.Bind(wx.EVT_TEXT_PASTE, self._on_text_field_paste)" in src

--- a/tests/test_new_conversation_empty_list.py
+++ b/tests/test_new_conversation_empty_list.py
@@ -1,0 +1,288 @@
+"""Tests for the New Conversation dialog listing contacts without typing.
+
+The dialog used to open with an empty list and only populate once the user
+typed something in the search field, because _do_search() returned early on
+an empty query and nothing populated the list at construction time. For a
+screen-reader user that meant: Ctrl+N opens a dialog, focus lands on an
+empty list, and there is no way to know which contacts exist without
+guessing a name to type.
+
+The fix makes an empty query list everything (chats first, then the
+remaining contacts), and the dialog populates the list at construction so
+the full contact list is visible immediately.
+
+NewConversationDialog is a wx.Dialog and can't be instantiated without a
+running wx.App, so _do_search is exercised against a stub carrying a fake
+results list — same approach as the rest of the UI-logic tests.
+"""
+
+from ui.dialogs.new_conversation import NewConversationDialog
+
+
+class _FakeResultsList:
+    def __init__(self):
+        self.items = []
+
+    def DeleteAllItems(self):
+        self.items = []
+
+    def Append(self, row):
+        self.items.append(row[0])
+
+
+class _FakeI18n:
+    def t(self, key):
+        return {"no_results": "Sem resultados"}.get(key, key)
+
+
+class _FakeMw:
+    def __init__(self, chats=None, contacts=None, lid_to_phone=None):
+        self.chats = dict(chats or {})
+        self.contacts = dict(contacts or {})
+        self._lid_to_phone = dict(lid_to_phone or {})
+        self.i18n = _FakeI18n()
+
+    def _normalize_jid(self, jid):
+        if not jid:
+            return jid
+        if ":" in jid and "@" in jid:
+            parts = jid.split("@", 1)
+            base = parts[0].split(":", 1)[0]
+            jid = f"{base}@{parts[1]}"
+        if jid.endswith("@c.us"):
+            return jid[:-5] + "@s.whatsapp.net"
+        return jid
+
+    def _resolve_contact_name(self, chat):
+        return chat.get("name", "")
+
+    def find_name_through_messages(self, chat):
+        return ""
+
+    def find_jid_through_messages(self, chat):
+        return ""
+
+    @staticmethod
+    def _group_name_from_chat_dict(chat):
+        name = (chat.get("name") or "").strip()
+        if name:
+            return name
+        subject = (chat.get("subject") or "").strip()
+        if subject:
+            return subject
+        group_meta = chat.get("groupMetadata")
+        if isinstance(group_meta, dict):
+            gm_subject = (group_meta.get("subject") or "").strip()
+            if gm_subject:
+                return gm_subject
+        return ""
+
+    def _is_bad_contact_name(self, name):
+        from core.utils import is_phone_like, looks_like_binary_blob
+        if not name or not isinstance(name, str):
+            return True
+        name = name.strip()
+        return (
+            not name
+            or name.isdigit()
+            or is_phone_like(name)
+            or looks_like_binary_blob(name)
+            or "sem nome" in name.lower()
+            or "unknown" in name.lower()
+            or name.lower() in ("no name", "desconhecido")
+        )
+
+
+class _Stub:
+    _do_search = NewConversationDialog._do_search
+    _name_is_usable = NewConversationDialog._name_is_usable
+    _dedup_key = NewConversationDialog._dedup_key
+
+    def __init__(self, mw):
+        self._mw = mw
+        self._results = []
+        self._results_list = _FakeResultsList()
+
+
+def _chat(jid, name):
+    return {"remoteJid": jid, "name": name}
+
+
+def _contact(jid, name):
+    return {"id": jid, "remoteJid": jid, "name": name}
+
+
+class TestEmptyQueryListsEverything:
+    def test_empty_query_lists_all_contacts(self):
+        mw = _FakeMw(
+            contacts={"1@s.whatsapp.net": _contact("1@s.whatsapp.net", "Ana")}
+        )
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert [n for n, _, _ in stub._results] == ["Ana"]
+        assert stub._results_list.items == ["Ana"]
+
+    def test_chats_and_contacts_are_all_sorted_together(self):
+        mw = _FakeMw(
+            chats={"9@s.whatsapp.net": _chat("9@s.whatsapp.net", "Grupo Família")},
+            contacts={
+                "1@s.whatsapp.net": _contact("1@s.whatsapp.net", "Ana"),
+                "2@s.whatsapp.net": _contact("2@s.whatsapp.net", "Bia"),
+            },
+        )
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert [n for n, _, _ in stub._results] == ["Ana", "Bia", "Grupo Família"]
+
+    def test_results_are_sorted_alphabetically(self):
+        mw = _FakeMw(
+            contacts={
+                "3@s.whatsapp.net": _contact("3@s.whatsapp.net", "carlos"),
+                "1@s.whatsapp.net": _contact("1@s.whatsapp.net", "Ana"),
+                "2@s.whatsapp.net": _contact("2@s.whatsapp.net", "Bia"),
+            }
+        )
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert [n for n, _, _ in stub._results] == ["Ana", "Bia", "carlos"]
+
+    def test_nameless_group_jid_is_filtered_out(self):
+        """The reported bug: a group with no name resolved to its raw
+        18-digit JID (e.g. 120363426112908706) via format_number()."""
+        mw = _FakeMw(
+            chats={
+                "120363426112908706@g.us": _chat("120363426112908706@g.us", ""),
+                "5@s.whatsapp.net": _chat("5@s.whatsapp.net", "Zé"),
+            }
+        )
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert [n for n, _, _ in stub._results] == ["Zé"]
+
+    def test_named_group_shows_its_name_not_the_raw_jid(self):
+        """A group WITH a name (name/subject/groupMetadata.subject) must
+        appear under that name, sorted with the rest — not fall through to
+        its raw 18-digit id."""
+        jid = "120363000000000001@g.us"
+        mw = _FakeMw(
+            chats={
+                jid: _chat(jid, "Família"),
+                "1@s.whatsapp.net": _chat("1@s.whatsapp.net", "Ana"),
+            }
+        )
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert [n for n, _, _ in stub._results] == ["Ana", "Família"]
+
+    def test_contact_with_only_a_phone_number_is_filtered_out(self):
+        mw = _FakeMw(
+            contacts={"5511999999999@s.whatsapp.net": _contact("5511999999999@s.whatsapp.net", "")}
+        )
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert stub._results == []
+        assert stub._results_list.items == ["Sem resultados"]
+
+    def test_contact_already_in_chats_is_not_duplicated(self):
+        jid = "1@s.whatsapp.net"
+        mw = _FakeMw(
+            chats={jid: _chat(jid, "Ana")},
+            contacts={jid: _contact(jid, "Ana")},
+        )
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert [n for n, _, _ in stub._results] == ["Ana"]
+
+    def test_cus_and_net_forms_of_the_same_contact_are_not_duplicated(self):
+        """Same phone stored once as @c.us (chat) and once as @s.whatsapp.net
+        (contact) must appear once — the raw JIDs differ but they're the
+        same person."""
+        mw = _FakeMw(
+            chats={"5511999999999@c.us": _chat("5511999999999@c.us", "Bia")},
+            contacts={"5511999999999@s.whatsapp.net": _contact("5511999999999@s.whatsapp.net", "Bia")},
+        )
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert [n for n, _, _ in stub._results] == ["Bia"]
+
+    def test_brazilian_8_vs_9_digit_forms_are_not_duplicated(self):
+        """551199999999 vs 5511999999999 (the 9th-digit variant) identify the
+        same number; both being present must yield a single row."""
+        mw = _FakeMw(
+            contacts={
+                "551199999999@s.whatsapp.net": _contact("551199999999@s.whatsapp.net", "Carla"),
+                "5511999999999@s.whatsapp.net": _contact("5511999999999@s.whatsapp.net", "Carla"),
+            }
+        )
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert [n for n, _, _ in stub._results] == ["Carla"]
+
+    def test_lid_chat_and_phone_contact_are_not_duplicated(self):
+        """A chat stored under @lid whose bridge maps back to a phone number
+        that's also in contacts must not show up twice."""
+        lid = "10000000000001@lid"
+        phone = "5511999999999@s.whatsapp.net"
+        mw = _FakeMw(
+            chats={lid: _chat(lid, "Duda")},
+            contacts={phone: _contact(phone, "Duda")},
+            lid_to_phone={lid: phone},
+        )
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert [n for n, _, _ in stub._results] == ["Duda"]
+
+    def test_nothing_at_all_apends_no_results_row(self):
+        stub = _Stub(_FakeMw())
+
+        stub._do_search("")
+
+        assert stub._results == []
+        assert stub._results_list.items == ["Sem resultados"]
+
+
+class TestTypedQueryStillFilters:
+    def test_typed_query_only_lists_matches(self):
+        mw = _FakeMw(
+            chats={"1@s.whatsapp.net": _chat("1@s.whatsapp.net", "Ana")},
+            contacts={
+                "2@s.whatsapp.net": _contact("2@s.whatsapp.net", "Bia"),
+                "3@s.whatsapp.net": _contact("3@s.whatsapp.net", "Ana Paula"),
+            },
+        )
+        stub = _Stub(mw)
+
+        stub._do_search("ana")
+
+        assert [n for n, _, _ in stub._results] == ["Ana", "Ana Paula"]
+
+    def test_typed_query_excludes_non_matches(self):
+        mw = _FakeMw(
+            contacts={"2@s.whatsapp.net": _contact("2@s.whatsapp.net", "Bia")}
+        )
+        stub = _Stub(mw)
+
+        stub._do_search("ana")
+
+        assert stub._results == []
+        assert stub._results_list.items == ["Sem resultados"]

--- a/tests/test_quote_lost_drops_reply_header.py
+++ b/tests/test_quote_lost_drops_reply_header.py
@@ -1,0 +1,138 @@
+"""Tests for the quote-lost fallback in text sends.
+
+Reported live: when a quoted (reply) text send fails server-side,
+send_text_message() retries as a plain send without the quote — but the
+virtual message kept its reply contextInfo, so the conversation row kept
+reading "Eu, respondendo a MK Digital: teste" even though the message was
+delivered with no quote at all.
+
+The fix threads a quote_lost flag from send_text_message() (which knows it
+stripped the quote) through MessageQueue._on_message_sent() down to
+ConversationsPanel._mark_message_sent(), which drops the contextInfo before
+re-rendering the row. The echo-matching path in MainWindow.on_new_message()
+never touches contextInfo, so without the explicit drop the stale reply
+header would live on forever.
+
+MainWindow is a wx.Frame and cannot be instantiated without a running
+wx.App, so the chain is exercised against small stubs — same approach as
+tests/test_failed_send_preview.py.
+"""
+
+from main import MainWindow
+from ui.conversations import ConversationsPanel
+
+
+class _FakeSound:
+    def __init__(self):
+        self.played = False
+
+    def play(self):
+        self.played = True
+
+
+class _FakeList:
+    def __init__(self):
+        self.renders = []
+        self.set_calls = []
+
+    def SetItemText(self, index, text):
+        self.set_calls.append((index, text))
+        while len(self.renders) <= index:
+            self.renders.append("")
+        self.renders[index] = text
+
+
+class _FakeMainWindow:
+    def __init__(self):
+        self.message_sent_sound = _FakeSound()
+        self.schedule_set_chats_calls = 0
+
+    def _schedule_save(self, dirty_jid=None):
+        pass
+
+    def _schedule_set_chats(self):
+        self.schedule_set_chats_calls += 1
+
+
+def _make_panel(msg):
+    panel = ConversationsPanel.__new__(ConversationsPanel)
+    panel._sorted_messages = [msg]
+    panel._played_sent_local_ids = set()
+    panel.messages_list = _FakeList()
+    panel.conversation = {"remoteJid": "j@c.us"}
+    panel.main_window = _FakeMainWindow()
+    panel._render_message_line = lambda m, **kw: "RENDERED:" + str(m.get("_local_id"))
+    return panel
+
+
+def _make_msg(**overrides):
+    msg = {
+        "_local_id": "loc-1",
+        "_local_pending": True,
+        "key": {"id": "loc-1", "fromMe": True, "remoteJid": "j@c.us"},
+        "messageType": "conversation",
+        "message": {"conversation": "teste"},
+        "messageTimestamp": 1,
+        "pushName": "",
+        "contextInfo": {
+            "stanzaId": "ABC",
+            "participant": "p@s.whatsapp.net",
+            "quotedMessage": {"conversation": "citação original"},
+            "_quotedFromMe": False,
+        },
+    }
+    msg.update(overrides)
+    return msg
+
+
+class TestMarkMessageSentQuoteLost:
+    def test_quote_lost_drops_context_info_from_the_row(self):
+        msg = _make_msg()
+        panel = _make_panel(msg)
+
+        ConversationsPanel._mark_message_sent(panel, "loc-1", real_id="REAL", quote_lost=True)
+
+        assert "contextInfo" not in msg
+        assert msg["_local_pending"] is False
+
+    def test_quote_lost_rereads_the_row(self):
+        msg = _make_msg()
+        panel = _make_panel(msg)
+
+        ConversationsPanel._mark_message_sent(panel, "loc-1", real_id="REAL", quote_lost=True)
+
+        assert panel.messages_list.set_calls == [(0, "RENDERED:loc-1")]
+
+    def test_without_quote_lost_context_info_is_kept(self):
+        msg = _make_msg()
+        panel = _make_panel(msg)
+
+        ConversationsPanel._mark_message_sent(panel, "loc-1", real_id="REAL", quote_lost=False)
+
+        assert "contextInfo" in msg
+        assert msg["_local_pending"] is False
+
+
+class TestOnMessageSentForwardsQuoteLost:
+    class _FakeConversationsPanel:
+        def __init__(self):
+            self.calls = []
+
+        def _mark_message_sent(self, local_id, real_id=None, quote_lost=False):
+            self.calls.append((local_id, real_id, quote_lost))
+
+    class _Stub:
+        _on_message_sent = MainWindow._on_message_sent
+
+        def __init__(self):
+            self.conversations_panel = TestOnMessageSentForwardsQuoteLost._FakeConversationsPanel()
+
+    def test_quote_lost_is_forwarded_to_the_panel(self):
+        mw = self._Stub()
+        mw._on_message_sent("loc-1", real_id="REAL", remote_jid="j@c.us", quote_lost=True)
+        assert mw.conversations_panel.calls == [("loc-1", "REAL", True)]
+
+    def test_default_quote_lost_is_false(self):
+        mw = self._Stub()
+        mw._on_message_sent("loc-1", real_id="REAL", remote_jid="j@c.us")
+        assert mw.conversations_panel.calls == [("loc-1", "REAL", False)]

--- a/tests/test_system_event_unread_and_reply.py
+++ b/tests/test_system_event_unread_and_reply.py
@@ -1,0 +1,187 @@
+"""Tests for two sides of the same reported bug: a group promote/demote
+arriving as a system event.
+
+* ``main._discount_non_countable_unread()`` must discount system events
+  (and own sends) from a server-reported unread count.  Observed live: a
+  group promote appeared as "1 não lida" in the chat list while the
+  conversation held nothing new — WhatsApp Web counts the promote toward
+  unread, the app's own on_new_message() deliberately never does, and the
+  correction that used to exist only looked at ``fromMe`` records.
+
+* ``ConversationsPanel._on_menu_reply()`` (Alt+R) and
+  ``_on_menu_reply_private()`` (Alt+Shift+R / "Responder em particular")
+  must refuse to enter reply mode for a system event: such messages carry
+  no quotable content, WhatsApp rejects a quoted reply to them (HTTP 500),
+  and the send path would otherwise announce "não foi possível citar a
+  mensagem original" only *after* the quote fell back on send.
+
+ConversationsPanel is a wx.Panel and can't be instantiated without a
+running wx.App, so its methods are exercised as plain functions against a
+small stub — same approach as tests/test_message_bookmarks.py.
+"""
+
+import pytest
+
+from main import _discount_non_countable_unread, is_countable_message
+from ui.conversations import ConversationsPanel
+
+
+def _msg(message_type, from_me=False, **extra):
+    m = {
+        "key": {"fromMe": from_me, "id": "X1"},
+        "messageType": message_type,
+        "message": {},
+    }
+    m.update(extra)
+    return m
+
+
+class TestDiscountNonCountableUnread:
+    def test_system_event_in_the_tail_is_discounted(self):
+        """The reported bug: a group promote (groupNotification) minted a
+        phantom "1 unread".  It must be discounted just like fromMe."""
+        records = [_msg("groupNotification")]
+        assert _discount_non_countable_unread(records, 1) == 0
+
+    def test_own_send_in_the_tail_is_still_discounted(self):
+        records = [_msg("conversation", from_me=True)]
+        assert _discount_non_countable_unread(records, 1) == 0
+
+    def test_real_incoming_content_is_not_discounted(self):
+        records = [_msg("conversation")]
+        assert _discount_non_countable_unread(records, 1) == 1
+
+    def test_mixed_tail_only_discounts_the_non_countable_records(self):
+        records = [
+            _msg("conversation"),
+            _msg("groupNotification"),
+            _msg("protocolMessage"),
+        ]
+        assert _discount_non_countable_unread(records, 3) == 1
+
+    def test_only_the_relevant_tail_is_inspected(self):
+        """A server count of 1 must not discount an OLDER system event that
+        is outside the tail that justifies the count."""
+        records = [
+            _msg("groupNotification"),
+            _msg("conversation"),
+        ]
+        assert _discount_non_countable_unread(records, 1) == 1
+
+    def test_larger_count_discounts_every_non_countable_in_the_tail(self):
+        records = [_msg("groupNotification"), _msg("conversation")]
+        assert _discount_non_countable_unread(records, 2) == 1
+
+    def test_zero_or_negative_count_is_untouched(self):
+        assert _discount_non_countable_unread([_msg("conversation")], 0) == 0
+        assert _discount_non_countable_unread([_msg("conversation")], -1) == -1
+
+    def test_no_records_returns_the_count_unchanged(self):
+        assert _discount_non_countable_unread([], 5) == 5
+        assert _discount_non_countable_unread(None, 5) == 5
+
+    def test_tolerates_junk_records(self):
+        records = ["nonsense", 42, None, {"key": {}}]
+        assert _discount_non_countable_unread(records, 2) == 0
+
+    def test_discount_is_consistent_with_is_countable_message(self):
+        """Anchor: whatever is_countable_message() rejects must be
+        discounted from a server-reported count."""
+        for message_type in (
+            "conversation", "groupNotification", "protocolMessage",
+            "imageMessage", "e2e_notification",
+        ):
+            records = [_msg(message_type)]
+            expected = 1 if is_countable_message(_msg(message_type)) else 0
+            assert _discount_non_countable_unread(records, 1) == expected, message_type
+
+
+class _FakeI18n:
+    _STRINGS = {
+        "reply_quote_lost": "não foi possível citar",
+        "reply_to": "Responder a {name}",
+        "reply_to_group": "Responder a {name} em {group}",
+    }
+
+    def t(self, key):
+        return self._STRINGS[key]
+
+
+class _FakeMainWindow:
+    def __init__(self):
+        self.i18n = _FakeI18n()
+        self.announced = []
+
+    def output(self, text):
+        self.announced.append(text)
+
+    def self_reference_label(self):
+        return "Você"
+
+
+class _FakeWidget:
+    def __init__(self):
+        self.set_label = None
+        self.shown = False
+        self.layout_called = False
+        self.focused = False
+
+    def SetLabel(self, text):
+        self.set_label = text
+
+    def Show(self):
+        self.shown = True
+
+    def Layout(self):
+        self.layout_called = True
+
+    def SetFocus(self):
+        self.focused = True
+
+
+class _Stub:
+    _is_system_event = staticmethod(ConversationsPanel._is_system_event)
+    _sender_label = ConversationsPanel._sender_label
+
+    def __init__(self):
+        self.main_window = _FakeMainWindow()
+        self._quoted_message = None
+        self.conversation = {"remoteJid": "5511999999999@s.whatsapp.net"}
+        self.conversation_name = "Grupo Teste"
+        self.message_label = _FakeWidget()
+        self._remove_quote_btn = _FakeWidget()
+        self.conversation_panel = _FakeWidget()
+        self.message_field = _FakeWidget()
+        self._lid_to_phone = {}
+        self._phone_to_lid = {}
+        self._presence_pushname_map = {}
+        self._group_participants_cache = []
+
+
+class TestReplyRefusesSystemEvents:
+    def test_reply_announces_and_skips_reply_mode(self):
+        """Alt+R / menu "Responder" on a system event must announce the
+        lost-quote message and NOT enter reply mode (no _quoted_message)."""
+        panel = _Stub()
+        ConversationsPanel._on_menu_reply(panel, _msg("groupNotification"))
+        assert panel.main_window.announced == ["não foi possível citar"]
+        assert panel._quoted_message is None
+
+    def test_reply_private_announces_and_does_not_navigate(self):
+        """Alt+Shift+R / "Responder em particular" on a system event must
+        be refused the same way, before any navigation to a private chat."""
+        panel = _Stub()
+        ConversationsPanel._on_menu_reply_private(
+            panel, _msg("groupNotification"), "5511999999999@lid")
+        assert panel.main_window.announced == ["não foi possível citar"]
+        assert panel._quoted_message is None
+
+    def test_non_system_message_still_enters_reply_mode(self):
+        """Sanity: the guard must not touch real messages.  A normal
+        conversation message still stores _quoted_message and shows the
+        reply header."""
+        panel = _Stub()
+        ConversationsPanel._on_menu_reply(panel, _msg("conversation", from_me=True))
+        assert panel.main_window.announced == []
+        assert panel._quoted_message is not None
+        assert panel.message_label.set_label == "Responder a Você"


### PR DESCRIPTION
## O que acontecia

Colar texto de fontes ricas (Google Docs, Word, sites, apps Apple) copia separadores Unicode U+2028 (LINE SEPARATOR) e U+2029 (PARAGRAPH SEPARATOR) no lugar do \n.

O campo wx.TextCtrl guardava esses caracteres literalmente: o controle nativo não os renderiza como quebra de linha (a colagem parecia "tudo numa linha"), mas o WhatsApp do destinatário renderiza U+2029 como quebra de parágrafo. Resultado: as "quebras artificiais/estranhas" relatadas.

## O que foi feito

- core/utils.py: novo helper normalize_line_separators() que converte U+2028, U+2029, NEL, VT, FF e CR isolado para \n.
- ui/conversations.py:
  - _on_message_field_paste intercepta EVT_TEXT_PASTE, normaliza o texto colado e insere com WriteText (campo passa a exibir as quebras corretas também);
  - on_send_message normaliza o texto lido do campo como salvaguarda (cobre envio e edição).
- tests/test_line_separator_normalization.py: 14 testes cobrindo o helper e o handler de colagem.

## Verificação

pytest tests/test_line_separator_normalization.py -> 14 passed. Suíte completa: 1887 passed; os 2 failures de test_api_patches_in_sync são drift pré-existente do client/api/, confirmados também no main limpo.