### PR TITLE
fix: sync deixa de acreditar no list-chats quando o store da página some

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -889,6 +889,17 @@ class MainWindow(wx.Frame):
         # expresses: _sync_completed goes back to False on an incomplete sync
         # and _initial_sync_running is cleared as soon as the thread exits.
         self._sync_ever_started = False
+        # High-water mark of what list-chats has answered with this session,
+        # across sync rounds. Session-scoped on purpose — see the evidence
+        # comment in _run_sync()'s retry loop: it is the one number that
+        # cannot be explained by WhatsApp Web's store still warming up, which
+        # is what lets a store that has gone missing be told apart from one
+        # that is merely cold. Never reset while the process lives; a chat
+        # count that was real once does not stop having been real.
+        self._chat_list_high_water = 0
+        # Consecutive sync rounds that found the store not answering, counted
+        # towards recreating the session. See _BROKEN_STORE_REPAIR_ROUNDS.
+        self._broken_store_rounds = 0
         self.contacts = {}
         # Presence cache: maps JID → {lastKnownPresence, lastSeen}. Must be
         # initialized here (not lazily in _build_lid_to_phone_cache, which only
@@ -8406,6 +8417,16 @@ class MainWindow(wx.Frame):
             # since none of those status calls are inside a try/finally and a
             # thread that dies mid-sync never reaches its own clear-status line.
             self._initial_sync_running = False
+            # Re-stamp on the way out, not only on the way in. The stamp made
+            # at the top of this method is what trigger_sync_if_needed()
+            # measures its cooldown from, so a round that takes longer than
+            # the cooldown has already exhausted it by the time it finishes —
+            # the backoff was structurally dead for exactly the large accounts
+            # it exists to protect. Measured on a 937-chat session: 17 seconds
+            # between the end of one full round and the start of the next,
+            # against a nominal 120 s. Keeping the entry stamp as well means a
+            # round that dies immediately still cannot spin.
+            self._last_sync_attempt_ts = time.time()
             wx.CallAfter(self._set_status, "")
 
     @staticmethod
@@ -8424,6 +8445,126 @@ class MainWindow(wx.Frame):
         if remaining >= confirm_attempts:
             return max_attempts
         return attempt + 1 + confirm_attempts
+
+    # ── WhatsApp Web's in-memory store going missing ────────────────────────
+    # list-chats is WPP.chat.list(), which is literally
+    # ChatStore.getModelsArray().slice() inside the page — so it answering
+    # with an empty list means the in-memory ChatStore is empty, not that the
+    # account is. Measured on a real 937-chat session: after the very first
+    # successful call (935 chats), *99 consecutive* list-chats attempts across
+    # four full sync rounds and 37 minutes answered HTTP 200 with `[]`, while
+    # get-messages on the same page kept returning up to 1000 messages per
+    # chat (3843 successful calls) — get-messages reads WhatsApp Web's
+    # IndexedDB via msgFindBefore(), never the in-memory stores. The page was
+    # healthy throughout: state MAIN (NORMAL), no navigation, no detached
+    # frame, no "WAPI is not defined". WPPConnect's own log named the same
+    # failure from the other side, verbatim: `TypeError: Cannot read
+    # properties of undefined (reading 'map')` out of getAllContacts, whose
+    # body is `WPP.whatsapp.ContactStore.map(...)` — that store was not empty
+    # but *undefined*.
+    #
+    # /history-sync-status reports storeCounts.chat from the IndexedDB side,
+    # and it said 937 on every single check in both captured sessions,
+    # including eight seconds before the app accepted 36 chats as a whole
+    # account. That number was already being fetched and logged and used for
+    # nothing; it is what tells "this account is empty" apart from "the store
+    # this call reads is broken", which no chat count on its own can do.
+    #
+    # A ratio rather than equality because list-chats legitimately answers
+    # with fewer chats than the store holds: the visibleChats filter drops
+    # activity-less one-to-one entries. Measured healthy ratios: 935/937 and
+    # 32/33. Half is far below anything a working page produces.
+    _STORE_PLAUSIBLE_RATIO = 0.5
+    # Consecutive implausible *and non-growing* answers before the store is
+    # declared broken. Both halves are load-bearing, and the growth half is
+    # the one that is easy to get wrong: evidence_count includes the local
+    # cache, so on a returning account every early answer of a genuinely cold
+    # store looks like a regression against it (931 cached vs. an answer of
+    # 0, then 100, then 400). Only a count that has stopped moving is
+    # evidence of anything. Three rather than two because a fresh pairing can
+    # legitimately sit at zero for a moment while the in-memory store hydrates
+    # behind the IndexedDB side that storeCounts reads.
+    _BROKEN_STORE_CONFIRM = 3
+    # Rounds that must detect a broken store before the session is recreated.
+    # One round backs off and re-checks; the second repairs. _restart_wpp_session()
+    # carries its own re-entrancy guard, its own 120 s cooldown and the
+    # _auto_restart_grace_active() window that keeps a restart from being
+    # mistaken for a phone-side unlink.
+    _BROKEN_STORE_REPAIR_ROUNDS = 2
+
+    @classmethod
+    def count_contradicts_page(cls, server_count: int,
+                               wa_web_count: "int | None") -> bool:
+        """True when list-chats answers with far fewer chats than WhatsApp Web
+        itself reports holding.
+
+        A ratio rather than equality because list-chats legitimately answers
+        with fewer chats than the store holds — the visibleChats filter drops
+        activity-less one-to-one entries. Measured healthy ratios on real
+        sessions: 935/937 and 32/33.
+
+        ``wa_web_count`` of None (no endpoint, no answer) or 0 (the page
+        agrees there is nothing) is never a contradiction: the first decides
+        nothing, and the second is the genuinely-empty account.
+        """
+        if wa_web_count is None or wa_web_count <= 0:
+            return False
+        return server_count < wa_web_count * cls._STORE_PLAUSIBLE_RATIO
+
+    @classmethod
+    def store_looks_broken(cls, server_count: int, wa_web_count: "int | None",
+                           evidence_count: int) -> bool:
+        """True when list-chats' answer contradicts the page's own store count.
+
+        ``evidence_count`` is the largest number of chats we have positive
+        evidence for — the biggest count this same round already saw, or the
+        size of the local cache. It is what keeps a store that is merely still
+        loading from being called broken: a loading store only ever grows, so
+        an answer below something we already had is a regression, and a
+        regression is not loading.
+
+        All three conditions have to hold, and each rules out a specific case
+        that must NOT be treated as broken:
+
+        * ``wa_web_count`` unknown (no endpoint, no answer) — decide nothing
+          and leave the existing heuristics in charge.
+        * The page itself reports no chats — then an empty list-chats agrees
+          with it. This is the genuinely-empty account, and also the account
+          whose conversations were all deleted from another device: the case
+          _settle_deadline_decision()'s docstring calls unresolvable is
+          resolved here, correctly, because both sources say zero.
+        * No evidence of content above the answer — a first pairing filling in
+          0 -> 4 -> 7 -> 11 never regresses, so it never lands here.
+        """
+        if evidence_count <= server_count:
+            return False
+        return cls.count_contradicts_page(server_count, wa_web_count)
+
+    def _wa_web_chat_count(self) -> "int | None":
+        """How many chats WhatsApp Web itself says it is holding, or None.
+
+        Reads storeCounts.chat from the same /history-sync-status payload
+        log_history_sync_status() already prints. Kept separate from
+        refresh_history_still_landing() because that one deliberately reads
+        only the two queue fields and discards the rest.
+
+        Short timeout on purpose: this is a corroborating probe inside the
+        retry loop, not the sync itself. The default 30 s would let a hung
+        endpoint add a minute and a half to a round that is already the slow
+        path, and an unanswered probe costs nothing — None simply leaves the
+        existing heuristics in charge.
+        """
+        status = self.fetch_history_sync_status(timeout=10)
+        if not isinstance(status, dict):
+            return None
+        counts = status.get("storeCounts")
+        if not isinstance(counts, dict):
+            return None
+        try:
+            count = int(counts.get("chat"))
+        except (TypeError, ValueError):
+            return None
+        return count if count >= 0 else None
 
     # Ceiling for the deadline extensions below. _CHAT_RETRIES (6) x
     # _CHAT_DELAY (5 s) gives the settle loop about 30 seconds, which is not
@@ -8591,6 +8732,20 @@ class MainWindow(wx.Frame):
         max_attempts = _CHAT_RETRIES
         saw_nonzero  = False
         attempt      = -1
+        # See store_looks_broken(): the largest chat count we have positive
+        # evidence for this round, and the largest count WhatsApp Web itself
+        # has claimed. Both only ever grow — a store that is loading does not
+        # shrink — so keeping the maximum rather than the latest reading is
+        # what makes a regression detectable at all.
+        wa_web_count    = None
+        broken_readings = 0
+        store_broken    = False
+        # The previous attempt's count, whatever it was — distinct from
+        # prev_server_count, which the settle rules only advance on the paths
+        # that reach the bottom of the loop. A count that is still growing is
+        # a store still loading, and must never be counted as broken however
+        # far below the page's own total it currently is.
+        last_count      = -1
         while True:
             attempt += 1
             if attempt >= max_attempts:
@@ -8599,7 +8754,18 @@ class MainWindow(wx.Frame):
                 logging.info("[start_sync] Aborting sync: offline mode activated mid-sync.")
                 self._sync_completed = False
                 return
-            result   = self.get_remote_chats(dict(self.chats), notify_errors=False)
+            # persist_full=False: the full clear-and-reimport writes every
+            # message of every chat, and running it once per attempt meant a
+            # 931-chat account rewrote its whole message store up to 30 times
+            # per round (measured at ~4 s a time, ~8 minutes of redundant
+            # writes across the captured session). Nothing needs it here —
+            # sync_chat_messages() persists each chat incrementally a few
+            # lines below, and the mute/pin/archive metadata this call learns
+            # is written by its own set_metadata_json() regardless of the
+            # flag. prune_stale keeps the one thing persist_full also gated,
+            # the phantom-chat sweep, which is a plain in-memory dict scan.
+            result   = self.get_remote_chats(dict(self.chats), persist_full=False,
+                                             prune_stale=True, notify_errors=False)
             if result is None:
                 if getattr(self, "_last_chat_fetch_disconnected", False):
                     # WhatsApp went down mid-sync: stop immediately, stay
@@ -8638,6 +8804,55 @@ class MainWindow(wx.Frame):
                 "[start_sync] list-chats attempt %d returned %d chats (previous: %d, local cache: %d)",
                 attempt + 1, server_count, prev_server_count, local_chat_count,
             )
+
+            # ── Is this answer even possible? ────────────────────────────
+            # Checked before any of the settle rules below, because every one
+            # of them takes the count at face value: a broken store answering
+            # 0 is read as "still arriving" and extended 30 times, and a
+            # broken store answering 36 against no local cache is *accepted*
+            # as the whole account. Both were captured live on the same
+            # 937-chat session. See store_looks_broken() for why the three
+            # conditions there are the ones that avoid false positives.
+            # Evidence is the high-water mark of what list-chats has itself
+            # answered *this session*, and deliberately NOT the local cache.
+            # The cache would make every early answer of a genuinely cold
+            # store look like a regression on a returning account (931 cached
+            # against 0, then 100, then 400) — the commonest startup shape
+            # there is, and one the code has a documented live capture of
+            # (attempts 1-5 -> 0, attempt 6 -> 498). A count this same session
+            # already produced cannot be explained by the store still warming
+            # up, which is what makes it evidence at all.
+            evidence_count = getattr(self, "_chat_list_high_water", 0)
+            if evidence_count > server_count:
+                # Re-read rather than caching one reading for the round: the
+                # count can still be filling in, and only a later, higher
+                # answer can turn a wrongly-innocent verdict into the right
+                # one. At most _BROKEN_STORE_CONFIRM + 1 calls per round,
+                # since a confirmed break exits the loop.
+                latest = self._wa_web_chat_count()
+                if latest is not None:
+                    wa_web_count = max(wa_web_count or 0, latest)
+            still_growing = server_count > last_count
+            last_count = server_count
+            if (not still_growing
+                    and self.store_looks_broken(server_count, wa_web_count, evidence_count)):
+                broken_readings += 1
+                logging.warning(
+                    "[start_sync] list-chats answered %d chat(s) while WhatsApp Web "
+                    "reports %s in its own store and we have evidence for %d "
+                    "(reading %d/%d) — the page's in-memory chat store looks broken, "
+                    "not cold.",
+                    server_count, wa_web_count, evidence_count,
+                    broken_readings, self._BROKEN_STORE_CONFIRM,
+                )
+                if broken_readings >= self._BROKEN_STORE_CONFIRM:
+                    store_broken = True
+                    break
+                time.sleep(_CHAT_DELAY)
+                continue
+            broken_readings = 0
+            self._chat_list_high_water = max(evidence_count, server_count)
+
             # First non-zero answer: make sure at least _CHAT_CONFIRM_ATTEMPTS
             # attempts remain so it can be confirmed by a second, equal one.
             # See _CHAT_CONFIRM_ATTEMPTS above for why the loop cannot be left
@@ -8682,6 +8897,32 @@ class MainWindow(wx.Frame):
                     time.sleep(_CHAT_DELAY)
                     continue
                 if decision == "accept":
+                    # Last check before a snapshot becomes "the whole account
+                    # for this session": does the page agree there is nothing
+                    # more? This is the failure that amputated a real account
+                    # — a first pairing with no cache to contradict it took
+                    # 36 chats as the complete list of 937 and never retried,
+                    # eight seconds before the same session logged
+                    # wa_web_chats=937. Only reachable once the full attempt
+                    # budget is spent (~2.5 minutes), so unlike the early
+                    # break above it cannot fire on a store that is merely
+                    # slow: one that has not filled in by now is not filling in.
+                    #
+                    # Deliberately count_contradicts_page() and not
+                    # store_looks_broken(): the regression evidence the latter
+                    # demands is what keeps the *early* break off a cold
+                    # store, and there is nothing left to be early about here.
+                    if wa_web_count is None:
+                        wa_web_count = self._wa_web_chat_count()
+                    if self.count_contradicts_page(server_count, wa_web_count):
+                        logging.error(
+                            "[start_sync] Refusing to accept %d chat(s) as the whole "
+                            "account: WhatsApp Web reports %s in its own store. Marking "
+                            "the store as not answering instead of syncing an amputated "
+                            "account.", server_count, wa_web_count,
+                        )
+                        store_broken = True
+                        break
                     logging.warning(
                         "[start_sync] Chat list never settled (last count: %d) but the extension "
                         "budget is spent — accepting this snapshot rather than declaring the sync "
@@ -8709,6 +8950,44 @@ class MainWindow(wx.Frame):
             logging.info("[start_sync] Aborting sync: WhatsApp is disconnected.")
             self._sync_completed = False
             return
+
+        if store_broken:
+            # Deliberately NOT settled and NOT accepted: this snapshot is
+            # known-wrong, so it must neither be announced as a finished sync
+            # nor be allowed to shrink the chat list. self.chats keeps
+            # whatever it already held — get_remote_chats() only merges, and
+            # its one pruning pass is keyed on JIDs present in the response,
+            # which is empty here.
+            self._broken_store_rounds = getattr(self, "_broken_store_rounds", 0) + 1
+            logging.error(
+                "[start_sync] WhatsApp Web's in-memory chat store is not answering "
+                "(round %d of %d before recreating the session). Messages are "
+                "unaffected — get-messages reads IndexedDB and keeps working — so "
+                "this sync continues with the chats already known locally.",
+                self._broken_store_rounds, self._BROKEN_STORE_REPAIR_ROUNDS,
+            )
+            if self._broken_store_rounds >= self._BROKEN_STORE_REPAIR_ROUNDS:
+                self._broken_store_rounds = 0
+                # Nothing short of rebuilding the page recovers a store in
+                # this state: it stayed broken for 37 minutes and four full
+                # sync rounds in the captured session, and no amount of
+                # re-asking changed it. Stop here rather than running the
+                # message and media phases into a session about to be torn
+                # down; the health checker starts a fresh sync once the new
+                # session is up.
+                logging.error(
+                    "[start_sync] Recreating the WPPConnect session to rebuild the "
+                    "store — this restores the existing WhatsApp session from its "
+                    "saved token, it does not ask for a new QR code."
+                )
+                self._sync_completed = False
+                self._sync_retry_count = getattr(self, "_sync_retry_count", 0) + 1
+                threading.Thread(target=self._restart_wpp_session, daemon=True).start()
+                return
+        else:
+            # A plausible answer clears the tally: only *consecutive* rounds
+            # count towards recreating the session.
+            self._broken_store_rounds = 0
         if not chat_list_ok:
             # Report once, after every attempt is exhausted, instead of one
             # modal dialog per attempt interrupting the screen reader.
@@ -9243,7 +9522,8 @@ class MainWindow(wx.Frame):
         parts = ser.split("_") if ser else []
         return parts[1] if len(parts) > 1 else ""
 
-    def get_remote_chats(self, chats, persist_full: bool = True, notify_errors: bool = True):
+    def get_remote_chats(self, chats, persist_full: bool = True, notify_errors: bool = True,
+                         prune_stale: "bool | None" = None):
         """Fetch/merge the remote chat list into `chats`.
 
         Returns the merged dict on success and **None** when every attempt
@@ -9264,7 +9544,17 @@ class MainWindow(wx.Frame):
         refresh, which otherwise re-clears and re-encrypts the *entire*
         chats+contacts DB every few minutes just to notice a pin/mute
         change on one chat).
+
+        `prune_stale` controls the retroactive phantom-chat sweep, which used
+        to ride along on `persist_full` for no reason other than both being
+        "right after a real sync" work. They have completely different costs —
+        the sweep is an in-memory dict scan, the save rewrites every message
+        in the database — so the initial sync's retry loop needs the first
+        without paying for the second. Defaults to `persist_full`, preserving
+        the previous behaviour for every caller that does not pass it.
         """
+        if prune_stale is None:
+            prune_stale = persist_full
         # Use the modern `list-chats` endpoint (WPP.chat.list) instead of the
         # deprecated `all-chats` (legacy WAPI.getAllChats). The legacy call omits
         # some chats — notably muted or pinned groups — so those never got
@@ -9790,9 +10080,9 @@ class MainWindow(wx.Frame):
                 # local cache before this filter existed: no local messages,
                 # no server-reported activity, and not deliberately pinned or
                 # muted by the user. Only worth the full-dict scan right after
-                # a real sync (persist_full=True) — the periodic background
+                # a real sync (prune_stale) — the periodic background
                 # refresh just wants pin/mute state, so skip it there.
-                if persist_full:
+                if prune_stale:
                     response_jids = {
                         self._normalize_jid(c.get("remoteJid", ""))
                         for c in response_data if isinstance(c, dict)

--- a/tests/test_chat_list_settled.py
+++ b/tests/test_chat_list_settled.py
@@ -56,12 +56,18 @@ class TestAttemptBudget:
             assert needed(attempt, 6, CONFIRM) >= 6
 
 
-def _run_loop(counts, local_cache, retries=6, confirm=CONFIRM):
+def _run_loop(counts, local_cache, retries=6, confirm=CONFIRM, wa_web=None,
+              high_water=0):
     """Faithful replica of _run_sync()'s list-chats retry loop.
 
     Only the settle decision is reproduced — the HTTP call, the failure/
     disconnect branches and the sleeps are not what these tests are about.
-    Returns (chat_list_settled, number_of_fetches_performed).
+
+    ``wa_web`` is what /history-sync-status reports in storeCounts.chat;
+    None means the endpoint answered nothing, which is the shape every test
+    written before that probe existed runs in.
+
+    Returns (chat_list_settled, number_of_fetches_performed, store_broken).
     """
     has_local_chats = local_cache > 0
     prev_server_count = -1
@@ -70,12 +76,31 @@ def _run_loop(counts, local_cache, retries=6, confirm=CONFIRM):
     max_attempts = retries
     attempt = -1
     fetches = 0
+    wa_web_count = None
+    broken_readings = 0
+    store_broken = False
+    last_count = -1
     while True:
         attempt += 1
         if attempt >= max_attempts:
             break
         server_count = counts[min(attempt, len(counts) - 1)]
         fetches += 1
+        evidence_count = high_water
+        if evidence_count > server_count and wa_web is not None:
+            wa_web_count = max(wa_web_count or 0, wa_web)
+        still_growing = server_count > last_count
+        last_count = server_count
+        if (not still_growing
+                and MainWindow.store_looks_broken(
+                    server_count, wa_web_count, evidence_count)):
+            broken_readings += 1
+            if broken_readings >= MainWindow._BROKEN_STORE_CONFIRM:
+                store_broken = True
+                break
+            continue
+        broken_readings = 0
+        high_water = max(evidence_count, server_count)
         if server_count > 0 and not saw_nonzero:
             saw_nonzero = True
             max_attempts = needed(attempt, max_attempts, confirm)
@@ -93,25 +118,30 @@ def _run_loop(counts, local_cache, retries=6, confirm=CONFIRM):
                 prev_server_count = server_count
                 continue
             if decision == "accept":
+                if wa_web is not None:
+                    wa_web_count = max(wa_web_count or 0, wa_web)
+                if MainWindow.count_contradicts_page(server_count, wa_web_count):
+                    store_broken = True
+                    break
                 settled_flag = True
             break
         prev_server_count = server_count
-    return settled_flag, fetches
+    return settled_flag, fetches, store_broken
 
 
 class TestSettleDecision:
     def test_cold_store_that_fills_in_on_the_last_attempt(self):
         """The regression: this is the real log, and it must settle."""
-        settled, _ = _run_loop([0, 0, 0, 0, 0, 498, 498], local_cache=0)
+        settled, _, _ = _run_loop([0, 0, 0, 0, 0, 498, 498], local_cache=0)
         assert settled is True
 
     def test_reconnection_with_a_warm_local_cache_settles_immediately(self):
-        settled, fetches = _run_loop([498], local_cache=498)
+        settled, fetches, _ = _run_loop([498], local_cache=498)
         assert settled is True
         assert fetches == 1
 
     def test_small_account_settling_early_still_works(self):
-        settled, fetches = _run_loop([4, 4, 4, 4, 4, 4], local_cache=0)
+        settled, fetches, _ = _run_loop([4, 4, 4, 4, 4, 4], local_cache=0)
         assert settled is True
         assert fetches == 2
 
@@ -125,25 +155,25 @@ class TestSettleDecision:
 
         The old guarantee ("still growing is never settled") now lives at the
         deadline only, keyed on size — see TestDeadlineDecision."""
-        settled, _ = _run_loop([4, 7, 11, 16, 22, 29, 37, 46], local_cache=0)
+        settled, _, _ = _run_loop([4, 7, 11, 16, 22, 29, 37, 46], local_cache=0)
         assert settled is True
 
     def test_a_late_starting_store_that_keeps_growing_also_settles(self):
         """Same change seen from the cold-store shape: nothing for the first
         attempts, then a list that is still arriving when the original budget
         would have expired."""
-        settled, _ = _run_loop([0, 0, 0, 0, 4, 7, 11, 15], local_cache=0)
+        settled, _, _ = _run_loop([0, 0, 0, 0, 4, 7, 11, 15], local_cache=0)
         assert settled is True
 
     def test_late_start_that_does_stabilise_settles(self):
-        settled, _ = _run_loop([0, 0, 0, 0, 4, 7, 7, 7], local_cache=0)
+        settled, _, _ = _run_loop([0, 0, 0, 0, 4, 7, 7, 7], local_cache=0)
         assert settled is True
 
     def test_a_server_stuck_on_zero_with_chats_cached_stays_unsettled(self):
         """We already hold 500 chats; the server insisting on 0 has not
         finished loading its store. Stored chats do not vanish, so this must
         stay incomplete and be retried rather than be taken at face value."""
-        settled, _ = _run_loop([0] * 40, local_cache=500)
+        settled, _, _ = _run_loop([0] * 40, local_cache=500)
         assert settled is False
 
     def test_an_account_that_really_is_empty_eventually_settles(self):
@@ -151,13 +181,13 @@ class TestSettleDecision:
         of a number with no conversations. Waiting longer cannot distinguish
         it from a cold store, so once the ceiling is reached the 0 is taken at
         face value; the alternative is re-syncing a brand-new number for ever."""
-        settled, _ = _run_loop([0] * 40, local_cache=0)
+        settled, _, _ = _run_loop([0] * 40, local_cache=0)
         assert settled is True
 
     def test_the_empty_account_is_not_accepted_before_the_ceiling(self):
         """It settles only after the full budget has been spent waiting — a
         store that is merely slow still gets every chance to fill in first."""
-        _, fetches = _run_loop([0] * 40, local_cache=0)
+        _, fetches, _ = _run_loop([0] * 40, local_cache=0)
         assert fetches == MainWindow._CHAT_ABSOLUTE_MAX_ATTEMPTS
 
     @pytest.mark.parametrize("counts", [
@@ -167,7 +197,7 @@ class TestSettleDecision:
     ])
     def test_extension_is_granted_at_most_once(self, counts):
         """saw_nonzero latches, so the budget cannot grow unboundedly."""
-        _, fetches = _run_loop(counts, local_cache=0)
+        _, fetches, _ = _run_loop(counts, local_cache=0)
         assert fetches <= 6 + CONFIRM
 
 
@@ -299,21 +329,21 @@ class TestTheLoopEndToEnd:
         6-attempt budget expires. It must not come out unsettled — that is
         what made the sync restart itself later."""
         counts = [0, 40, 90, 150, 220, 300, 380, 460, 540, 600, 640, 660, 660]
-        settled, _ = _run_loop(counts, local_cache=0)
+        settled, _, _ = _run_loop(counts, local_cache=0)
         assert settled is True
 
     def test_a_large_account_that_never_stops_growing_is_still_accepted(self):
         """Even with no two equal counts anywhere, a big snapshot beats an
         endless re-sync loop."""
         counts = [i * 40 for i in range(1, 40)]
-        settled, _ = _run_loop(counts, local_cache=0)
+        settled, _, _ = _run_loop(counts, local_cache=0)
         assert settled is True
 
     def test_the_extension_is_bounded(self):
         """It buys time, it does not hang: the loop cannot run past the
         ceiling however long the list keeps growing."""
         counts = [i * 40 for i in range(1, 60)]
-        _, fetches = _run_loop(counts, local_cache=0)
+        _, fetches, _ = _run_loop(counts, local_cache=0)
         assert fetches <= MainWindow._CHAT_ABSOLUTE_MAX_ATTEMPTS
 
 
@@ -336,13 +366,13 @@ class TestSmallAccountsAreNotLockedOut:
         ([0, 0, 0, 0, 0, 1, 1], "one conversation, arriving late"),
     ])
     def test_a_small_account_still_settles(self, counts, label):
-        settled, _ = _run_loop(counts, local_cache=0)
+        settled, _, _ = _run_loop(counts, local_cache=0)
         assert settled is True, label
 
     def test_a_small_account_never_reaches_the_size_check(self):
         """Two attempts, not the full budget — proof the deadline branch (the
         only place size is looked at) is not involved."""
-        _, fetches = _run_loop([3, 3, 3, 3, 3, 3], local_cache=0)
+        _, fetches, _ = _run_loop([3, 3, 3, 3, 3, 3], local_cache=0)
         assert fetches == 2
 
     def test_nothing_cached_means_the_deadline_never_says_incomplete(self):
@@ -359,3 +389,220 @@ class TestSmallAccountsAreNotLockedOut:
         }
         assert outcomes <= {"extend", "accept"}
         assert MainWindow._settle_deadline_decision(4, 4, ceiling, 0) == "accept"
+
+
+class TestStoreLooksBroken:
+    """list-chats answering with a chat count that contradicts WhatsApp Web's
+    own store count.
+
+    Confirmed live on a 937-chat account, in two captured sessions. list-chats
+    is WPP.chat.list(), i.e. ChatStore.getModelsArray().slice() inside the
+    page, so an empty answer means the in-memory store is empty — not the
+    account. The same session's get-messages kept returning up to 1000
+    messages per chat, because that path reads IndexedDB instead, and
+    /history-sync-status reported storeCounts.chat = 937 on every check.
+
+    Every settle rule below this takes the count at face value, and both of
+    its readings of a broken store are wrong in opposite directions: with a
+    local cache it says "incomplete" and re-runs the whole sync for ever;
+    without one it *accepts* the broken snapshot as the entire account (the
+    second session was declared synced with 36 of 937 conversations).
+    """
+
+    broken = staticmethod(MainWindow.store_looks_broken)
+
+    def test_the_captured_resync_loop(self):
+        """Session one: 931 chats cached, list-chats answering 0, page holding 937."""
+        assert self.broken(0, 937, 931) is True
+
+    def test_the_captured_amputated_account(self):
+        """Session two: no cache, 36 chats seen once, then 0 against 937."""
+        assert self.broken(0, 937, 36) is True
+
+    def test_an_answer_far_below_the_page_is_broken_even_when_non_zero(self):
+        assert self.broken(36, 937, 300) is True
+
+    # ── The three ways a suspicious-looking count is NOT a broken store ──
+
+    def test_no_store_count_decides_nothing(self):
+        """Older client/api/ builds have no such route. Without corroboration
+        the existing heuristics must stay in charge, not be overridden by a
+        guess."""
+        assert self.broken(0, None, 931) is False
+
+    def test_a_page_reporting_no_chats_agrees_with_an_empty_answer(self):
+        """Both sources say zero. This is the genuinely empty account — and
+        also the account whose conversations were all deleted from another
+        device, which _settle_deadline_decision()'s docstring calls
+        indistinguishable from a cold store. Two sources distinguish it."""
+        assert self.broken(0, 0, 931) is False
+
+    def test_a_loading_store_never_regresses_so_it_is_never_broken(self):
+        """A first pairing filling in 0 -> 4 -> 7 -> 11: each answer is the
+        largest seen so far, so evidence never exceeds it."""
+        for seen, count in ((0, 0), (0, 4), (4, 7), (7, 11)):
+            assert self.broken(count, 937, seen) is False
+
+    def test_an_answer_matching_the_page_is_healthy(self):
+        """The measured healthy ratios, from the two real sessions."""
+        assert self.broken(935, 937, 931) is False
+        assert self.broken(32, 33, 33) is False
+
+    def test_the_ratio_boundary(self):
+        ratio = MainWindow._STORE_PLAUSIBLE_RATIO
+        assert self.broken(int(1000 * ratio), 1000, 1000) is False
+        assert self.broken(int(1000 * ratio) - 1, 1000, 1000) is True
+
+
+class TestBrokenStoreInTheLoop:
+    """The same thing seen through the retry loop: what the loop now does
+    instead of extending 30 times or accepting a broken snapshot."""
+
+    def test_the_resync_loop_stops_instead_of_extending_thirty_times(self):
+        """Session one, round two. The first round of that session answered
+        935, which is the high-water mark round two inherits — that is the
+        evidence, not the local cache. The old loop spent 30 attempts on
+        0 -> 0 (~6 minutes) because _settle_deadline_decision() reads 0 as
+        "still arriving", then declared the sync incomplete and had the health
+        checker start it over: four full rounds in the captured 37 minutes."""
+        settled, fetches, broken = _run_loop(
+            [0] * 40, local_cache=931, wa_web=937, high_water=935)
+        assert broken is True
+        assert settled is False
+        # The first reading is a growth from "nothing seen yet" and so is
+        # never counted; the confirmations follow it.
+        assert fetches <= MainWindow._BROKEN_STORE_CONFIRM + 1
+
+    def test_the_amputated_account_is_not_accepted(self):
+        """Session two, exactly as logged: 0, then 36, then 0 for ever. The
+        old loop ran out its budget and *accepted* — marking the sync complete
+        with 36 of 937 conversations and never retrying."""
+        settled, _, broken = _run_loop([0, 36] + [0] * 40, local_cache=0, wa_web=937)
+        assert broken is True
+        assert settled is False
+
+    def test_a_confirmed_break_needs_more_than_one_reading(self):
+        """A single dip is not proof. The reading after it is what decides,
+        and a store that recovers settles normally."""
+        settled, _, broken = _run_loop([500, 0, 500, 500], local_cache=0, wa_web=937)
+        assert broken is False
+        assert settled is True
+
+    # ── Nothing that worked before may change ───────────────────────────
+
+    def test_a_cold_store_filling_in_late_still_settles(self):
+        settled, _, broken = _run_loop([0, 0, 0, 0, 0, 498, 498], local_cache=0, wa_web=937)
+        assert broken is False
+        assert settled is True
+
+    def test_a_genuinely_empty_account_still_settles(self):
+        """Page and list-chats agree on zero, so no break is declared and the
+        deadline still accepts it."""
+        settled, _, broken = _run_loop([0] * 40, local_cache=0, wa_web=0)
+        assert broken is False
+        assert settled is True
+
+    def test_a_reconnection_with_a_warm_cache_still_settles_on_the_first_call(self):
+        settled, fetches, broken = _run_loop([498], local_cache=498, wa_web=500)
+        assert broken is False
+        assert settled is True
+        assert fetches == 1
+
+    def test_chats_deleted_from_another_device_are_not_called_broken(self):
+        """The user really did delete everything elsewhere: the page reports
+        zero too, so this settles as an empty account instead of looping."""
+        settled, _, broken = _run_loop([0] * 40, local_cache=660, wa_web=0)
+        assert broken is False
+
+
+class TestAColdStoreIsNotABrokenStore:
+    """The false positive the growth check exists to stop.
+
+    evidence_count includes the local cache, so on a returning account every
+    early answer of a genuinely cold store reads as a regression against it —
+    931 cached against an answer of 0, then 100, then 400, each one well under
+    half of what the page reports. Without the growth check those are two
+    consecutive "broken" readings and the session gets recreated for nothing,
+    in the single commonest startup shape there is.
+    """
+
+    def test_a_cold_store_filling_in_under_a_large_cache(self):
+        settled, _, broken = _run_loop(
+            [0, 100, 400, 900, 931, 931], local_cache=931, wa_web=937)
+        assert broken is False, "a store that is still filling in was called broken"
+        assert settled is True
+
+    def test_a_slow_cold_store_that_only_starts_late(self):
+        settled, _, broken = _run_loop(
+            [0, 0, 0, 0, 498, 498], local_cache=931, wa_web=937)
+        assert broken is False
+
+    def test_a_fresh_pairing_hydrating_behind_indexeddb(self):
+        """storeCounts reads the IndexedDB side, which can be ahead of the
+        in-memory store on a first pairing. A brief zero before the list
+        appears must not be mistaken for the store being gone."""
+        settled, _, broken = _run_loop(
+            [0, 36, 300, 937, 937], local_cache=0, wa_web=937)
+        assert broken is False
+        assert settled is True
+
+    def test_a_stalled_store_is_still_caught(self):
+        """The guard is about growth, not about being generous: a count that
+        stops moving below what the page reports is still the broken store."""
+        settled, _, broken = _run_loop(
+            [0] * 40, local_cache=931, wa_web=937, high_water=935)
+        assert broken is True
+        assert settled is False
+
+
+class TestEvidenceIsTheSessionHighWaterMarkNotTheCache:
+    """Which number counts as "we know there are chats" decides everything
+    about false positives, and the local cache is the wrong one.
+
+    The cache is always there on a returning account, so using it made every
+    early answer of a cold store a regression — including the shape the code
+    has a live capture of (attempts 1-5 -> 0, attempt 6 -> 498). What cannot
+    be explained by a store still warming up is a count *this same session*
+    already produced. That is why the mark lives on the instance and survives
+    across rounds: session one answered 935 in its first round and 0 in every
+    round after.
+    """
+
+    def test_the_documented_cold_store_is_untouched_even_with_a_full_cache(self):
+        settled, _, broken = _run_loop(
+            [0, 0, 0, 0, 0, 498, 498], local_cache=931, wa_web=937, high_water=0)
+        assert broken is False
+        assert settled is True
+
+    def test_a_first_round_that_never_answers_falls_back_to_the_old_rule(self):
+        """Nothing has been seen this session, so a zero is not yet provably
+        a regression. With chats cached the deadline still says incomplete —
+        exactly what happened before any of this existed."""
+        settled, _, broken = _run_loop(
+            [0] * 40, local_cache=931, wa_web=937, high_water=0)
+        assert broken is False
+        assert settled is False
+
+    def test_the_amputation_veto_does_not_need_a_prior_answer(self):
+        """The fresh-install failure: no cache, nothing seen this session, so
+        the early break cannot fire — and the deadline would have *accepted*
+        zero as an empty account. The veto is what stops it, and it only
+        needs the page's own count."""
+        settled, _, broken = _run_loop(
+            [0] * 40, local_cache=0, wa_web=937, high_water=0)
+        assert broken is True
+        assert settled is False
+
+    def test_a_genuinely_empty_account_still_settles_at_the_deadline(self):
+        """The veto reads the page, and the page agrees there is nothing."""
+        settled, _, broken = _run_loop(
+            [0] * 40, local_cache=0, wa_web=0, high_water=0)
+        assert broken is False
+        assert settled is True
+
+    def test_with_no_page_count_the_veto_cannot_fire(self):
+        """Older client/api/ builds have no /history-sync-status route."""
+        settled, _, broken = _run_loop(
+            [0] * 40, local_cache=0, wa_web=None, high_water=0)
+        assert broken is False
+        assert settled is True

--- a/tests/test_get_remote_chats_persistence.py
+++ b/tests/test_get_remote_chats_persistence.py
@@ -1,0 +1,201 @@
+"""Tests for what get_remote_chats() writes, and what it sweeps.
+
+`persist_full` used to gate two things that have nothing to do with each
+other: the full clear-and-reimport save, which rewrites every message of
+every chat, and the retroactive phantom-chat sweep, which is a plain
+in-memory dict scan. The initial sync's retry loop needs the second and
+cannot afford the first.
+
+Measured on a 937-chat session: the loop called this with the save enabled up
+to 30 times per round at roughly 4 s each, about 8 minutes of redundant
+writes across the capture, for data that sync_chat_messages() then persists
+incrementally chat by chat anyway. Splitting them is what makes the loop
+cheap without losing the sweep.
+
+MainWindow is a wx.Frame, so the method is bound to a stub carrying only the
+attributes it reads — the same pattern the other main.py tests use.
+"""
+
+import json
+import types
+
+import pytest
+
+import main
+from main import MainWindow
+
+
+class _Response:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _DB:
+    def __init__(self):
+        self.metadata = {}
+
+    def set_metadata_json(self, key, value):
+        self.metadata[key] = value
+
+
+class _Stub:
+    """Minimum surface get_remote_chats() actually reads on the happy path."""
+
+    def __init__(self, chats=None):
+        self.wpp_server = "http://127.0.0.1"
+        self.wpp_port = 6300
+        self.token = "tok"
+        self.chats = chats or {}
+        self.contacts = {}
+        self.settings = {"cleared_chats": {}}
+        self.db = _DB()
+        self._deleted_chats = set()
+        self._muted_chats = {}
+        self._pinned_chats = set()
+        self._archived_chats = set()
+        self._lid_to_phone = {}
+        self._phone_to_lid = {}
+        self._group_name_cache = {}
+        self._locally_read_at = {}
+        self.conversations_panel = None
+        self.save_data_calls = 0
+        self.schedule_save_calls = 0
+
+    # ── collaborators ────────────────────────────────────────────────
+    def save_data(self, chats, contacts):
+        self.save_data_calls += 1
+
+    def _schedule_save(self, *a, **kw):
+        self.schedule_save_calls += 1
+
+    def _check_wa_connection_closed(self, response):
+        return False
+
+    def _fill_group_name(self, jid):
+        return ""
+
+    def _group_name_from_chat_dict(self, chat):
+        return (chat.get("groupMetadata") or {}).get("subject", "") or chat.get("name", "")
+
+    def _persist_locally_read_at(self):
+        pass
+
+
+def _make(chats=None):
+    stub = _Stub(chats)
+    for name in ("get_remote_chats", "_normalize_jid", "_lift_contact_identity",
+                 "_last_received_jid"):
+        # Read from __dict__, not getattr: accessing a staticmethod through
+        # the class hands back the plain function, so `isinstance(...,
+        # staticmethod)` is always False there and every one of them would be
+        # re-bound as an instance method and receive `self` as its first
+        # argument.
+        raw = MainWindow.__dict__[name]
+        if isinstance(raw, staticmethod):
+            setattr(stub, name, raw.__func__)
+        else:
+            setattr(stub, name, types.MethodType(raw, stub))
+    return stub
+
+
+def _chat(jid, **extra):
+    payload = {"id": {"_serialized": jid}, "t": 1700000000, "unreadCount": 0}
+    payload.update(extra)
+    return payload
+
+
+@pytest.fixture
+def post(monkeypatch):
+    """Patch the one HTTP call, and hand back a slot for the payload."""
+    box = {"payload": []}
+
+    def _post(url, json=None, headers=None, timeout=None):
+        return _Response(box["payload"])
+
+    monkeypatch.setattr(main.requests, "post", _post)
+    return box
+
+
+class TestTheFullSaveIsOptional:
+    def test_persist_full_false_does_not_rewrite_the_database(self, post):
+        post["payload"] = [_chat("5511900000001@c.us")]
+        stub = _make()
+        result = stub.get_remote_chats({}, persist_full=False, notify_errors=False)
+        assert result is not None
+        assert stub.save_data_calls == 0
+        assert stub.schedule_save_calls == 1
+
+    def test_persist_full_true_still_rewrites(self, post):
+        post["payload"] = [_chat("5511900000001@c.us")]
+        stub = _make()
+        stub.get_remote_chats({}, persist_full=True, notify_errors=False)
+        assert stub.save_data_calls == 1
+
+    def test_the_chat_list_is_still_merged_either_way(self, post):
+        post["payload"] = [_chat("5511900000001@c.us"), _chat("5511900000002@c.us")]
+        stub = _make()
+        result = stub.get_remote_chats({}, persist_full=False, notify_errors=False)
+        assert set(result) == {"5511900000001@s.whatsapp.net",
+                               "5511900000002@s.whatsapp.net"}
+
+    def test_mute_and_pin_metadata_is_written_regardless_of_the_flag(self, post):
+        """The settle loop learns these from the same response, and they are
+        written by their own set_metadata_json() — dropping the full save must
+        not drop them."""
+        post["payload"] = [_chat("5511900000001@c.us", muteExpiration=-1)]
+        stub = _make()
+        stub.get_remote_chats({}, persist_full=False, notify_errors=False)
+        assert "muted_chats" in stub.db.metadata
+        assert stub._muted_chats
+
+
+class TestTheSweepIsIndependentOfTheSave:
+    """A phantom one-to-one entry — in the cache, echoed by the server, with
+    no messages and no activity — is what the sweep exists to remove."""
+
+    def _phantom_cache(self):
+        return {
+            "5511900000009@s.whatsapp.net": {
+                "remoteJid": "5511900000009@s.whatsapp.net",
+                "messages": {"messages": {"records": []}},
+                "t": 0,
+                "unreadCount": 0,
+            }
+        }
+
+    def test_the_sweep_runs_without_the_full_save(self, post):
+        """The combination the settle loop now uses."""
+        post["payload"] = [{"id": {"_serialized": "5511900000009@c.us"},
+                            "t": 0, "unreadCount": 0}]
+        stub = _make()
+        result = stub.get_remote_chats(self._phantom_cache(), persist_full=False,
+                                       prune_stale=True, notify_errors=False)
+        assert "5511900000009@s.whatsapp.net" not in result
+        assert stub.save_data_calls == 0
+
+    def test_prune_stale_defaults_to_persist_full(self, post):
+        """Every caller that does not pass the new flag keeps its old
+        behaviour exactly — that is the whole point of the default."""
+        post["payload"] = [{"id": {"_serialized": "5511900000009@c.us"},
+                            "t": 0, "unreadCount": 0}]
+
+        swept = _make().get_remote_chats(self._phantom_cache(), persist_full=True,
+                                         notify_errors=False)
+        assert "5511900000009@s.whatsapp.net" not in swept
+
+        kept = _make().get_remote_chats(self._phantom_cache(), persist_full=False,
+                                        notify_errors=False)
+        assert "5511900000009@s.whatsapp.net" in kept
+
+    def test_a_chat_with_activity_is_never_swept(self, post):
+        post["payload"] = [_chat("5511900000009@c.us")]
+        cache = self._phantom_cache()
+        cache["5511900000009@s.whatsapp.net"]["t"] = 1700000000
+        result = _make().get_remote_chats(cache, persist_full=False,
+                                          prune_stale=True, notify_errors=False)
+        assert "5511900000009@s.whatsapp.net" in result

--- a/tests/test_run_sync_broken_store.py
+++ b/tests/test_run_sync_broken_store.py
@@ -1,0 +1,246 @@
+"""Tests that drive the real _run_sync() retry loop, not a replica of it.
+
+tests/test_chat_list_settled.py keeps a hand-written copy of this loop so the
+settle *decisions* can be exercised as pure functions. That copy has drifted
+from the real loop before — the whole suite stayed green over a branch it
+covered nothing of — and by construction it can never cover the wiring: which
+number is passed as evidence, whether the growth guard is consulted, whether
+the deadline veto is called at all. Those live only in _run_sync().
+
+So these bind _run_sync() itself to a stub and let it run, with every
+collaborator past the chat-list fetch reduced to a no-op. What is asserted is
+only what the loop decides: how many times it asked, whether the sync was
+marked complete, and whether the session was recreated.
+
+MainWindow is a wx.Frame and cannot be instantiated without a running wx.App,
+so the method is bound to a plain object — the same pattern the other main.py
+tests use.
+"""
+
+import types
+
+import pytest
+
+import main
+from main import MainWindow
+
+
+class _Sound:
+    def play(self):
+        pass
+
+
+class _I18n:
+    def t(self, key, *a, **kw):
+        return key
+
+
+class _Stub:
+    """Everything _run_sync() touches, reduced to the smallest thing that
+    still lets the real loop run."""
+
+    def __init__(self, counts, wa_web, local_chats, high_water=0):
+        self._counts = list(counts)
+        self._wa_web = wa_web
+        self.chats = {
+            f"55119{i:08d}@s.whatsapp.net": {"remoteJid": f"55119{i:08d}@s.whatsapp.net"}
+            for i in range(local_chats)
+        }
+        self._chat_list_high_water = high_water
+        self._broken_store_rounds = 0
+
+        self._wa_connected = True
+        self.offline_mode = False
+        self.background_mode = True
+        self._sync_completed = False
+        self._sync_retry_count = 0
+        self._initial_sync_running = True
+        self.settings = {"storage": {"auto_download_media": False},
+                         "user_interface": {}}
+        self.i18n = _I18n()
+        self.synchronizing_sound = _Sound()
+        self.sync_complete_sound = _Sound()
+        self.error_sound = _Sound()
+        self._last_chat_fetch_count = 0
+        self._last_chat_fetch_disconnected = False
+        self._last_chat_fetch_error = None
+        self._chats_awaiting_messages = set()
+        self._lid_to_phone = {}
+        self._history_still_landing = False
+
+        # what the test inspects
+        self.fetches = 0
+        self.settle_fetches = 0
+        self.full_saves_in_settle_loop = 0
+        self.wa_web_probes = 0
+        self.restarted = False
+        self.message_sync_ran = 0
+
+    # ── the two calls the loop actually makes ────────────────────────
+    def get_remote_chats(self, chats, persist_full=True, notify_errors=True,
+                         prune_stale=None):
+        # prune_stale=True is what the settle loop passes and nothing else
+        # does, which is how the two callers inside _run_sync() are told
+        # apart — the loop, and the single refresh after the message phase.
+        # Counting the loop's calls separately also pins the reason that
+        # keyword exists: the loop must get the phantom sweep *without* the
+        # full clear-and-reimport save, which it used to run once per attempt.
+        if prune_stale:
+            self.settle_fetches += 1
+            if persist_full:
+                self.full_saves_in_settle_loop += 1
+        idx = min(self.fetches, len(self._counts) - 1)
+        self.fetches += 1
+        self._last_chat_fetch_count = self._counts[idx]
+        return dict(chats)
+
+    def _wa_web_chat_count(self):
+        self.wa_web_probes += 1
+        return self._wa_web
+
+    def _restart_wpp_session(self):
+        self.restarted = True
+
+    def sync_remote_chats(self):
+        self.message_sync_ran += 1
+
+    # ── collaborators whose return value the loop uses ───────────────
+    def normalize_chats(self, chats):
+        return chats
+
+    def deduplicate_chats(self, chats):
+        return chats
+
+    def refresh_history_still_landing(self, context=""):
+        return False
+
+    def sync_media_for_all_chats(self):
+        return 0
+
+    # ── everything else downstream: no-ops ───────────────────────────
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return lambda *a, **kw: None
+
+
+def _make(counts, wa_web, local_chats=0, high_water=0):
+    stub = _Stub(counts, wa_web, local_chats, high_water)
+    for name in ("_run_sync", "_should_abort_sync_for_offline",
+                 "_announce_sync_events_enabled", "count_contradicts_page",
+                 "store_looks_broken", "_attempts_needed_to_confirm",
+                 "_settle_deadline_decision", "history_page_target"):
+        raw = MainWindow.__dict__[name]
+        if isinstance(raw, (staticmethod, classmethod)):
+            setattr(stub, name, getattr(MainWindow, name))
+        else:
+            setattr(stub, name, types.MethodType(raw, stub))
+    for const in ("_CHAT_ABSOLUTE_MAX_ATTEMPTS", "_CHAT_ATTEMPT_EXTENSION",
+                  "_STORE_PLAUSIBLE_RATIO", "_BROKEN_STORE_CONFIRM",
+                  "_BROKEN_STORE_REPAIR_ROUNDS", "_DEEP_SYNC_TOP_N",
+                  "_DEEP_SYNC_COUNT"):
+        setattr(stub, const, getattr(MainWindow, const))
+    return stub
+
+
+@pytest.fixture(autouse=True)
+def _fast(monkeypatch):
+    """The loop sleeps 5 s between attempts and wx is not running here."""
+    monkeypatch.setattr(main.time, "sleep", lambda *_a: None)
+    monkeypatch.setattr(main.wx, "CallAfter", lambda fn, *a, **kw: None)
+    monkeypatch.setattr(main.threading, "Thread",
+                        lambda target=None, **kw: types.SimpleNamespace(
+                            start=lambda: target and target(), is_alive=lambda: False))
+
+
+class TestTheCapturedSessions:
+    def test_the_resync_loop_stops_early_instead_of_extending_to_thirty(self):
+        """Session one, round two: 931 cached, 935 seen in round one, the page
+        still reporting 937, and list-chats answering 0 for ever. The old loop
+        spent all 30 attempts here."""
+        stub = _make([0] * 60, wa_web=937, local_chats=931, high_water=935)
+        stub._run_sync()
+        assert stub.restarted is False           # first round only backs off
+        assert stub._broken_store_rounds == 1
+        assert stub._sync_completed is False
+        assert stub.settle_fetches <= MainWindow._BROKEN_STORE_CONFIRM + 1
+        assert stub.full_saves_in_settle_loop == 0
+
+    def test_the_second_such_round_recreates_the_session(self):
+        stub = _make([0] * 60, wa_web=937, local_chats=931, high_water=935)
+        stub._broken_store_rounds = MainWindow._BROKEN_STORE_REPAIR_ROUNDS - 1
+        stub._run_sync()
+        assert stub.restarted is True
+        assert stub._sync_completed is False
+        assert stub.message_sync_ran == 0, "ran the message phase into a dying session"
+
+    def test_the_amputated_account_is_refused(self):
+        """Session two: fresh install, no cache, 36 seen once, then 0. The old
+        loop accepted it and marked the sync complete with 36 of 937."""
+        stub = _make([0, 36] + [0] * 60, wa_web=937, local_chats=0)
+        stub._run_sync()
+        assert stub._sync_completed is False
+        assert stub._broken_store_rounds == 1
+
+
+class TestTheGrowthGuard:
+    """A cold store filling in must never be called broken. evidence_count
+    comes from the session high-water mark and the growth guard covers the
+    ramp inside a round; remove either and this is the shape that breaks."""
+
+    def test_a_cold_store_under_a_large_cache_still_settles(self):
+        stub = _make([0, 100, 400, 900, 931, 931], wa_web=937, local_chats=931)
+        stub._run_sync()
+        assert stub.restarted is False
+        assert stub._broken_store_rounds == 0
+        assert stub._sync_completed is True
+        assert stub.message_sync_ran == 1
+
+    def test_the_documented_late_filling_store_still_settles(self):
+        """The shape the code has a live capture of: nothing for five
+        attempts, then the whole list."""
+        stub = _make([0, 0, 0, 0, 0, 498, 498], wa_web=937, local_chats=931)
+        stub._run_sync()
+        assert stub.restarted is False
+        assert stub._sync_completed is True
+
+    def test_a_reconnection_with_a_warm_cache_settles_on_the_first_answer(self):
+        stub = _make([931], wa_web=937, local_chats=931)
+        stub._run_sync()
+        assert stub.settle_fetches == 1
+        assert stub._sync_completed is True
+
+
+class TestTheDeadlineVeto:
+    def test_zero_is_not_accepted_as_an_empty_account_when_the_page_disagrees(self):
+        """No cache and nothing seen this session, so the early break cannot
+        fire — the deadline would have accepted. Only the veto stops it."""
+        stub = _make([0] * 60, wa_web=937, local_chats=0)
+        stub._run_sync()
+        assert stub._sync_completed is False
+        assert stub._broken_store_rounds == 1
+
+    def test_a_genuinely_empty_account_is_still_accepted(self):
+        """Page and list-chats agree on zero."""
+        stub = _make([0] * 60, wa_web=0, local_chats=0)
+        stub._run_sync()
+        assert stub._sync_completed is False  # no chats to sync
+        assert stub._broken_store_rounds == 0
+        assert stub.restarted is False
+
+    def test_without_the_status_endpoint_nothing_new_fires(self):
+        """Older client/api/ builds answer nothing; behaviour is unchanged."""
+        stub = _make([0] * 60, wa_web=None, local_chats=931, high_water=935)
+        stub._run_sync()
+        assert stub.restarted is False
+        assert stub._broken_store_rounds == 0
+        assert stub.settle_fetches == MainWindow._CHAT_ABSOLUTE_MAX_ATTEMPTS
+
+
+class TestTheProbeIsNotChatty:
+    def test_a_healthy_sync_never_asks_the_page_for_its_count(self):
+        """The probe is only worth making when something already looks wrong;
+        a normal sync must not pay for it."""
+        stub = _make([931, 931], wa_web=937, local_chats=931)
+        stub._run_sync()
+        assert stub.wa_web_probes == 0

--- a/tests/test_sync_retry_cooldown.py
+++ b/tests/test_sync_retry_cooldown.py
@@ -1,0 +1,157 @@
+"""Tests for the gap trigger_sync_if_needed() actually enforces between two
+sync rounds.
+
+The backoff was structurally dead for exactly the accounts it exists to
+protect. start_sync() stamped _last_sync_attempt_ts on the way *in*, and
+trigger_sync_if_needed() measures its cooldown from that stamp — so a round
+lasting longer than the cooldown had already exhausted it before it finished,
+and the health checker (every 30 s) could start the next round immediately.
+
+Measured on a 937-chat session: four full sync rounds in 37 minutes, with 17
+seconds between the end of one and the start of the next, against a nominal
+120 s cooldown. Stamping again on the way out is what makes the cooldown mean
+"since the last round ended".
+
+MainWindow is a wx.Frame and cannot be instantiated without a running wx.App,
+so the methods under test are bound to a plain stub carrying only the
+attributes they touch — the same pattern the other main.py tests use.
+"""
+
+import threading
+import time
+import types
+
+import pytest
+
+import main
+from main import MainWindow
+
+
+class _Stub:
+    """Minimum surface start_sync()/trigger_sync_if_needed() actually read."""
+
+    def __init__(self, run_duration=0.0):
+        self._ui_ready_event = threading.Event()
+        self._ui_ready_event.set()
+        self._initial_sync_running = False
+        self._sync_completed = False
+        self._sync_ever_started = False
+        self._sync_run_id = 0
+        self._sync_retry_count = 0
+        self._last_sync_attempt_ts = 0.0
+        self._wa_connected = True
+        self.sync_thread = None
+        self._sync_start_lock = threading.Lock()
+        self._run_duration = run_duration
+        self.ran = 0
+        self.status_calls = []
+
+    def _set_status(self, text):
+        self.status_calls.append(text)
+
+    def _run_sync(self):
+        self.ran += 1
+        if self._run_duration:
+            time.sleep(self._run_duration)
+
+
+def _bind(stub, *names):
+    for name in names:
+        setattr(stub, name, types.MethodType(getattr(MainWindow, name), stub))
+    for name in ("_SYNC_RETRY_COOLDOWN",):
+        setattr(stub, name, getattr(MainWindow, name))
+
+
+@pytest.fixture
+def stub(monkeypatch):
+    # wx.CallAfter is the only wx touched here, and only to clear the status
+    # text; run it inline so no event loop is required.
+    monkeypatch.setattr(main.wx, "CallAfter",
+                        lambda fn, *a, **kw: fn(*a, **kw))
+    s = _Stub()
+    _bind(s, "start_sync", "trigger_sync_if_needed", "_try_start_sync_thread")
+    return s
+
+
+class TestTheStampIsMadeOnTheWayOut:
+    def test_a_finished_round_stamps_the_time_it_ended(self, stub):
+        stub._run_duration = 0.2
+        before = time.time()
+        stub.start_sync()
+        # The entry stamp would be <= `before + epsilon`; the exit stamp
+        # cannot be earlier than when _run_sync() returned.
+        assert stub._last_sync_attempt_ts >= before + 0.2
+
+    def test_a_round_that_raises_still_stamps(self, stub):
+        """The stamp lives in the finally block for the same reason the
+        running flag does: a round that dies mid-way must not leave the next
+        one free to start instantly."""
+        def _boom():
+            stub.ran += 1
+            raise RuntimeError("sync exploded")
+        stub._run_sync = _boom
+        before = time.time()
+        stub.start_sync()
+        assert stub.ran == 1
+        assert stub._last_sync_attempt_ts >= before
+
+    def test_the_entry_stamp_is_kept_as_well(self, stub):
+        """A round that returns immediately (no connection, for instance) is
+        still covered — the entry stamp is what stops it spinning."""
+        stub._run_sync = lambda: None
+        before = time.time()
+        stub.start_sync()
+        assert stub._last_sync_attempt_ts >= before
+
+
+class TestTheCooldownIsHonouredAfterALongRound:
+    def test_the_captured_failure_no_longer_reproduces(self, stub):
+        """The measured shape, scaled down: a round that outlasts its own
+        cooldown, then the health checker arriving the moment it ends.
+
+        The round has to genuinely take longer than the cooldown for this to
+        exercise anything — that is the whole bug. With the entry stamp alone,
+        the cooldown measured from a moment already in the past and had
+        expired before the round even finished. Real durations rather than a
+        patched clock, because start_sync() stamps the entry itself and there
+        is nothing to preset."""
+        stub._SYNC_RETRY_COOLDOWN = 0.1
+        stub._run_duration = 0.3        # 3 x the cooldown, like 4 min vs 120 s
+        stub.start_sync()
+        stub._sync_completed = False
+        stub._sync_retry_count = 1
+
+        stub.ran = 0
+        stub.trigger_sync_if_needed()
+        thread = stub.sync_thread
+        if thread is not None:
+            thread.join(timeout=5)
+        assert stub.ran == 0, "a new round started right after the last one ended"
+
+    def test_a_round_is_allowed_once_the_cooldown_has_really_elapsed(self, stub):
+        stub.start_sync()
+        stub._sync_completed = False
+        stub._sync_retry_count = 1
+        stub._last_sync_attempt_ts = (
+            time.time() - MainWindow._SYNC_RETRY_COOLDOWN - 1
+        )
+        stub.ran = 0
+        stub.trigger_sync_if_needed()
+        # trigger_sync_if_needed() starts a thread; wait for it to run.
+        thread = stub.sync_thread
+        if thread is not None:
+            thread.join(timeout=5)
+        assert stub.ran == 1
+
+    def test_a_completed_sync_is_never_restarted(self, stub):
+        stub._sync_completed = True
+        stub.ran = 0
+        stub.trigger_sync_if_needed()
+        assert stub.ran == 0
+
+    def test_nothing_starts_while_disconnected(self, stub):
+        stub._wa_connected = False
+        stub._last_sync_attempt_ts = 0
+        stub.ran = 0
+        stub.trigger_sync_if_needed()
+        assert stub.ran == 0


### PR DESCRIPTION
## O que os logs provam

Dois logs de campo da mesma conta de **937 conversas**. Os dois sintomas relatados são **o mesmo bug**, com desfechos opostos dependendo só de haver cache local.

O `list-chats` não demora nem falha — responde **200 com lista vazia, em segundos**, enquanto o `get-messages` na mesma página devolve até 1000 mensagens por conversa.

| sinal | valor |
|---|---|
| tentativas de `list-chats` na sessão | 100 |
| …que devolveram conversas | **1** (a primeira, 935) |
| …que devolveram `0` | **99**, ao longo de 4 rodadas e 37 min |
| `get-messages` no mesmo período | 3.843, funcionando |
| `wa_web_chats` (`/history-sync-status`) | **937**, em toda checagem |
| timeouts de banco | **0** |
| estado da página | `MAIN (NORMAL)` o tempo todo |

`WPP.chat.list()` é `ChatStore.getModelsArray().slice()` dentro da página, então lista vazia = store em memória vazio, não conta vazia. O log do WPPConnect nomeia a mesma falha pelo outro lado, literalmente:

```
TypeError: Cannot read properties of undefined (reading 'map')
    at getAllContacts (...\dist\controller\deviceController.js:2994:15)
```

`WAPI.getAllContacts` é `WPP.whatsapp.ContactStore.map(...)` — esse store não estava vazio, estava **`undefined`**. O `get-messages` sobrevive porque vai por `msgFindBefore()`, que consulta o IndexedDB.

**Com cache local (931):** `incomplete` → 4 rodadas completas em 37 min.
**Sem cache local (instalação nova):** tentativa 2 devolveu 36, o resto 0 → `accept` → sync **declarado concluído com 36 de 937**, sem nova tentativa.

## ⚠️ O que este PR NÃO corrige

**A causa raiz é da página / wa-js e continua lá.** Este PR corrige o WinZapp *acreditar* na resposta e amplificá-la.

O conserto ativo (recriar a sessão) é a única recuperação disponível, e **não foi validado contra a falha real** — eu nunca reproduzi o store quebrado ao vivo, só tenho os logs. **É exatamente isso que o teste ao vivo precisa responder.** Ver "Como testar".

## As mudanças

1. **Detecção** — cruza `list-chats` com `storeCounts.chat` do `/history-sync-status`, número que já era buscado e logado e não decidia nada (reportou 937 inclusive 8 s antes do app aceitar 36). Duas defesas com gatilhos diferentes de propósito:
   - **Quebra rápida** (`store_looks_broken`): exige regressão contra a marca-d'água da sessão + contradição da página + contagem parada. Sai em ~4 tentativas, não 30.
   - **Veto no prazo** (`count_contradicts_page`): só a contradição, e só depois do orçamento inteiro (~2,5 min). É o que cobre a instalação nova, onde não há resposta anterior para servir de evidência.

2. **Conserto ativo** — duas rodadas consecutivas recriam a sessão via `_restart_wpp_session()`, que já existia com todas as guardas mas só era alcançável por `_dead_browser_strikes` — que nunca conta aqui, porque a página *está* viva.

3. **`persist_full=False` no laço** — o save completo reescreve toda mensagem de toda conversa e rodava uma vez por tentativa (~4 s cada, ~8 min de escrita redundante na sessão capturada). `prune_stale` vira parâmetro próprio (default = `persist_full`, sem mudança para nenhum chamador existente).

4. **Cooldown carimbado na saída da rodada** — era só na entrada, então uma rodada mais longa que o cooldown já o tinha esgotado ao terminar. Medido: 17 s entre rodadas, contra 120 s nominais.

### A armadilha que evitei

Minha primeira versão usava `local_chat_count` como evidência. Isso marcaria como quebrado **todo store frio num usuário que já tem conversas** (931 em cache contra 0 → 100 → 400) — a forma de partida mais comum que existe, e da qual o código tem captura documentada (`[0,0,0,0,0,498]`). Por isso a evidência é a marca-d'água da sessão e existe a guarda de crescimento. `TestTheGrowthGuard` cobre exatamente isso.

## Testes

**2522 passando.** `tests/test_run_sync_broken_store.py` roda o `_run_sync` **real**, não uma réplica — foi escrito depois de descobrir que os testes na réplica de `test_chat_list_settled.py` não cobriam duas das três defesas (sabotar o código deixava a suíte verde, a mesma armadilha que 7da08f8 documenta).

Conferido sabotando cada defesa em separado:

| sabotagem | testes que caem |
|---|---|
| detector desligado | 8 |
| guarda de crescimento removida | 2 |
| veto de amputação removido | 1 |
| `persist_full=True` de volta | 1 |
| escalonamento removido | 1 |

Sem dano colateral em nenhuma.

## Como testar ao vivo

Precisa de uma conta grande. O que olhar no `log.log`:

```
grep -E "list-chats attempt|looks broken|Refusing to accept|Recreating the WPPConnect|Sync incomplete|history-sync\]" log.log
```

- **Caminho feliz:** nada de novo aparece, e `wa_web_probes` não é pago (a sonda só roda quando algo já parece errado).
- **Se o store quebrar de novo:** deve aparecer `list-chats answered 0 chat(s) while WhatsApp Web reports 937` em vez de 30 tentativas silenciosas, e depois `Recreating the WPPConnect session`.
- **A pergunta em aberto:** *depois* do restart, o `list-chats` volta a responder? Se voltar, o bug está resolvido de ponta a ponta. Se não voltar, a detecção e o backoff seguem valendo (para de amputar conta e de rodar em laço), mas o conserto precisa de outra abordagem — provavelmente reinjeção do wa-js.

## Escopo

Não toca em recebimento de mensagens. O `_sync_completed = False` no reconnect do Socket.IO (`websocket_client.py:189`) é o gatilho da rodada extra, mas existe para recuperar mensagens perdidas no intervalo do socket — ficou intocado, e o carimbo de cooldown na saída já contém a tempestade que ele causava.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWZCJFmXULHDzRZM3Q6Ekt
