### PR TITLE
fix: getAllContacts sem TypeError em listChats undefined (contatos zerados na sync)

### DIFF
--- a/client/api_patches/src/controller/deviceController.ts
+++ b/client/api_patches/src/controller/deviceController.ts
@@ -2987,11 +2987,19 @@ export async function getAllContacts(req: Request, res: Response) {
       // to actually finish. listChats() wraps the same modern, non-
       // deprecated WPP.chat.list() the list-chats route already uses, with
       // the same ignoreGroupMetadata skip.
+      // listChats().catch(() => []) only covers a *rejection* — the promise
+      // can also resolve to undefined (e.g. the page's execution context was
+      // destroyed by a navigation mid-evaluate). Guard with Array.isArray so
+      // an undefined/non-array result degrades to "no active-chat filter"
+      // instead of throwing, which made get_remote_contacts() (WinZapp's
+      // Python caller) abort on the 500 with zero contacts on every sync.
       const chats = await req.client
         .listChats({ ignoreGroupMetadata: true } as any)
         .catch(() => []);
       const activeChatIds = new Set(
-        chats.map((c: any) => c?.id?._serialized || c?.id).filter(Boolean)
+        (Array.isArray(chats) ? chats : [])
+          .map((c: any) => c?.id?._serialized || c?.id)
+          .filter(Boolean)
       );
 
       response = response.filter((c: any) => {


### PR DESCRIPTION
## O que foi

Correção do bug que deixava o WinZapp com **0 contatos** em toda sincronização, reportado pelo Gustavo (logs em `gustavo/`).

## Causa

`getAllContacts()` em `client/api_patches/src/controller/deviceController.ts:2994` fazia `chats.map(...)` sobre o resultado de `listChats().catch(() => [])`. O `.catch` só cobre **rejeição** — a promise pode **resolver** para `undefined` (contexto de página destruído por navegação durante o evaluate). Aí `chats.map` estoura `TypeError: Cannot read properties of undefined (reading 'map')` → 500 `Error on get all constacts`.

O caller Python (`main.py`) aborta no 500 sem retry (`if response.status_code >= 500: break`), então o resultado era 0 contatos baixados a cada ciclo de sync:

```
[get_remote_contacts] API error 500: Error on get all constacts
[get_remote_contacts] Downloaded 0 contacts from WPPConnect API.
```

## Fix

Guard `Array.isArray(chats) ? chats : []` antes do `.map` — resultado undefined/não-array degrada para "sem filtro de chat ativo" em vez de quebrar; o caller Python recebe `[]` e faz os retries próprios.

## Validação ao vivo (conta principal)

Antes: `Downloaded 0 contacts` + 500 repetido. Depois do fix (dist recompilado):

```
[get_remote_contacts] Downloaded 479 contacts from WPPConnect API.
[get_remote_contacts] Total filtered contacts (phonebook): 470 (com nomes)
```

Zero erros no log do launch, conexão estável.

## Nota

`tests/test_api_patches_in_sync.py` passa para `deviceController.ts` (único fail no arquivo é `createSessionUtil.ts`, drift pré-existente de CRLF na máquina local — HEAD é LF; não relacionado a esta mudança).