### PR TITLE
fix/audio-host-api-fallback

### DIFF
--- a/client/core/audio_devices.py
+++ b/client/core/audio_devices.py
@@ -216,6 +216,35 @@ def find_input_device_index(name: str, pa: "pyaudio.PyAudio | None" = None):
     return _match_device(name, enumerate_input_devices(pa))
 
 
+def fallback_input_device_indices(pa: "pyaudio.PyAudio | None" = None, exclude=()) -> list:
+    """Input device indices still worth trying after the preferred open
+    attempts — the pinned device, then `input_device_index=None` — have all
+    failed.
+
+    `input_device_index=None` does not mean "whichever device works": PortAudio
+    resolves it to the default device of its *default host API*, which is MME
+    on Windows. enumerate_input_devices() deliberately reads the WASAPI host
+    API instead, so the indices it returns are a different set of handles,
+    potentially onto the very same microphone reached by a different path.
+    Host APIs fail independently — the same headset answered -9999
+    "Unanticipated host error" through MME, DirectSound and WDM-KS but -9996
+    "Invalid device" through WASAPI, three drivers disagreeing about one piece
+    of hardware. "The default device refused every rate/channel combo" is
+    therefore not evidence that nothing on this machine can record, which is
+    the conclusion both recording paths used to draw.
+
+    Costs nothing while recording works: callers only get here after every
+    earlier attempt returned None — the path that previously just gave up.
+
+    Never raises: enumerate_input_devices() already guarantees that, and both
+    callers run inside a daemon thread where an escaping exception dies unseen.
+    `exclude` drops indices already tried; None entries in it are ignored,
+    being the system-default sentinel rather than an index.
+    """
+    skip = {idx for idx in exclude if idx is not None}
+    return [idx for idx, _name in enumerate_input_devices(pa) if idx not in skip]
+
+
 # Sample-rate/channel combinations to try opening an input device with, in
 # preference order — must mirror ui/conversations.py's _start_voice_recording()
 # fallback chain exactly. A single hardcoded (rate, channels) pair doesn't

--- a/client/core/audio_devices.py
+++ b/client/core/audio_devices.py
@@ -83,24 +83,60 @@ def _pyaudio_input_devices(pa: "pyaudio.PyAudio") -> list:
     try:
         host_api = pa.get_host_api_info_by_type(pyaudio.paWASAPI)
     except Exception:
-        host_api = pa.get_default_host_api_info()
+        # This fallback used to be unguarded — an error handler with an
+        # unhandled error of its own. PortAudio can fail to resolve *any*
+        # host API (Windows Audio service stopped, no sound hardware at
+        # all), and that exception then escaped the entire enumeration
+        # instead of degrading to "no input devices", which is what every
+        # caller is written to expect. See enumerate_input_devices().
+        try:
+            host_api = pa.get_default_host_api_info()
+        except Exception:
+            logging.warning(
+                "[audio] No usable PortAudio host API — reporting no input devices.",
+                exc_info=True,
+            )
+            return []
+
+    # host_api is a plain dict from PortAudio; a malformed/empty one must not
+    # take the caller down either. "index" was read inside the loop before,
+    # so a missing key silently produced an empty list N times over — same
+    # outcome, but nothing said why.
+    try:
+        host_api_index = host_api["index"]
+        device_count = host_api.get("deviceCount", 0)
+    except Exception:
+        logging.warning("[audio] Unusable host API info: %r.", host_api)
+        return []
 
     devices = []
-    for i in range(host_api.get("deviceCount", 0)):
+    for i in range(device_count):
         try:
-            info = pa.get_device_info_by_host_api_device_index(host_api["index"], i)
+            info = pa.get_device_info_by_host_api_device_index(host_api_index, i)
+            if info.get("maxInputChannels", 0) > 0:
+                # Inside the try: a device whose info dict is missing
+                # index/name is one device to skip, not a reason to drop
+                # every device found so far.
+                devices.append((info["index"], str(info["name"]).strip()))
         except Exception:
             continue
-        if info.get("maxInputChannels", 0) > 0:
-            devices.append((info["index"], str(info["name"]).strip()))
     return devices
 
 
 def enumerate_input_devices(pa: "pyaudio.PyAudio | None" = None) -> list:
     """[(device_index, friendly_name), ...] for input-capable devices. Opens
-    a temporary PyAudio instance if `pa` isn't supplied. Returns an empty
-    list if PyAudio itself isn't installed (see the import at the top of
-    this file) rather than raising."""
+    a temporary PyAudio instance if `pa` isn't supplied.
+
+    Never raises: an empty list means "no input device to offer", whether
+    because PyAudio isn't installed (see the import at the top of this file),
+    because PortAudio itself can't start, or because no host API resolved.
+    That contract was documented here long before the code actually honoured
+    it — two calls were left unguarded (the get_default_host_api_info()
+    fallback in _pyaudio_input_devices(), and the pyaudio.PyAudio()
+    construction just below), so a broken audio stack propagated an exception
+    into all four call sites instead. Callers rely on the empty case: it
+    resolves to input_device_index=None, i.e. the system default device.
+    """
     if pyaudio is None:
         # WinZapp fork: PyAudio has no wheel on Python 3.14, so degrade to a
         # sounddevice query instead of reporting no input devices at all.
@@ -115,9 +151,28 @@ def enumerate_input_devices(pa: "pyaudio.PyAudio | None" = None) -> list:
             return []
     owns_pa = pa is None
     if owns_pa:
-        pa = pyaudio.PyAudio()
+        try:
+            pa = pyaudio.PyAudio()
+        except Exception:
+            # Constructing PyAudio initialises PortAudio, which fails outright
+            # when the Windows Audio service is stopped or no endpoint exists.
+            # Every caller that passes no `pa` of its own lands here: the
+            # Settings > Audio Devices combo (ui/dialogs/settings_dialog.py)
+            # and apply_audio_devices() during startup (main.py).
+            logging.warning(
+                "[audio] Failed to initialise PyAudio for device enumeration.",
+                exc_info=True,
+            )
+            return []
     try:
         return _pyaudio_input_devices(pa)
+    except Exception:
+        # Belt and braces: _pyaudio_input_devices() handles its own known
+        # failure points, but this function's contract is "never raise", and
+        # its callers run on the wx UI thread (Settings dialog) or inside a
+        # daemon thread where an escaping exception dies unseen.
+        logging.warning("[audio] Failed to enumerate input devices.", exc_info=True)
+        return []
     finally:
         if owns_pa:
             try:

--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -789,6 +789,7 @@
     "soundpack_import_error_invalid_zip": "Invalid .zip file.",
     "media_unsupported_error": "the file appears to be corrupted or in a format WhatsApp cannot process",
     "voice_recording_unavailable": "Voice recording is unavailable on this Python install (audio library not found).",
+    "voice_recording_device_failed": "Could not open the microphone. Check that it is connected and that WinZapp is allowed to use it in Windows privacy settings.",
     "copy_caption": "Copy caption",
     "group_admin_suffix": "group admin",
     "remove_member": "Remove member",

--- a/client/languages/es-ES.json
+++ b/client/languages/es-ES.json
@@ -789,6 +789,7 @@
     "soundpack_import_error_invalid_zip": "Archivo .zip no válido.",
     "media_unsupported_error": "el archivo parece estar dañado o en un formato que WhatsApp no puede procesar",
     "voice_recording_unavailable": "Grabación de voz no disponible en esta instalación de Python (biblioteca de audio no encontrada).",
+    "voice_recording_device_failed": "No se pudo abrir el micrófono. Comprueba que está conectado y que WinZapp tiene permiso para usarlo en la configuración de privacidad de Windows.",
     "copy_caption": "Copiar leyenda",
     "group_admin_suffix": "administrador del grupo",
     "remove_member": "Eliminar miembro",

--- a/client/languages/pl.json
+++ b/client/languages/pl.json
@@ -789,6 +789,7 @@
     "soundpack_import_error_invalid_zip": "Nieprawidłowy plik .zip.",
     "media_unsupported_error": "plik wydaje się uszkodzony lub zapisany w formacie, którego WhatsApp nie potrafi przetworzyć",
     "voice_recording_unavailable": "Nagrywanie głosu jest niedostępne w tej instalacji Pythona (nie znaleziono biblioteki audio).",
+    "voice_recording_device_failed": "Nie udało się otworzyć mikrofonu. Sprawdź, czy jest podłączony i czy WinZapp ma uprawnienia do jego użycia w ustawieniach prywatności systemu Windows.",
     "copy_caption": "Kopiuj podpis",
     "group_admin_suffix": "administrator grupy",
     "remove_member": "Usuń uczestnika",

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -789,6 +789,7 @@
     "soundpack_import_error_invalid_zip": "Arquivo .zip inválido.",
     "media_unsupported_error": "o arquivo parece estar corrompido ou em um formato que o WhatsApp não consegue processar",
     "voice_recording_unavailable": "Gravação de voz indisponível nesta instalação do Python (biblioteca de áudio não encontrada).",
+    "voice_recording_device_failed": "Não foi possível abrir o microfone. Verifique se ele está conectado e se o WinZapp tem permissão para acessá-lo nas configurações de privacidade do Windows.",
     "copy_caption": "Copiar legenda",
     "group_admin_suffix": "admin do grupo",
     "remove_member": "Remover membro",

--- a/client/languages/pt-PT.json
+++ b/client/languages/pt-PT.json
@@ -789,6 +789,7 @@
     "soundpack_import_error_invalid_zip": "Ficheiro .zip inválido.",
     "media_unsupported_error": "o ficheiro parece estar corrompido ou num formato que o WhatsApp não consegue processar",
     "voice_recording_unavailable": "Gravação de voz indisponível nesta instalação do Python (biblioteca de áudio não encontrada).",
+    "voice_recording_device_failed": "Não foi possível abrir o microfone. Verifique se está ligado e se o WinZapp tem permissão para lhe aceder nas definições de privacidade do Windows.",
     "copy_caption": "Copiar legenda",
     "group_admin_suffix": "administrador do grupo",
     "remove_member": "Remover membro",

--- a/client/status_panel.py
+++ b/client/status_panel.py
@@ -1949,8 +1949,18 @@ class StatusPanel(wx.Panel):
             self._recording_starting = False
 
             if stream is None:
+                # voice_recording_unavailable means "PyAudio isn't installed"
+                # (see the top of _start_voice_recording) — reused here it
+                # pointed at the wrong cause entirely, since PyAudio is
+                # plainly present if we got as far as trying to open a
+                # stream. The device-specific message tells the user the one
+                # thing that is actionable: check the mic and its Windows
+                # permission.
+                logging.warning(
+                    "[status audio] No input stream could be opened — recording not started."
+                )
                 wx.MessageBox(
-                    self.main_window.i18n.t("voice_recording_unavailable"),
+                    self.main_window.i18n.t("voice_recording_device_failed"),
                     self.main_window.app_name,
                     wx.OK | wx.ICON_WARNING, self,
                 )

--- a/client/status_panel.py
+++ b/client/status_panel.py
@@ -13,7 +13,9 @@ from ui.accessible import (
 )
 from core.utils import format_number, get_downloads_folder, normalize_line_separators
 from core.video_player import VideoPlayer
-from core.audio_devices import find_input_device_index, RECORDING_SAMPLE_CONFIGS
+from core.audio_devices import (
+    find_input_device_index, fallback_input_device_indices, RECORDING_SAMPLE_CONFIGS,
+)
 
 try:
     import pyaudio
@@ -1925,6 +1927,24 @@ class StatusPanel(wx.Panel):
                 stream, rate, ch = _try_open(input_device_index)
                 if stream is None and input_device_index is not None:
                     stream, rate, ch = _try_open(None)
+
+                if stream is None:
+                    # Same last resort as ConversationsPanel, and kept
+                    # deliberately identical to it: _try_open(None) only
+                    # covers the default host API's default device, so a
+                    # microphone that refuses MME but answers on WASAPI is
+                    # still reachable by index. Posting a voice status and
+                    # sending a voice message have no reason to disagree
+                    # about which microphones exist — this panel already
+                    # drifted behind the other one once.
+                    for idx in fallback_input_device_indices(pa, exclude=(input_device_index,)):
+                        stream, rate, ch = _try_open(idx)
+                        if stream is not None:
+                            logging.info(
+                                "[status audio] Default input device failed; recording via "
+                                "enumerated device index %s instead.", idx,
+                            )
+                            break
             except Exception:
                 logging.exception(
                     "[status audio] Failed to open the recording stream (device=%r).",

--- a/client/status_panel.py
+++ b/client/status_panel.py
@@ -702,6 +702,17 @@ class StatusPanel(wx.Panel):
         self._recording_channels = 1
         self._recording_paused  = False
         self._is_recording      = False
+        # True while a background thread is opening the PyAudio input stream.
+        # pa.open() (and find_input_device_index()'s device enumeration) can
+        # block for seconds negotiating with the driver, and this used to run
+        # straight on the wx thread — freezing the window, and the screen
+        # reader with it, for as long as the driver took. Mirrors
+        # ConversationsPanel's own recording open (client/ui/conversations.py):
+        # _recording_starting guards against re-entry, _recording_open_token
+        # lets a discard/close that happens mid-open throw the stream away
+        # once it finally arrives.
+        self._recording_starting   = False
+        self._recording_open_token = 0
 
         self.SetSizer(sizer)
 
@@ -1828,7 +1839,8 @@ class StatusPanel(wx.Panel):
         If voice post panel is shown: start recording if idle, or send if recording."""
         if self._voice_post_panel.IsShown():
             if not self._is_recording:
-                self._start_voice_recording()
+                if not self._recording_starting:
+                    self._start_voice_recording()
             else:
                 self._on_send_voice_status(None)
         else:
@@ -1846,7 +1858,8 @@ class StatusPanel(wx.Panel):
 
     def _on_record_voice_button(self, event):
         if not self._is_recording:
-            self._start_voice_recording()
+            if not self._recording_starting:
+                self._start_voice_recording()
         else:
             self._on_send_voice_status(event)
 
@@ -1887,39 +1900,83 @@ class StatusPanel(wx.Panel):
             return None, None, None
 
         configured_name = getattr(self.main_window, "effective_input_device_name", "") or ""
-        input_device_index = find_input_device_index(configured_name, pa) if configured_name else None
 
-        stream, rate, ch = _try_open(input_device_index)
-        if stream is None and input_device_index is not None:
-            stream, rate, ch = _try_open(None)
+        # Everything up to here is cheap. find_input_device_index() and
+        # pa.open() are not: both talk to the audio driver and can block for
+        # seconds, and they used to run right here on the wx thread — the
+        # window (and the screen reader reading it) froze for the duration.
+        self._recording_starting = True
+        self._recording_open_token += 1
+        my_token = self._recording_open_token
 
-        if stream is None:
-            wx.MessageBox(
-                self.main_window.i18n.t("voice_recording_unavailable"),
-                self.main_window.app_name,
-                wx.OK | wx.ICON_WARNING, self,
-            )
-            return
+        def _bg_open_stream():
+            # An exception escaping this function would die unseen in a daemon
+            # thread and take the wx.CallAfter with it, leaving
+            # _recording_starting stuck True — and both entry points
+            # (_on_record_voice_button, _on_ctrl_r_shortcut) refuse to start
+            # while it is, so the record control would go dead for the rest of
+            # the session. _on_stream_opened() is the only thing that clears
+            # the flag, so it is scheduled from a finally and runs either way.
+            stream = rate = ch = None
+            try:
+                input_device_index = (
+                    find_input_device_index(configured_name, pa) if configured_name else None
+                )
+                stream, rate, ch = _try_open(input_device_index)
+                if stream is None and input_device_index is not None:
+                    stream, rate, ch = _try_open(None)
+            except Exception:
+                logging.exception(
+                    "[status audio] Failed to open the recording stream (device=%r).",
+                    configured_name,
+                )
+            finally:
+                wx.CallAfter(_on_stream_opened, stream, rate, ch)
 
-        self._recording_stream   = stream
-        self._recording_rate     = rate
-        self._recording_channels = ch
-        self._is_recording       = True
+        def _on_stream_opened(stream, rate, ch):
+            # Discard the result if the panel was closed or the recording
+            # discarded while the stream was still opening — otherwise a
+            # stream nobody asked for any more starts capturing in silence.
+            if my_token != self._recording_open_token:
+                if stream is not None:
+                    try:
+                        stream.stop_stream()
+                        stream.close()
+                    except Exception:
+                        pass
+                return
 
-        if hasattr(self.main_window, "voicemsg_startrecording_sound"):
-            self.main_window.voicemsg_startrecording_sound.play()
+            self._recording_starting = False
 
-        i18n = self.main_window.i18n
-        self._voice_status_lbl.SetLabel(i18n.t("recording_in_progress"))
-        self._voice_close_btn.SetLabel(i18n.t("discard_voice_message"))
-        self._voice_close_btn.Show()
-        self._voice_start_btn.Hide()
-        self._voice_pause_btn.SetLabel(i18n.t("pause_recording"))
-        self._voice_pause_btn.Show()
-        self._voice_send_btn.SetLabel(i18n.t("send_voice_message"))
-        self._voice_send_btn.Show()
-        self.Layout()
-        self._voice_send_btn.SetFocus()
+            if stream is None:
+                wx.MessageBox(
+                    self.main_window.i18n.t("voice_recording_unavailable"),
+                    self.main_window.app_name,
+                    wx.OK | wx.ICON_WARNING, self,
+                )
+                return
+
+            self._recording_stream   = stream
+            self._recording_rate     = rate
+            self._recording_channels = ch
+            self._is_recording       = True
+
+            if hasattr(self.main_window, "voicemsg_startrecording_sound"):
+                self.main_window.voicemsg_startrecording_sound.play()
+
+            i18n = self.main_window.i18n
+            self._voice_status_lbl.SetLabel(i18n.t("recording_in_progress"))
+            self._voice_close_btn.SetLabel(i18n.t("discard_voice_message"))
+            self._voice_close_btn.Show()
+            self._voice_start_btn.Hide()
+            self._voice_pause_btn.SetLabel(i18n.t("pause_recording"))
+            self._voice_pause_btn.Show()
+            self._voice_send_btn.SetLabel(i18n.t("send_voice_message"))
+            self._voice_send_btn.Show()
+            self.Layout()
+            self._voice_send_btn.SetFocus()
+
+        threading.Thread(target=_bg_open_stream, daemon=True).start()
 
     def _toggle_pause_voice_recording(self, event):
         if not self._is_recording:
@@ -1948,6 +2005,11 @@ class StatusPanel(wx.Panel):
             self._recording_stream = None
 
     def _on_close_voice_panel(self, event):
+        # Bump the token so a stream still opening on a background thread (see
+        # _start_voice_recording) is closed and discarded when it arrives,
+        # instead of starting to capture into a panel the user just dismissed.
+        self._recording_open_token += 1
+        self._recording_starting = False
         if self._is_recording and hasattr(self.main_window, "voicemsg_discard_sound"):
             try:
                 self.main_window.voicemsg_discard_sound.play()

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -21,7 +21,9 @@ except ImportError:
 import wave
 import sound_lib.stream as sl_stream
 from sound_lib.effects import Tempo
-from core.audio_devices import find_input_device_index, RECORDING_SAMPLE_CONFIGS
+from core.audio_devices import (
+    find_input_device_index, fallback_input_device_indices, RECORDING_SAMPLE_CONFIGS,
+)
 from core.audio_transcode import transcode_m4a_to_wav
 from core.sound_system import load_sound
 from ui.accessible import (
@@ -2057,6 +2059,26 @@ class ConversationsPanel(wx.Panel):
                 if stream is None and input_device_index is not None:
                     fell_back = True
                     stream, rate, ch = _try_open(None)
+
+                if stream is None:
+                    # Last resort, and the reason this branch exists at all:
+                    # _try_open(None) asks PortAudio for the default device of
+                    # its *default* host API — MME on Windows — which is not
+                    # the same handle set enumerate_input_devices() reads
+                    # (WASAPI). One host API refusing a microphone says
+                    # nothing about the others; see
+                    # fallback_input_device_indices() for the observed
+                    # disagreement. Giving up here used to mean "no recording
+                    # this session" while a working path to the same mic sat
+                    # one index away, unexamined.
+                    for idx in fallback_input_device_indices(pa, exclude=(input_device_index,)):
+                        stream, rate, ch = _try_open(idx)
+                        if stream is not None:
+                            logging.info(
+                                "[audio] Default input device failed; recording via "
+                                "enumerated device index %s instead.", idx,
+                            )
+                            break
             except Exception:
                 logging.exception(
                     "[audio] Failed to open the recording stream (device=%r).",

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -2086,13 +2086,39 @@ class ConversationsPanel(wx.Panel):
                 # (retried again next launch) but fall back to the system
                 # default for the rest of this run.
                 self.main_window.effective_input_device_name = ""
+                if stream is not None:
+                    # Only worth saying when the fallback actually worked.
+                    # If it didn't, recording never started at all, and the
+                    # message below is the accurate thing to report instead
+                    # of two dialogs in a row.
+                    wx.MessageBox(
+                        self.main_window.i18n.t("audio_device_failed_input").format(device=configured_name),
+                        self.main_window.i18n.t("error").format(app_name=self.main_window.app_name),
+                        wx.OK | wx.ICON_WARNING, self,
+                    )
+
+            if stream is None:
+                # This used to `return` in silence unless a *configured*
+                # device had failed (fell_back above) — and a pinned device
+                # is not the default state. On a machine with no device
+                # pinned, every open failure was invisible: no dialog, no
+                # sound, nothing in log.log. Reported live as "I press
+                # record and nothing happens at all", against a mic whose
+                # every sample-rate/channel combo PortAudio rejected with
+                # -9999. For a screen-reader-first app that is the worst
+                # outcome available — there is no visual cue either, so
+                # nothing tells the user whether the app, the shortcut or
+                # the microphone is at fault. StatusPanel already warned in
+                # this exact situation; the two panels disagreed, and the
+                # busier one was the silent one.
+                logging.warning(
+                    "[audio] No input stream could be opened — recording not started."
+                )
                 wx.MessageBox(
-                    self.main_window.i18n.t("audio_device_failed_input").format(device=configured_name),
+                    self.main_window.i18n.t("voice_recording_device_failed"),
                     self.main_window.i18n.t("error").format(app_name=self.main_window.app_name),
                     wx.OK | wx.ICON_WARNING, self,
                 )
-
-            if stream is None:
                 return
 
             self._recording_stream      = stream

--- a/tests/test_audio_devices.py
+++ b/tests/test_audio_devices.py
@@ -20,6 +20,7 @@ from core.audio_devices import (
     _match_device,
     enumerate_input_devices,
     enumerate_output_devices,
+    fallback_input_device_indices,
     test_input_device as _test_input_device,
 )
 from core.sound_system import SoundSystem
@@ -442,3 +443,49 @@ class TestBrokenAudioStack:
         fake_pa = _BrokenPyAudio()
         monkeypatch.setattr(audio_devices_module.pyaudio, "PyAudio", lambda: fake_pa)
         assert audio_devices_module.find_input_device_index("Microfone USB") is None
+
+
+class TestFallbackInputDeviceIndices:
+    """The candidates a recording path may still try once its preferred
+    attempts have failed.
+
+    `input_device_index=None` is not "any device that works": PortAudio maps
+    it to the default device of its default host API (MME on Windows), while
+    enumerate_input_devices() reads WASAPI. They are different handles, and
+    host APIs fail independently — so the default refusing every rate/channel
+    combo does not mean nothing on the machine can record, which is exactly
+    the conclusion both recording paths used to draw before giving up.
+    """
+
+    def test_offers_every_enumerated_index(self, monkeypatch):
+        monkeypatch.setattr(audio_devices_module, "enumerate_input_devices",
+                            lambda pa=None: [(12, "Headset"), (18, "Webcam")])
+        assert fallback_input_device_indices() == [12, 18]
+
+    def test_skips_indices_already_tried(self, monkeypatch):
+        """The pinned device was tried first and failed; retrying it would
+        just cost another round of driver negotiation for a known answer."""
+        monkeypatch.setattr(audio_devices_module, "enumerate_input_devices",
+                            lambda pa=None: [(12, "Headset"), (18, "Webcam")])
+        assert fallback_input_device_indices(exclude=(12,)) == [18]
+
+    def test_none_in_exclude_is_ignored(self, monkeypatch):
+        """None is the system-default sentinel, not a device index — dropping
+        entries equal to it would silently remove device 0 on any machine
+        where PortAudio numbers from zero."""
+        monkeypatch.setattr(audio_devices_module, "enumerate_input_devices",
+                            lambda pa=None: [(0, "Onboard"), (12, "Headset")])
+        assert fallback_input_device_indices(exclude=(None,)) == [0, 12]
+
+    def test_no_devices_means_nothing_left_to_try(self, monkeypatch):
+        monkeypatch.setattr(audio_devices_module, "enumerate_input_devices",
+                            lambda pa=None: [])
+        assert fallback_input_device_indices() == []
+
+    def test_a_broken_audio_stack_yields_no_candidates(self, monkeypatch):
+        """Not a separate guard, just the consequence of going through
+        enumerate_input_devices(): its "never raises" contract carries over,
+        which matters because both callers run in a daemon thread where an
+        escaping exception dies unseen."""
+        monkeypatch.setattr(audio_devices_module.pyaudio, "PyAudio", lambda: _BrokenPyAudio())
+        assert fallback_input_device_indices() == []

--- a/tests/test_audio_devices.py
+++ b/tests/test_audio_devices.py
@@ -350,3 +350,95 @@ class TestPyAudioUnavailable:
     def test_test_input_device_returns_false(self, monkeypatch):
         monkeypatch.setattr(audio_devices_module, "pyaudio", None)
         assert _test_input_device(5) is False
+
+
+class _BrokenPyAudio:
+    """Stands in for pyaudio.PyAudio on a machine whose audio stack is down
+    (Windows Audio service stopped, no endpoint at all): PortAudio resolves
+    no host API, so both the WASAPI query and the default-host-API fallback
+    raise instead of returning info."""
+
+    def __init__(self, default_raises=True, host_api=None):
+        self.default_raises = default_raises
+        self.host_api = host_api
+        self.terminated = False
+
+    def get_host_api_info_by_type(self, _type):
+        raise OSError(-9998, "Invalid host API")
+
+    def get_default_host_api_info(self):
+        if self.default_raises:
+            raise OSError(-9998, "Invalid host API")
+        return self.host_api
+
+    def get_device_info_by_host_api_device_index(self, _api_index, index):
+        return {"index": index, "name": f"Mic {index}", "maxInputChannels": 1}
+
+    def terminate(self):
+        self.terminated = True
+
+
+class TestBrokenAudioStack:
+    """enumerate_input_devices() documents "never raises", but two calls were
+    left unguarded and broke that contract on a machine with no working audio
+    stack: the get_default_host_api_info() fallback inside the WASAPI handler
+    (an error handler with an unhandled error of its own), and the
+    pyaudio.PyAudio() construction.
+
+    All four call sites are hurt by an escaping exception — the Settings >
+    Audio Devices combo and apply_audio_devices() run it on the wx UI thread,
+    and ui/conversations.py runs it inside a daemon thread where the traceback
+    dies unseen and used to leave the record button permanently dead (see
+    tests/test_recording_open_failure.py).
+    """
+
+    def test_returns_empty_when_no_host_api_resolves(self, monkeypatch):
+        fake_pa = _BrokenPyAudio()
+        monkeypatch.setattr(audio_devices_module.pyaudio, "PyAudio", lambda: fake_pa)
+        assert enumerate_input_devices() == []
+        # The temporary instance must still be cleaned up on the failure path.
+        assert fake_pa.terminated is True
+
+    def test_returns_empty_when_pyaudio_cannot_be_constructed(self, monkeypatch):
+        def _boom():
+            raise OSError(-9996, "Device unavailable")
+
+        monkeypatch.setattr(audio_devices_module.pyaudio, "PyAudio", _boom)
+        assert enumerate_input_devices() == []
+
+    def test_falls_back_to_the_default_host_api_when_wasapi_is_absent(self, monkeypatch):
+        """The fallback is guarded now, but it must still *work* — WASAPI is
+        Windows-only, and the default host API is the whole point of it."""
+        fake_pa = _BrokenPyAudio(
+            default_raises=False,
+            host_api={"index": 0, "deviceCount": 2},
+        )
+        monkeypatch.setattr(audio_devices_module.pyaudio, "PyAudio", lambda: fake_pa)
+        assert enumerate_input_devices() == [(0, "Mic 0"), (1, "Mic 1")]
+
+    def test_returns_empty_on_host_api_info_without_an_index(self, monkeypatch):
+        fake_pa = _BrokenPyAudio(default_raises=False, host_api={"deviceCount": 3})
+        monkeypatch.setattr(audio_devices_module.pyaudio, "PyAudio", lambda: fake_pa)
+        assert enumerate_input_devices() == []
+
+    def test_a_single_malformed_device_does_not_drop_the_others(self, monkeypatch):
+        """One bad device info dict is one device to skip, not a reason to
+        report none — the index/name lookup used to sit outside the per-device
+        try, so a single malformed entry took the whole list with it."""
+        class _OneBadDevice(_BrokenPyAudio):
+            def get_device_info_by_host_api_device_index(self, _api_index, index):
+                if index == 1:
+                    return {"maxInputChannels": 1}      # no index, no name
+                return {"index": index, "name": f"Mic {index}", "maxInputChannels": 1}
+
+        fake_pa = _OneBadDevice(default_raises=False, host_api={"index": 0, "deviceCount": 3})
+        monkeypatch.setattr(audio_devices_module.pyaudio, "PyAudio", lambda: fake_pa)
+        assert enumerate_input_devices() == [(0, "Mic 0"), (2, "Mic 2")]
+
+    def test_find_input_device_index_degrades_to_the_system_default(self, monkeypatch):
+        """What the callers actually consume: None means "use whatever
+        PyAudio's own default is", which is how recording keeps working at
+        all on a machine where enumeration fails."""
+        fake_pa = _BrokenPyAudio()
+        monkeypatch.setattr(audio_devices_module.pyaudio, "PyAudio", lambda: fake_pa)
+        assert audio_devices_module.find_input_device_index("Microfone USB") is None

--- a/tests/test_recording_open_failure.py
+++ b/tests/test_recording_open_failure.py
@@ -85,6 +85,9 @@ class _FakeStream:
     def __init__(self):
         self.closed = False
 
+    def start_stream(self):
+        pass
+
     def stop_stream(self):
         pass
 
@@ -296,3 +299,91 @@ class TestFailedOpenIsAnnounced:
         assert [b[0] for b in _BOXES] == ["audio_device_failed_input"]
         assert stub._is_recording is True
         assert stub._recording_starting is False
+
+
+class _FakeSelectivePyAudio:
+    """A PyAudio stand-in where exactly one device index can be opened and
+    every other attempt raises -9999, mirroring a machine whose default host
+    API refuses the microphone that a different host API accepts. Records the
+    index of every attempt, in order, so a test can assert what was tried and
+    in which sequence."""
+
+    def __init__(self, working_index=None):
+        self.working_index = working_index
+        self.opened_indices = []
+
+    def open(self, **kwargs):
+        idx = kwargs.get("input_device_index")
+        self.opened_indices.append(idx)
+        if self.working_index is None or idx != self.working_index:
+            raise OSError(-9999, "Unanticipated host error")
+        return _FakeStream()
+
+
+class TestHostApiFallback:
+    """_try_open(None) asks PortAudio for the default device of its *default*
+    host API — MME on Windows — which is not the handle set
+    enumerate_input_devices() reads (WASAPI). One host API refusing a
+    microphone establishes nothing about the others, so giving up after the
+    default failed could abandon recording for the session while a working
+    path to the same microphone sat one index away, never attempted.
+    """
+
+    def test_a_failed_default_falls_back_to_an_enumerated_device(self, scheduled, monkeypatch):
+        calls, fired = scheduled
+        monkeypatch.setattr(conversations_module, "fallback_input_device_indices",
+                            lambda pa, exclude=(): [7])
+
+        stub = _Stub()
+        stub.main_window.effective_input_device_name = ""   # nothing pinned
+        stub._recording_pa = _FakeSelectivePyAudio(working_index=7)
+        stub._start_voice_recording()
+        assert fired.wait(timeout=5)
+        _dispatch(calls)
+
+        # The system default is still preferred and still tried first.
+        assert stub._recording_pa.opened_indices[0] is None
+        assert 7 in stub._recording_pa.opened_indices
+        assert stub._is_recording is True
+        assert stub._recording_starting is False
+        assert _BOXES == [], "recording started — there was nothing to warn about"
+
+    def test_the_pinned_device_is_not_tried_a_second_time(self, scheduled, monkeypatch):
+        """It already failed as the first attempt; re-opening it would spend
+        another full round of driver negotiation on a known answer."""
+        calls, fired = scheduled
+        seen = {}
+
+        def _candidates(pa, exclude=()):
+            seen["exclude"] = exclude
+            return []
+
+        monkeypatch.setattr(conversations_module, "find_input_device_index", lambda *a, **kw: 3)
+        monkeypatch.setattr(conversations_module, "fallback_input_device_indices", _candidates)
+
+        stub = _Stub()
+        stub._start_voice_recording()
+        assert fired.wait(timeout=5)
+        _dispatch(calls)
+
+        assert 3 in seen["exclude"]
+
+    def test_every_candidate_failing_still_warns(self, scheduled, monkeypatch):
+        """Non-regression guard on the fix this branch already carries: the
+        fallback adds attempts, it must not swallow the announcement when all
+        of them fail."""
+        calls, fired = scheduled
+        monkeypatch.setattr(conversations_module, "fallback_input_device_indices",
+                            lambda pa, exclude=(): [7, 9])
+
+        stub = _Stub()
+        stub.main_window.effective_input_device_name = ""
+        stub._recording_pa = _FakeSelectivePyAudio(working_index=None)
+        stub._start_voice_recording()
+        assert fired.wait(timeout=5)
+        _dispatch(calls)
+
+        assert 7 in stub._recording_pa.opened_indices
+        assert 9 in stub._recording_pa.opened_indices
+        assert [b[0] for b in _BOXES] == ["voice_recording_device_failed"]
+        assert stub._is_recording is False

--- a/tests/test_recording_open_failure.py
+++ b/tests/test_recording_open_failure.py
@@ -1,5 +1,5 @@
 """Regression coverage for ConversationsPanel._start_voice_recording()'s
-background stream open (_bg_open_stream).
+background stream open (_bg_open_stream) and how its failures reach the user.
 
 Opening the PyAudio input stream moved off the UI thread because pa.open()
 can block for seconds negotiating with the driver. That handed the method a
@@ -12,9 +12,13 @@ the session — no dialog, no sound, and (in a daemon thread) no traceback
 anywhere the user can see.
 
 find_input_device_index() is the realistic raiser: core.audio_devices'
-_pyaudio_input_devices() falls back to an unguarded get_default_host_api_info()
-when the WASAPI query fails, which is exactly the kind of broken audio stack
-the background open exists to survive in the first place.
+_pyaudio_input_devices() falls back to get_default_host_api_info() when the
+WASAPI query fails, which is exactly the kind of broken audio stack the
+background open exists to survive in the first place.
+
+The second half of this file covers the outcome once the open genuinely
+fails: it must be *announced*. That path used to return in silence unless a
+pinned device had failed, which is not the default configuration.
 
 ConversationsPanel is a wx.Panel and can't be instantiated without a running
 wx.App, so the method under test is bound onto a plain stub carrying only the
@@ -39,13 +43,53 @@ class _FakeI18n:
 class _FakeMainWindow:
     def __init__(self, device_name="Microfone USB"):
         self.i18n = _FakeI18n()
+        self.app_name = "WinZapp"
         self.output_calls = []
         # Non-empty so _bg_open_stream() actually calls
         # find_input_device_index() — the raiser under test.
         self.effective_input_device_name = device_name
+        # Only touched once an open succeeds and the panel is armed.
+        self.voicemsg_startrecording_sound = types.SimpleNamespace(play=lambda: None)
+        self.settings = {"user_interface": {"voice_record_focus": "send"}}
+        self.recording_status_calls = []
 
     def output(self, text):
         self.output_calls.append(text)
+
+    def send_recording_status(self, jid, on, is_group):
+        self.recording_status_calls.append((jid, on, is_group))
+
+
+class _FakeWidget:
+    """Every wx control _on_stream_opened() touches once it decides to arm
+    the recording UI. None of them assert anything; they exist so the method
+    can run to completion off a plain stub."""
+
+    def Hide(self):
+        pass
+
+    def Show(self, show=True):
+        pass
+
+    def Layout(self):
+        pass
+
+    def SetLabel(self, _text):
+        pass
+
+    def SetFocus(self):
+        pass
+
+
+class _FakeStream:
+    def __init__(self):
+        self.closed = False
+
+    def stop_stream(self):
+        pass
+
+    def close(self):
+        self.closed = True
 
 
 class _Stub:
@@ -61,28 +105,46 @@ class _Stub:
         self._recording_open_token = 0
         self._is_recording = False
         self._recording_stream = None
+        self.settings = {"user_interface": {"voice_record_focus": "send"}}
+        for name in ("message_field", "send_message_btn", "record_voice_message_btn",
+                     "_add_attachment_btn", "_voice_panel", "conversation_panel",
+                     "_pause_resume_btn", "_send_voice_btn", "_discard_voice_btn"):
+            setattr(self, name, _FakeWidget())
+
+
+# Filled by the `scheduled` fixture's wx.MessageBox stand-in. Kept module-level
+# so the fixture's return shape stays (calls, fired) for the tests that predate
+# any dialog being shown on this path at all.
+_BOXES: list = []
 
 
 @pytest.fixture
 def scheduled(monkeypatch):
     """Capture wx.CallAfter(...) instead of dispatching it, and expose an
-    Event so the test can wait for the background thread deterministically."""
+    Event so the test can wait for the background thread deterministically.
+    wx.MessageBox is captured into _BOXES for the same reason: there is no
+    wx.App here, and a real modal dialog would hang the run."""
     calls = []
     fired = threading.Event()
+    _BOXES.clear()
 
     def _fake_call_after(func, *args, **kwargs):
         calls.append((func, args, kwargs))
         fired.set()
 
     monkeypatch.setattr(conversations_module.wx, "CallAfter", _fake_call_after)
+    monkeypatch.setattr(conversations_module.wx, "MessageBox",
+                        lambda *args, **kwargs: _BOXES.append(args))
     # A stand-in for the real module: present (so the method doesn't take the
     # "PyAudio not installed" early return) but never actually touched,
-    # because find_input_device_index() raises first.
+    # because find_input_device_index() is stubbed in every test below.
     monkeypatch.setattr(
         conversations_module,
         "pyaudio",
         types.SimpleNamespace(paInt16=8, paContinue=0),
     )
+    monkeypatch.setattr(conversations_module, "find_input_device_index",
+                        lambda *a, **kw: None)
     return calls, fired
 
 
@@ -90,65 +152,147 @@ def _boom(*_args, **_kwargs):
     raise OSError("no default host API")
 
 
-def test_stream_open_failure_still_schedules_the_callback(scheduled, monkeypatch):
-    """An exception inside the background thread must not swallow the
-    wx.CallAfter — otherwise _on_stream_opened() never runs."""
-    calls, fired = scheduled
-    monkeypatch.setattr(conversations_module, "find_input_device_index", _boom)
-
-    stub = _Stub()
-    stub._start_voice_recording()
-
-    assert fired.wait(timeout=5), "background thread never scheduled _on_stream_opened"
-    assert len(calls) == 1
-    _func, args, _kwargs = calls[0]
-    stream, rate, ch, fell_back = args
-    # Nothing opened, and no device fallback was reached before the raise.
-    assert stream is None
-    assert rate is None
-    assert ch is None
-    assert fell_back is False
-
-
-def test_recording_flag_is_released_after_a_failed_open(scheduled, monkeypatch):
-    """The whole point of the callback still running: the flag it clears is
-    what on_record_voice_message() checks before allowing another attempt."""
-    calls, fired = scheduled
-    monkeypatch.setattr(conversations_module, "find_input_device_index", _boom)
-
-    stub = _Stub()
-    stub._start_voice_recording()
-    assert stub._recording_starting is True, "flag should be set while opening"
-
-    assert fired.wait(timeout=5)
+def _dispatch(calls, *override):
+    """Run what wx would have run on the main thread, optionally overriding
+    the arguments the background thread produced."""
     func, args, _kwargs = calls[0]
-    func(*args)  # what wx would have run on the main thread
-
-    assert stub._recording_starting is False
-    # A failed open must not leave the panel believing it is recording.
-    assert stub._is_recording is False
-    assert stub._recording_stream is None
+    func(*(override or args))
 
 
-def test_record_button_still_responds_after_a_failed_open(scheduled, monkeypatch):
-    """End-to-end guard on the actual user-visible symptom: the second press
-    of the record button must reach _start_voice_recording() again."""
-    calls, fired = scheduled
-    monkeypatch.setattr(conversations_module, "find_input_device_index", _boom)
+class TestCallbackAlwaysRuns:
+    """_on_stream_opened() is the only thing that clears _recording_starting,
+    so it has to be reached no matter how _bg_open_stream() ends."""
 
-    stub = _Stub()
-    stub._start_voice_recording()
-    assert fired.wait(timeout=5)
-    func, args, _kwargs = calls[0]
-    func(*args)
+    def test_stream_open_failure_still_schedules_the_callback(self, scheduled, monkeypatch):
+        calls, fired = scheduled
+        monkeypatch.setattr(conversations_module, "find_input_device_index", _boom)
 
-    # Replay on_record_voice_message()'s own guard rather than trusting the
-    # flag by name: this is the condition that used to be permanently False.
-    reached = []
-    stub._start_voice_recording = lambda: reached.append(True)
-    if stub._is_recording:
-        pass
-    elif not stub._recording_starting:
+        stub = _Stub()
         stub._start_voice_recording()
 
-    assert reached == [True], "record button stayed dead after a failed open"
+        assert fired.wait(timeout=5), "background thread never scheduled _on_stream_opened"
+        assert len(calls) == 1
+        _func, args, _kwargs = calls[0]
+        stream, rate, ch, fell_back = args
+        # Nothing opened, and no device fallback was reached before the raise.
+        assert stream is None
+        assert rate is None
+        assert ch is None
+        assert fell_back is False
+
+    def test_recording_flag_is_released_after_a_failed_open(self, scheduled, monkeypatch):
+        """The whole point of the callback still running: the flag it clears is
+        what on_record_voice_message() checks before allowing another attempt."""
+        calls, fired = scheduled
+        monkeypatch.setattr(conversations_module, "find_input_device_index", _boom)
+
+        stub = _Stub()
+        stub._start_voice_recording()
+        assert stub._recording_starting is True, "flag should be set while opening"
+
+        assert fired.wait(timeout=5)
+        _dispatch(calls)
+
+        assert stub._recording_starting is False
+        # A failed open must not leave the panel believing it is recording.
+        assert stub._is_recording is False
+        assert stub._recording_stream is None
+
+    def test_record_button_still_responds_after_a_failed_open(self, scheduled, monkeypatch):
+        """End-to-end guard on the actual user-visible symptom: the second press
+        of the record button must reach _start_voice_recording() again."""
+        calls, fired = scheduled
+        monkeypatch.setattr(conversations_module, "find_input_device_index", _boom)
+
+        stub = _Stub()
+        stub._start_voice_recording()
+        assert fired.wait(timeout=5)
+        _dispatch(calls)
+
+        # Replay on_record_voice_message()'s own guard rather than trusting the
+        # flag by name: this is the condition that used to be permanently False.
+        reached = []
+        stub._start_voice_recording = lambda: reached.append(True)
+        if stub._is_recording:
+            pass
+        elif not stub._recording_starting:
+            stub._start_voice_recording()
+
+        assert reached == [True], "record button stayed dead after a failed open"
+
+
+class TestFailedOpenIsAnnounced:
+    """A microphone that cannot be opened used to be reported to the user only
+    when a *pinned* device had failed — and pinning one in Settings is not the
+    default state. With none pinned (input_device_name: ""), fell_back stays
+    False and the failure path returned in silence: no dialog, no sound,
+    nothing in log.log.
+
+    Reported live against an H510-PRO headset whose every sample-rate/channel
+    combo PortAudio rejected with -9999: "I press record and nothing happens at
+    all". For a screen-reader-first app that is the worst outcome available —
+    there is no visual cue either, so nothing tells the user whether the app,
+    the shortcut or the microphone is at fault. StatusPanel already warned in
+    this same situation; the two panels disagreed, and the busier one was the
+    silent one.
+    """
+
+    def test_open_failure_with_no_pinned_device_still_warns(self, scheduled):
+        calls, fired = scheduled
+
+        stub = _Stub()
+        # No device pinned — the default state, and the one that used to be
+        # silent because fell_back can never become True without one.
+        stub.main_window.effective_input_device_name = ""
+        stub._start_voice_recording()
+        assert fired.wait(timeout=5)
+        _dispatch(calls)
+
+        assert [b[0] for b in _BOXES] == ["voice_recording_device_failed"], \
+            "open failure was reported to nobody"
+        assert stub._recording_starting is False
+        assert stub._is_recording is False
+
+    def test_exception_path_is_announced_too(self, scheduled, monkeypatch):
+        """The raise-in-the-thread case ends in the same stream=None callback,
+        so it must reach the user as well, not just the log."""
+        calls, fired = scheduled
+        monkeypatch.setattr(conversations_module, "find_input_device_index", _boom)
+
+        stub = _Stub()
+        stub._start_voice_recording()
+        assert fired.wait(timeout=5)
+        _dispatch(calls)
+
+        assert [b[0] for b in _BOXES] == ["voice_recording_device_failed"]
+
+    def test_a_failed_fallback_reports_once_not_twice(self, scheduled):
+        """fell_back means "the pinned device failed, trying the default". If
+        the default failed too, recording never started — saying "falling back
+        to the default" and then "could not open the mic" stacks two dialogs,
+        and the first is misleading on its own."""
+        calls, fired = scheduled
+
+        stub = _Stub()
+        stub._start_voice_recording()
+        assert fired.wait(timeout=5)
+        _dispatch(calls, None, None, None, True)      # stream=None, fell_back=True
+
+        assert [b[0] for b in _BOXES] == ["voice_recording_device_failed"]
+        # The broken pinned device is still dropped for the rest of the session.
+        assert stub.main_window.effective_input_device_name == ""
+
+    def test_a_successful_fallback_still_reports_the_broken_device(self, scheduled):
+        """The opposite guard: when the fallback works, the user must still be
+        told their pinned device is gone. That message is not collateral of the
+        new one."""
+        calls, fired = scheduled
+
+        stub = _Stub()
+        stub._start_voice_recording()
+        assert fired.wait(timeout=5)
+        _dispatch(calls, _FakeStream(), 48000, 1, True)   # fallback succeeded
+
+        assert [b[0] for b in _BOXES] == ["audio_device_failed_input"]
+        assert stub._is_recording is True
+        assert stub._recording_starting is False

--- a/tests/test_status_voice.py
+++ b/tests/test_status_voice.py
@@ -32,6 +32,7 @@ of this test suite (test_status_panel.py).
 """
 
 import os
+import types
 
 import status_panel as status_panel_module
 from status_panel import StatusPanel
@@ -360,4 +361,184 @@ class TestChooseVoiceStatusDegradesGracefullyWithoutPyaudio:
         stub._on_choose_voice_status(None)
 
         assert stub.main_window.output_calls == []
+        assert stub._recording_stream is None
+
+
+class _FakeStream:
+    def __init__(self):
+        self.stopped = False
+        self.closed = False
+
+    def start_stream(self):
+        pass
+
+    def stop_stream(self):
+        self.stopped = True
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeRecordingPyAudio:
+    """Stands in for a live pyaudio.PyAudio instance: records every open()
+    so a test can assert the driver was NOT touched on the wx thread."""
+
+    def __init__(self, works=True):
+        self.works = works
+        self.opened_with = []
+
+    def open(self, rate, channels, format, input, input_device_index,
+             frames_per_buffer, stream_callback):
+        self.opened_with.append((rate, channels))
+        if not self.works:
+            raise OSError(-9996, "Device unavailable")
+        return _FakeStream()
+
+
+class _RecordingStub(_Stub):
+    """_Stub plus the attributes the background stream open touches."""
+
+    _start_voice_recording = StatusPanel._start_voice_recording
+    _on_close_voice_panel  = StatusPanel._on_close_voice_panel
+    _on_record_voice_button = StatusPanel._on_record_voice_button
+
+    def __init__(self, pa_works=True, device_name="Microfone USB"):
+        super().__init__()
+        self.main_window.effective_input_device_name = device_name
+        self._recording_pa = _FakeRecordingPyAudio(works=pa_works)
+        self._recording_starting = False
+        self._recording_open_token = 0
+        self._recording_rate = 48000
+        self._recording_channels = 1
+        self._status_list = _FakeButton()
+
+
+class _CapturedThread:
+    """Captures the thread target instead of running it, so the test controls
+    exactly when the "background" work happens."""
+
+    created = []
+
+    def __init__(self, target=None, daemon=None, **_kw):
+        self.target = target
+        self.daemon = daemon
+        self.started = False
+        _CapturedThread.created.append(self)
+
+    def start(self):
+        self.started = True
+
+
+class TestVoiceStatusRecordingOpensOffTheUiThread:
+    """find_input_device_index() and pa.open() both negotiate with the audio
+    driver and can block for seconds. In StatusPanel they ran directly on the
+    wx thread, so starting a voice status froze the window — and the screen
+    reader reading it — for however long the driver took. ConversationsPanel
+    had the same bug and was fixed first (see
+    tests/test_recording_open_failure.py); this is the same treatment for the
+    status panel, including the finally that guarantees the flag is released.
+    """
+
+    def _patch(self, monkeypatch, call_after, message_boxes=None):
+        _CapturedThread.created = []
+        monkeypatch.setattr(status_panel_module.threading, "Thread", _CapturedThread)
+        monkeypatch.setattr(status_panel_module.wx, "CallAfter",
+                            lambda func, *a, **kw: call_after.append((func, a)))
+        monkeypatch.setattr(status_panel_module.wx, "MessageBox",
+                            lambda *a, **kw: (message_boxes if message_boxes is not None else []).append(a))
+        monkeypatch.setattr(status_panel_module, "pyaudio",
+                            types.SimpleNamespace(paInt16=8, paContinue=0))
+
+    def test_the_driver_is_not_touched_before_the_thread_runs(self, monkeypatch):
+        scheduled = []
+        self._patch(monkeypatch, scheduled)
+        stub = _RecordingStub()
+
+        stub._start_voice_recording()
+
+        # Returned immediately: the open is queued, not done.
+        assert stub._recording_starting is True
+        assert stub._is_recording is False
+        assert stub._recording_pa.opened_with == [], "pa.open() ran on the wx thread"
+        assert len(_CapturedThread.created) == 1
+        assert _CapturedThread.created[0].daemon is True
+        assert _CapturedThread.created[0].started is True
+
+    def test_successful_open_arms_the_panel_from_the_callback(self, monkeypatch):
+        scheduled = []
+        self._patch(monkeypatch, scheduled)
+        monkeypatch.setattr(status_panel_module, "find_input_device_index", lambda *a, **kw: 3)
+        stub = _RecordingStub()
+
+        stub._start_voice_recording()
+        _CapturedThread.created[0].target()          # the "background" work
+
+        assert stub._recording_pa.opened_with == [(48000, 1)]
+        func, args = scheduled[0]
+        func(*args)                                   # what wx would dispatch
+
+        assert stub._is_recording is True
+        assert stub._recording_starting is False
+        assert stub._voice_status_lbl.label == "recording_in_progress"
+
+    def test_open_failure_releases_the_flag_and_warns(self, monkeypatch):
+        scheduled, boxes = [], []
+        self._patch(monkeypatch, scheduled, boxes)
+        monkeypatch.setattr(status_panel_module, "find_input_device_index", lambda *a, **kw: 3)
+        stub = _RecordingStub(pa_works=False)
+
+        stub._start_voice_recording()
+        _CapturedThread.created[0].target()
+        func, args = scheduled[0]
+        func(*args)
+
+        assert stub._recording_starting is False
+        assert stub._is_recording is False
+        assert len(boxes) == 1
+
+    def test_an_exception_still_schedules_the_callback(self, monkeypatch):
+        """The finally: an escaping exception would die unseen in a daemon
+        thread, leaving _recording_starting stuck True and both entry points
+        refusing to ever start recording again."""
+        scheduled, boxes = [], []
+        self._patch(monkeypatch, scheduled, boxes)
+
+        def _boom(*_a, **_kw):
+            raise OSError("no default host API")
+
+        monkeypatch.setattr(status_panel_module, "find_input_device_index", _boom)
+        stub = _RecordingStub()
+
+        stub._start_voice_recording()
+        _CapturedThread.created[0].target()
+
+        assert len(scheduled) == 1, "exception swallowed the wx.CallAfter"
+        func, args = scheduled[0]
+        func(*args)
+        assert stub._recording_starting is False
+
+        # The user-visible symptom: pressing record again must get through.
+        reached = []
+        stub._start_voice_recording = lambda: reached.append(True)
+        stub._on_record_voice_button(None)
+        assert reached == [True], "record control stayed dead after a failed open"
+
+    def test_a_stream_that_arrives_after_discard_is_thrown_away(self, monkeypatch):
+        scheduled = []
+        self._patch(monkeypatch, scheduled)
+        monkeypatch.setattr(status_panel_module, "find_input_device_index", lambda *a, **kw: 3)
+        stub = _RecordingStub()
+
+        stub._start_voice_recording()
+        _CapturedThread.created[0].target()
+
+        # User closes the voice panel while the stream is still opening.
+        stub._on_close_voice_panel(None)
+
+        func, args = scheduled[0]
+        func(*args)
+
+        opened_stream = args[0]
+        assert opened_stream.closed is True, "orphan stream left capturing"
+        assert stub._is_recording is False
         assert stub._recording_stream is None

--- a/tests/test_status_voice.py
+++ b/tests/test_status_voice.py
@@ -542,3 +542,102 @@ class TestVoiceStatusRecordingOpensOffTheUiThread:
         assert opened_stream.closed is True, "orphan stream left capturing"
         assert stub._is_recording is False
         assert stub._recording_stream is None
+
+
+class _FakeSelectivePyAudio:
+    """Like _FakeRecordingPyAudio, but only ONE device index opens — the shape
+    of a machine whose default host API refuses the microphone that another
+    host API accepts. Records every attempted index, in order."""
+
+    def __init__(self, working_index=None):
+        self.working_index = working_index
+        self.opened_indices = []
+        self.opened_with = []
+
+    def open(self, rate, channels, format, input, input_device_index,
+             frames_per_buffer, stream_callback):
+        self.opened_indices.append(input_device_index)
+        self.opened_with.append((rate, channels))
+        if self.working_index is None or input_device_index != self.working_index:
+            raise OSError(-9999, "Unanticipated host error")
+        return _FakeStream()
+
+
+class TestVoiceStatusHostApiFallback:
+    """Same last resort as ConversationsPanel, and deliberately identical to
+    it: posting a voice status and sending a voice message have no reason to
+    disagree about which microphones exist. This panel already drifted behind
+    the other one once — it kept opening the stream on the wx thread long
+    after the conversations panel had stopped (see
+    TestVoiceStatusRecordingOpensOffTheUiThread above).
+    """
+
+    def _patch(self, monkeypatch, call_after, message_boxes=None):
+        _CapturedThread.created = []
+        monkeypatch.setattr(status_panel_module.threading, "Thread", _CapturedThread)
+        monkeypatch.setattr(status_panel_module.wx, "CallAfter",
+                            lambda func, *a, **kw: call_after.append((func, a)))
+        monkeypatch.setattr(status_panel_module.wx, "MessageBox",
+                            lambda *a, **kw: (message_boxes if message_boxes is not None else []).append(a))
+        monkeypatch.setattr(status_panel_module, "pyaudio",
+                            types.SimpleNamespace(paInt16=8, paContinue=0))
+
+    def test_a_failed_default_falls_back_to_an_enumerated_device(self, monkeypatch):
+        scheduled, boxes = [], []
+        self._patch(monkeypatch, scheduled, boxes)
+        monkeypatch.setattr(status_panel_module, "find_input_device_index", lambda *a, **kw: None)
+        monkeypatch.setattr(status_panel_module, "fallback_input_device_indices",
+                            lambda pa, exclude=(): [12])
+
+        stub = _RecordingStub(device_name="")
+        stub._recording_pa = _FakeSelectivePyAudio(working_index=12)
+        stub._start_voice_recording()
+        _CapturedThread.created[0].target()
+        func, args = scheduled[0]
+        func(*args)
+
+        assert stub._recording_pa.opened_indices[0] is None
+        assert 12 in stub._recording_pa.opened_indices
+        assert stub._is_recording is True
+        assert stub._recording_starting is False
+        assert boxes == [], "recording started — there was nothing to warn about"
+
+    def test_the_pinned_device_is_not_tried_a_second_time(self, monkeypatch):
+        scheduled, boxes = [], []
+        self._patch(monkeypatch, scheduled, boxes)
+        seen = {}
+
+        def _candidates(pa, exclude=()):
+            seen["exclude"] = exclude
+            return []
+
+        monkeypatch.setattr(status_panel_module, "find_input_device_index", lambda *a, **kw: 3)
+        monkeypatch.setattr(status_panel_module, "fallback_input_device_indices", _candidates)
+
+        stub = _RecordingStub(pa_works=False)
+        stub._start_voice_recording()
+        _CapturedThread.created[0].target()
+        func, args = scheduled[0]
+        func(*args)
+
+        assert 3 in seen["exclude"]
+
+    def test_every_candidate_failing_still_warns(self, monkeypatch):
+        scheduled, boxes = [], []
+        self._patch(monkeypatch, scheduled, boxes)
+        monkeypatch.setattr(status_panel_module, "find_input_device_index", lambda *a, **kw: None)
+        monkeypatch.setattr(status_panel_module, "fallback_input_device_indices",
+                            lambda pa, exclude=(): [12, 18])
+
+        stub = _RecordingStub(device_name="")
+        stub._recording_pa = _FakeSelectivePyAudio(working_index=None)
+        stub._start_voice_recording()
+        _CapturedThread.created[0].target()
+        func, args = scheduled[0]
+        func(*args)
+
+        assert 12 in stub._recording_pa.opened_indices
+        assert 18 in stub._recording_pa.opened_indices
+        assert stub._recording_starting is False
+        assert stub._is_recording is False
+        assert len(boxes) == 1


### PR DESCRIPTION
Quatro correções no caminho de gravação de áudio, encontradas em sequência depois de alguns testes.

## O que muda

**Enumeração não derruba mais o app** (`87b0fc8`)
`enumerate_input_devices()` documentava "never raises" desde sempre, mas duas
chamadas ficaram fora de proteção: o `get_default_host_api_info()` dentro do
`except` do WASAPI — um tratador de erro com erro próprio — e o
`pyaudio.PyAudio()` do caminho de quem não passa um `pa`. Numa máquina com o
serviço de Áudio parado, as duas estouravam e a exceção escapava para os quatro
chamadores. Agora degradam para lista vazia, que todos já sabem tratar.

**Gravar status não congela mais a janela** (`12e584a`)
`StatusPanel._start_voice_recording()` chamava `find_input_device_index()` e
`pa.open()` direto na thread do wx. Os dois negociam com o driver e podem
bloquear por segundos — e enquanto bloqueiam, a MainLoop não gira: a janela
trava e o leitor de tela junto. Foi para thread daemon, com `try/finally` para
não deixar `_recording_starting` preso em True, e token para descartar stream
órfão. O `ConversationsPanel` já tinha recebido esse tratamento; o painel de
status tinha ficado para trás.

**Falha ao abrir passa a ser comunicada** (`153ffdc`)
O caminho `stream is None` retornava em silêncio. O aviso existia, mas dentro
do `if fell_back:`, que só é verdade quando um dispositivo *fixado* falha — e
fixar um não é o estado padrão de nenhuma instalação. Sem dispositivo fixado:
nenhum diálogo, nenhum som, nenhuma linha no `log.log`.

**Fallback com os dispositivos enumerados** (`019d7d7`)
`input_device_index=None` não significa "qualquer dispositivo que funcione": o
PortAudio resolve isso para o dispositivo padrão do *host API padrão*, que no
Windows é o MME, enquanto `enumerate_input_devices()` lê o WASAPI. São handles
diferentes, possivelmente para o mesmo microfone por caminhos diferentes — e
host APIs falham de forma independente. A cadeia passa a ser
`fixado -> padrão (MME) -> cada índice enumerado (WASAPI)`. Custo zero quando
tudo funciona: o laço só roda depois que todas as tentativas anteriores
voltaram `None`, ou seja, no caminho que antes simplesmente desistia.
