### PR TITLE
fix: reação de outra pessoa não aparecia na mensagem quando a conversa não estava aberta

### DIFF
--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -9785,6 +9785,62 @@ class ConversationsPanel(wx.Panel):
             # suppressed in on_messages_upsert to avoid double-counting.
             wx.CallAfter(self._on_own_reaction_sent, jid, msg_key, emoji)
 
+    def apply_incoming_reaction(self, remote_jid: str, msg: dict):
+        """Apply a reactionMessage that just arrived over the WebSocket.
+
+        Persisting is unconditional; only the live redraw is conditional on
+        the reacted-to chat being the one currently open. main.py's
+        on_new_message() deliberately never appends a reactionMessage to a
+        chat's `records` itself, so this is the ONLY thing that files a live
+        reaction anywhere — and it used to run behind
+        on_incoming_message()'s "is this conversation open?" guard, which
+        meant a reaction to a chat the user was not looking at (the normal
+        case: the toast for it only ever fires while the window is in the
+        background) was applied nowhere at all. It showed up as a
+        notification and then simply did not exist: opening the conversation
+        afterwards rebuilds _reaction_map by scanning `records`, which never
+        received it.
+
+        _reaction_map, by contrast, only ever describes the conversation
+        currently rendered in messages_list — populate_messages() rebuilds it
+        from scratch per conversation — so it is only touched when this
+        reaction really belongs to that conversation.
+        """
+        reaction   = (msg.get("message") or {}).get("reactionMessage") or {}
+        emoji      = reaction.get("text", "")
+        orig_id    = (reaction.get("key") or {}).get("id", "")
+        sender_key = self._reactor_key_from_msg(msg)
+        if not orig_id or not sender_key:
+            return
+
+        if self._matches_open_conversation(remote_jid):
+            per_msg = self._reaction_map.setdefault(orig_id, {})
+            if emoji:
+                # A new/changed reaction from this sender replaces theirs —
+                # it never accumulates into a bogus higher count.
+                per_msg[sender_key] = emoji
+            else:
+                # Empty emoji = this sender removed their reaction.
+                per_msg.pop(sender_key, None)
+            # Re-render the original message in the list
+            for i, m in enumerate(self._sorted_messages):
+                if not self._is_separator(m) and m.get("key", {}).get("id") == orig_id:
+                    self.messages_list.SetItemText(i, self._render_message_line(m))
+                    break
+
+        # Persist so populate_messages()/refresh_active_conversation_messages()
+        # (which rebuild _reaction_map purely from `records`) can recover this
+        # reaction whenever the message list is (re)built — see
+        # _persist_reaction_record()'s own docstring. Not _track_last_reaction()
+        # or _schedule_set_chats() here — main.py's on_new_message() already
+        # calls both for every reaction from someone else.
+        own_key = msg.get("key", {}) or {}
+        self._persist_reaction_record(
+            remote_jid, orig_id, reaction.get("key") or {}, sender_key,
+            bool(own_key.get("fromMe")), emoji,
+            participant=own_key.get("participant", ""),
+        )
+
     def _persist_reaction_record(self, jid: str, orig_id: str, msg_key: dict,
                                   sender_key: str, from_me: bool, emoji: str,
                                   participant: str = "") -> "dict | None":
@@ -9816,6 +9872,12 @@ class ConversationsPanel(wx.Panel):
         chat = self.main_window.get_chat(jid)
         if not chat or not orig_id:
             return None
+        # get_chat() already resolves the @lid/phone duality when looking the
+        # chat up, but the record itself still has to be filed under the
+        # chat's own canonical JID: a live reaction arrives under whichever
+        # form the event happened to use, and persisting it under the other
+        # one wrote it into a DB bucket the conversation never reads back.
+        jid = chat.get("remoteJid") or jid
         rxn_id = (
             f"_rxn_{orig_id}" if sender_key == self._SELF_REACTOR_KEY
             else f"_rxn_{orig_id}_{sender_key}"
@@ -10314,6 +10376,25 @@ class ConversationsPanel(wx.Panel):
 
     # ── Real-time incoming message ────────────────────────────────────────────
 
+    def _matches_open_conversation(self, remote_jid: str) -> bool:
+        """True when remote_jid addresses the conversation currently open.
+
+        Tolerates the @lid/phone duality in both directions: a live event may
+        arrive under either form regardless of which one the open conversation
+        was loaded under.
+        """
+        if self.conversation is None:
+            return False
+        conv_jid = self.conversation.get("remoteJid", "")
+        if conv_jid == remote_jid:
+            return True
+        mapped_lid = getattr(self.main_window, "_phone_to_lid", {}).get(conv_jid, "")
+        mapped_phone = getattr(self.main_window, "_lid_to_phone", {}).get(conv_jid, "")
+        return bool(
+            (mapped_lid and mapped_lid == remote_jid)
+            or (mapped_phone and mapped_phone == remote_jid)
+        )
+
     def on_incoming_message(self, remote_jid: str, msg: dict):
         """
         Called (on the main thread) when a new message arrives via WebSocket.
@@ -10321,18 +10402,18 @@ class ConversationsPanel(wx.Panel):
         message to the list; otherwise does nothing (the unread badge in the
         conversations list is updated separately via set_chats).
         """
+        # Reactions are handled BEFORE the "is this conversation open?" guard
+        # below — unlike a normal message, a reaction still has to be recorded
+        # for a chat the user is not currently looking at. See
+        # apply_incoming_reaction().
+        if msg.get("messageType") == "reactionMessage":
+            self.apply_incoming_reaction(remote_jid, msg)
+            return  # Don't add reaction as a separate row
+
         if self.conversation is None:
             return
-        
-        conv_jid = self.conversation.get("remoteJid", "")
-        jids_match = (conv_jid == remote_jid)
-        if not jids_match:
-            mapped_lid = getattr(self.main_window, "_phone_to_lid", {}).get(conv_jid, "")
-            mapped_phone = getattr(self.main_window, "_lid_to_phone", {}).get(conv_jid, "")
-            if (mapped_lid and mapped_lid == remote_jid) or (mapped_phone and mapped_phone == remote_jid):
-                jids_match = True
 
-        if not jids_match:
+        if not self._matches_open_conversation(remote_jid):
             return
 
         # Get the top visible item before inserting the message
@@ -10352,43 +10433,6 @@ class ConversationsPanel(wx.Panel):
                 m = self._sorted_messages[top_idx]
                 if not self._is_separator(m):
                     top_msg_id = m.get("key", {}).get("id", "")
-        # ── Reaction messages: update reaction_map and re-render original ────
-        if msg.get("messageType") == "reactionMessage":
-            reaction   = (msg.get("message") or {}).get("reactionMessage") or {}
-            emoji      = reaction.get("text", "")
-            orig_id    = (reaction.get("key") or {}).get("id", "")
-            sender_key = self._reactor_key_from_msg(msg)
-            if orig_id and sender_key:
-                per_msg = self._reaction_map.setdefault(orig_id, {})
-                if emoji:
-                    # A new/changed reaction from this sender replaces theirs —
-                    # it never accumulates into a bogus higher count.
-                    per_msg[sender_key] = emoji
-                else:
-                    # Empty emoji = this sender removed their reaction.
-                    per_msg.pop(sender_key, None)
-                # Re-render the original message in the list
-                for i, m in enumerate(self._sorted_messages):
-                    if not self._is_separator(m) and m.get("key", {}).get("id") == orig_id:
-                        self.messages_list.SetItemText(i, self._render_message_line(m))
-                        break
-                # Persist so populate_messages()/refresh_active_conversation_
-                # messages() (which rebuild _reaction_map purely from
-                # `records`) can recover this reaction after anything
-                # repopulates the message list — see
-                # _persist_reaction_record()'s own docstring for the bug
-                # this fixes (a reaction from someone else used to vanish
-                # the next time anything rebuilt the list, since it only
-                # ever touched the in-memory map). Not _track_last_reaction()
-                # or _schedule_set_chats() here — main.py's on_new_message()
-                # already calls both for every reaction from someone else.
-                own_key = msg.get("key", {}) or {}
-                self._persist_reaction_record(
-                    remote_jid, orig_id, reaction.get("key") or {}, sender_key,
-                    bool(own_key.get("fromMe")), emoji,
-                    participant=own_key.get("participant", ""),
-                )
-            return  # Don't add reaction as a separate row
         # Avoid duplicates
         msg_id = msg.get("key", {}).get("id", "")
         if msg_id:

--- a/tests/test_reaction_persisted_from_others.py
+++ b/tests/test_reaction_persisted_from_others.py
@@ -84,6 +84,8 @@ class _FakeMainWindow:
 
 class _Stub:
     on_incoming_message      = ConversationsPanel.on_incoming_message
+    apply_incoming_reaction  = ConversationsPanel.apply_incoming_reaction
+    _matches_open_conversation = ConversationsPanel._matches_open_conversation
     _persist_reaction_record = ConversationsPanel._persist_reaction_record
     _reactor_key_from_msg    = ConversationsPanel._reactor_key_from_msg
     _is_separator            = ConversationsPanel._is_separator

--- a/tests/test_reaction_persisted_when_chat_closed.py
+++ b/tests/test_reaction_persisted_when_chat_closed.py
@@ -1,0 +1,212 @@
+"""Tests for a reaction that arrives for a chat the user is NOT looking at.
+
+Reported live: "quando alguém reage a uma mensagem, o toast vem, mas não
+consta a reação na mensagem".  The toast is the tell — MainWindow.
+_maybe_notify_reaction() only raises a toast when the window is in the
+background, i.e. exactly when the reacted-to conversation is very unlikely
+to be the one open in ConversationsPanel.
+
+Root cause: main.py's on_new_message() deliberately never appends a
+reactionMessage to a chat's own `records` (a raw reaction record must not
+become a chat-list preview), so the ONLY thing that files a live reaction
+anywhere is ConversationsPanel — and its reaction handling sat *behind*
+on_incoming_message()'s "is this conversation open?" early return.  A
+reaction for any other chat was therefore applied nowhere at all: it
+notified, and then simply did not exist.  Opening the conversation
+afterwards rebuilds _reaction_map by scanning `records`, which never
+received it.
+
+Reactions are now handled before that guard (apply_incoming_reaction()):
+persisting is unconditional, only the live redraw of the message row still
+depends on the chat being the one on screen.
+
+ConversationsPanel is a wx.Panel and cannot be instantiated without a
+running wx.App, so the methods are exercised against a small stub — same
+approach as tests/test_reaction_persisted_from_others.py.
+"""
+
+from ui.conversations import ConversationsPanel
+
+
+class _FakeMessagesList:
+    def __init__(self):
+        self.items = []
+
+    def Freeze(self):
+        pass
+
+    def Thaw(self):
+        pass
+
+    def InsertItem(self, pos, text):
+        self.items.insert(pos, text)
+
+    def SetItemText(self, pos, text):
+        self.items[pos] = text
+
+
+class _FakeDB:
+    def __init__(self):
+        self.inserted = []
+
+    def insert_message(self, jid, record):
+        self.inserted.append((jid, record))
+
+
+class _FakeMainWindow:
+    def __init__(self, chats):
+        self.chats = chats
+        self.db = _FakeDB()
+        self._lid_to_phone = {}
+        self._phone_to_lid = {}
+
+    def _allow_ui_focus_changes(self):
+        return False
+
+    def get_chat(self, jid):
+        chat = self.chats.get(jid)
+        if chat is not None:
+            return chat
+        alt = (self._lid_to_phone.get(jid, "") if jid.endswith("@lid")
+               else self._phone_to_lid.get(jid, ""))
+        return self.chats.get(alt) if alt else None
+
+
+class _Stub:
+    on_incoming_message        = ConversationsPanel.on_incoming_message
+    apply_incoming_reaction    = ConversationsPanel.apply_incoming_reaction
+    _matches_open_conversation = ConversationsPanel._matches_open_conversation
+    _persist_reaction_record   = ConversationsPanel._persist_reaction_record
+    _reactor_key_from_msg      = ConversationsPanel._reactor_key_from_msg
+    _is_separator              = ConversationsPanel._is_separator
+    _SELF_REACTOR_KEY          = ConversationsPanel._SELF_REACTOR_KEY
+
+    def __init__(self, open_jid, chats):
+        self.main_window = _FakeMainWindow(chats)
+        self.messages_list = _FakeMessagesList()
+        self._sorted_messages = []
+        self.conversation = {"remoteJid": open_jid} if open_jid else None
+        self._reaction_map = {}
+        self._render_message_line = lambda msg, *a, **kw: msg["key"]["id"]
+
+
+def _chat(jid, messages=None):
+    return {
+        "remoteJid": jid,
+        "messages": {"messages": {"records": list(messages or [])}},
+    }
+
+
+def _orig_msg(mid="m1"):
+    return {"key": {"id": mid, "fromMe": True},
+            "messageType": "conversation", "message": {"conversation": "oi"}}
+
+
+def _reaction(orig_id="m1", emoji="\U0001F44D", chat_jid="", reactor=""):
+    key = {"id": "R" + orig_id, "fromMe": False, "remoteJid": chat_jid}
+    if reactor:
+        key["participant"] = reactor
+    return {
+        "key": key,
+        "messageType": "reactionMessage",
+        "message": {"reactionMessage": {
+            "text": emoji,
+            "key": {"id": orig_id, "fromMe": True, "remoteJid": chat_jid},
+        }},
+    }
+
+
+OPEN_JID = "5511111111111@s.whatsapp.net"
+OTHER_JID = "5522222222222@s.whatsapp.net"
+THUMBS_UP = "\U0001F44D"
+
+
+def _rebuild_reaction_map(records):
+    """Mirror of the _reaction_map rebuild populate_messages() runs over
+    `records` every time it repopulates the message list."""
+    rmap: dict = {}
+    for m in records:
+        if m.get("messageType") != "reactionMessage":
+            continue
+        reaction = (m.get("message") or {}).get("reactionMessage") or {}
+        orig_id = (reaction.get("key") or {}).get("id", "")
+        key = m.get("key", {})
+        sender = ("_me_" if key.get("fromMe")
+                  else key.get("participant") or key.get("remoteJid") or "")
+        if not orig_id or not sender:
+            continue
+        if reaction.get("text", ""):
+            rmap.setdefault(orig_id, {})[sender] = reaction["text"]
+        else:
+            rmap.setdefault(orig_id, {}).pop(sender, None)
+    return rmap
+
+
+class TestReactionForAChatThatIsNotOpen:
+    def _panel(self):
+        chats = {OPEN_JID: _chat(OPEN_JID),
+                 OTHER_JID: _chat(OTHER_JID, [_orig_msg()])}
+        return _Stub(OPEN_JID, chats), chats
+
+    def test_reaction_is_persisted_into_the_closed_chats_records(self):
+        panel, chats = self._panel()
+        panel.on_incoming_message(
+            OTHER_JID, _reaction(chat_jid=OTHER_JID, reactor=OTHER_JID))
+        records = chats[OTHER_JID]["messages"]["messages"]["records"]
+        reactions = [r for r in records if r["messageType"] == "reactionMessage"]
+        assert len(reactions) == 1
+        assert reactions[0]["message"]["reactionMessage"]["text"] == THUMBS_UP
+
+    def test_reaction_is_written_to_the_database(self):
+        panel, _ = self._panel()
+        panel.on_incoming_message(
+            OTHER_JID, _reaction(chat_jid=OTHER_JID, reactor=OTHER_JID))
+        assert [jid for jid, _ in panel.main_window.db.inserted] == [OTHER_JID]
+
+    def test_the_persisted_record_shows_up_when_that_chat_is_opened(self):
+        panel, chats = self._panel()
+        panel.on_incoming_message(
+            OTHER_JID, _reaction(chat_jid=OTHER_JID, reactor=OTHER_JID))
+        rmap = _rebuild_reaction_map(
+            chats[OTHER_JID]["messages"]["messages"]["records"])
+        assert rmap == {"m1": {OTHER_JID: THUMBS_UP}}
+
+    def test_the_open_conversations_reaction_map_is_left_alone(self):
+        panel, _ = self._panel()
+        panel.on_incoming_message(
+            OTHER_JID, _reaction(chat_jid=OTHER_JID, reactor=OTHER_JID))
+        # _reaction_map only ever describes the conversation on screen —
+        # populate_messages() rebuilds it per conversation.
+        assert panel._reaction_map == {}
+
+    def test_reaction_is_persisted_even_with_no_conversation_open_at_all(self):
+        chats = {OTHER_JID: _chat(OTHER_JID, [_orig_msg()])}
+        panel = _Stub(None, chats)
+        panel.on_incoming_message(
+            OTHER_JID, _reaction(chat_jid=OTHER_JID, reactor=OTHER_JID))
+        records = chats[OTHER_JID]["messages"]["messages"]["records"]
+        assert any(r["messageType"] == "reactionMessage" for r in records)
+
+    def test_a_reaction_for_the_open_chat_still_updates_the_live_map(self):
+        chats = {OPEN_JID: _chat(OPEN_JID, [_orig_msg()])}
+        panel = _Stub(OPEN_JID, chats)
+        panel._sorted_messages = [_orig_msg()]
+        panel.messages_list.items = ["m1"]
+        panel.on_incoming_message(
+            OPEN_JID, _reaction(chat_jid=OPEN_JID, reactor=OPEN_JID))
+        assert panel._reaction_map == {"m1": {OPEN_JID: THUMBS_UP}}
+        assert panel.messages_list.items == ["m1"]  # row re-rendered in place
+
+    def test_reaction_arriving_under_the_lid_form_is_filed_under_the_phone_jid(self):
+        lid = "187707351400583@lid"
+        chats = {OTHER_JID: _chat(OTHER_JID, [_orig_msg()])}
+        panel = _Stub(OPEN_JID, chats)
+        panel.main_window._lid_to_phone = {lid: OTHER_JID}
+        panel.on_incoming_message(lid, _reaction(chat_jid=lid, reactor=lid))
+        records = chats[OTHER_JID]["messages"]["messages"]["records"]
+        rxn = next(r for r in records if r["messageType"] == "reactionMessage")
+        # Filed under the chat's own canonical JID, not the @lid the event
+        # happened to arrive under — otherwise the DB row lands in a bucket
+        # the conversation never reads back.
+        assert rxn["key"]["remoteJid"] == OTHER_JID
+        assert [jid for jid, _ in panel.main_window.db.inserted] == [OTHER_JID]

--- a/tests/test_unread_separator_reuse.py
+++ b/tests/test_unread_separator_reuse.py
@@ -56,6 +56,7 @@ def _msg(mid, from_me=False):
 
 class _Stub:
     on_incoming_message = ConversationsPanel.on_incoming_message
+    _matches_open_conversation = ConversationsPanel._matches_open_conversation
     _is_separator = ConversationsPanel._is_separator
     # Bound from the real class rather than faked: on_incoming_message() calls
     # these, and a hand-written stand-in would be free to drift from what the


### PR DESCRIPTION
## O bug

Quando alguém reage a uma mensagem, o toast chega, mas a reação não consta na mensagem.

O toast é a pista. `MainWindow._maybe_notify_reaction()` só dispara um **toast** com a janela em segundo plano — ou seja, exatamente quando a conversa que recebeu a reação quase nunca é a que está aberta no `ConversationsPanel`.

## Causa

`on_new_message()` de propósito **nunca** grava um `reactionMessage` nos `records` da conversa (um registro cru de reação não pode virar prévia da lista de conversas). Então a *única* coisa que arquivava uma reação recebida ao vivo era o `ConversationsPanel` — e esse tratamento estava **depois** do early return "essa conversa está aberta?" de `on_incoming_message()`.

Resultado: reação para qualquer chat que não fosse o aberto na hora era aplicada em lugar nenhum. Notificava e simplesmente deixava de existir — ao abrir a conversa depois, `populate_messages()` reconstrói o `_reaction_map` varrendo `records`, que nunca recebeu nada.

## A correção

- Novo `apply_incoming_reaction()` — a **persistência é incondicional**; só o redesenho ao vivo da linha da mensagem (e o `_reaction_map`, que descreve apenas a conversa renderizada) continua condicionado ao chat estar na tela.
- `on_incoming_message()` trata `reactionMessage` **antes** da guarda de conversa aberta, delegando pra lá.
- Guarda de JID extraída para `_matches_open_conversation()`, usada pelos dois caminhos em vez de duplicar a lógica @lid/telefone.
- Relacionado: `_persist_reaction_record()` agora arquiva sob o JID canônico do chat. O `get_chat()` já resolvia a dualidade @lid/telefone na *busca*, mas o registro ia para o banco sob a forma que o evento por acaso usou — parando num bucket que a conversa nunca lê de volta.

## Testes

`tests/test_reaction_persisted_when_chat_closed.py` (7 testes) cobre: persistência em chat fechado, gravação no banco, reconstrução do mapa ao abrir a conversa, mapa da conversa aberta intacto, sem conversa nenhuma aberta, caminho ao vivo ainda funcionando, e a reação chegando em @lid.

Dois stubs de teste existentes (`test_reaction_persisted_from_others.py`, `test_unread_separator_reuse.py`) precisaram do bind dos novos métodos.

Suíte completa: **2476 passed, 2 skipped**. Validado também rodando o app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
