### PR TITLE
fix: leitura de conversa no celular não zerava o badge no WinZapp

### DIFF
--- a/client/api_patches/src/util/createSessionUtil.ts
+++ b/client/api_patches/src/util/createSessionUtil.ts
@@ -791,6 +791,16 @@ export default class CreateSessionUtil {
    * `WPP.on` lives on the page and is re-injected fresh on every WhatsApp
    * Web reload, same as the msgKey._serialized shim above — re-install on
    * 'load' too, or the first reload silently drops this listener.
+   *
+   * The install itself polls (same setInterval pattern as the
+   * MsgKey._serialized/status-sender shims above), instead of trusting the
+   * single attempt the first version of this patch made: wireListeners()
+   * runs before isConnected() is confirmed, so window.WPP routinely isn't
+   * injected yet at that point, and WhatsApp Web's SPA never fires a second
+   * 'load' once connected — so a failed first try used to mean the listener
+   * never existed for the rest of the session. Measured live: zero
+   * chats-update events for unreadCount over 24+ minutes of active message
+   * traffic with the single-attempt version.
    */
   async onUnreadCountChanged(client: WhatsAppServer, req: Request) {
     try {
@@ -812,70 +822,88 @@ export default class CreateSessionUtil {
     const installListener = () => {
       client.page
         .evaluate(() => {
-          const WPP = (window as any).WPP;
-          if (
-            !WPP ||
-            !WPP.on ||
-            (window as any).__winzappUnreadListenerInstalled
-          ) {
-            return;
-          }
-          (window as any).__winzappUnreadListenerInstalled = true;
-          WPP.on('chat.unread_count_changed', (evt: any) => {
-            try {
-            const chatId = evt?.chat?.id?._serialized || evt?.chat?.id;
-            if (!chatId) return;
-            // The count this chat held BEFORE the change, forwarded so the
-            // client can tell a real read apart from a meaningless zero.
-            // A chat merely being loaded into the Store reports unreadCount=0
-            // with nothing behind it, and is indistinguishable from "the user
-            // just read this chat on their phone" unless you know whether the
-            // count actually fell from something.
-            //
-            // Measured against a live session: the field really is a plain
-            // number, matching wa-js's own typing. Three consecutive messages
-            // in one group came through as unreadCount 1/2/3 with
-            // previousUnreadCount 0/1/2 — tracking exactly one step behind.
-            // The suspicion it might be Backbone's options object (wa-js
-            // emits it straight from the Store's `change:unreadCount`
-            // callback, whose third argument is options in every other
-            // handler of that shape) did not hold. The `.previous()` fallback
-            // stays anyway: it costs nothing, and it is what keeps this
-            // working if a future wa-js changes the payload — silently, since
-            // nothing else here would notice. Neither being a number sends
-            // null, and the client then keeps its own conservative count.
-            // Deriving `previous` must never be able to suppress the event
-            // itself: the unread count is the payload that matters and the
-            // previous value is an extra, so it is computed defensively and
-            // the emit happens regardless. Reading `.previous` off a Store
-            // model is a property access on foreign, minified code that can
-            // throw or be a getter with side effects, and a throw anywhere in
-            // this callback silently takes the whole listener down — the
-            // client then stops being told about unread counts at all, with
-            // nothing in any log to say so. Measured, not hypothetical: an
-            // earlier version of this block computed `previous` inline and
-            // the chats-update stream stopped dead.
-            let previous: any = null;
-            try {
-              const raw = evt?.previousUnreadCount;
-              if (typeof raw === 'number') {
-                previous = raw;
-              } else if (typeof evt?.chat?.previous === 'function') {
-                const p = evt.chat.previous('unreadCount');
-                previous = typeof p === 'number' ? p : null;
+          const install = () => {
+            const WPP = (window as any).WPP;
+            if (!WPP || !WPP.on) return false;
+            if ((window as any).__winzappUnreadListenerInstalled) return true;
+            (window as any).__winzappUnreadListenerInstalled = true;
+            WPP.on('chat.unread_count_changed', (evt: any) => {
+              try {
+              const chatId = evt?.chat?.id?._serialized || evt?.chat?.id;
+              if (!chatId) return;
+              // The count this chat held BEFORE the change, forwarded so the
+              // client can tell a real read apart from a meaningless zero.
+              // A chat merely being loaded into the Store reports unreadCount=0
+              // with nothing behind it, and is indistinguishable from "the user
+              // just read this chat on their phone" unless you know whether the
+              // count actually fell from something.
+              //
+              // Measured against a live session: the field really is a plain
+              // number, matching wa-js's own typing. Three consecutive messages
+              // in one group came through as unreadCount 1/2/3 with
+              // previousUnreadCount 0/1/2 — tracking exactly one step behind.
+              // The suspicion it might be Backbone's options object (wa-js
+              // emits it straight from the Store's `change:unreadCount`
+              // callback, whose third argument is options in every other
+              // handler of that shape) did not hold. The `.previous()` fallback
+              // stays anyway: it costs nothing, and it is what keeps this
+              // working if a future wa-js changes the payload — silently, since
+              // nothing else here would notice. Neither being a number sends
+              // null, and the client then keeps its own conservative count.
+              // Deriving `previous` must never be able to suppress the event
+              // itself: the unread count is the payload that matters and the
+              // previous value is an extra, so it is computed defensively and
+              // the emit happens regardless. Reading `.previous` off a Store
+              // model is a property access on foreign, minified code that can
+              // throw or be a getter with side effects, and a throw anywhere in
+              // this callback silently takes the whole listener down — the
+              // client then stops being told about unread counts at all, with
+              // nothing in any log to say so. Measured, not hypothetical: an
+              // earlier version of this block computed `previous` inline and
+              // the chats-update stream stopped dead.
+              let previous: any = null;
+              try {
+                const raw = evt?.previousUnreadCount;
+                if (typeof raw === 'number') {
+                  previous = raw;
+                } else if (typeof evt?.chat?.previous === 'function') {
+                  const p = evt.chat.previous('unreadCount');
+                  previous = typeof p === 'number' ? p : null;
+                }
+              } catch (e) {
+                previous = null;
               }
-            } catch (e) {
-              previous = null;
-            }
-            (window as any).__winzappOnUnreadChanged(chatId, evt.unreadCount, previous);
-            } catch (e) {
-              // Anything unexpected in here costs at most this one event.
-              // Never the listener: WhatsApp Web's own objects are foreign
-              // and minified, and losing this stream means unread counts
-              // silently stop updating everywhere in the app.
-            }
-          });
+              (window as any).__winzappOnUnreadChanged(chatId, evt.unreadCount, previous);
+              } catch (e) {
+                // Anything unexpected in here costs at most this one event.
+                // Never the listener: WhatsApp Web's own objects are foreign
+                // and minified, and losing this stream means unread counts
+                // silently stop updating everywhere in the app.
+              }
+            });
+            return true;
+          };
+          if (install()) return 'installed';
+          // wa-js is injected into the page asynchronously after each
+          // (re)connect — the same reason the MsgKey._serialized and status
+          // sender shims above poll instead of trusting a single attempt.
+          // wireListeners() (which calls this) runs BEFORE isConnected() is
+          // even confirmed, so window.WPP routinely does not exist yet on
+          // this first try. Without retrying, the listener was simply never
+          // installed for the rest of the session — WhatsApp Web's SPA never
+          // fires another 'load' once connected, so the page-reload reinstall
+          // below never got a chance to run either. Measured live: zero
+          // chats-update events for unreadCount over 24+ minutes of active
+          // message traffic in one session.
+          let tries = 0;
+          const timer = setInterval(() => {
+            if (install() || ++tries > 60) clearInterval(timer);
+          }, 500);
+          return 'scheduled (wa-js not ready yet)';
         })
+        .then((result: string) =>
+          req.logger.info(`[${client.session}] onUnreadCountChanged listener: ${result}`)
+        )
         .catch((e: any) =>
           req.logger.warn(
             `[onUnreadCountChanged] install failed: ${e?.message || e}`

--- a/client/api_patches/src/util/createSessionUtil.ts
+++ b/client/api_patches/src/util/createSessionUtil.ts
@@ -822,11 +822,22 @@ export default class CreateSessionUtil {
     const installListener = () => {
       client.page
         .evaluate(() => {
+          // Everything in here is wrapped, and the "installed" flag is only
+          // set once WPP.on() has actually returned: `WPP.on` is foreign,
+          // minified code that can throw even once the `!WPP.on` guard has
+          // passed (wa-js present, emitter not bootstrapped). Marking the
+          // context as installed first would leave it permanently claiming a
+          // listener it never registered, and letting the throw escape is
+          // worse still — on the first attempt it rejects the whole evaluate
+          // so the retry below is never even scheduled, and from inside the
+          // retry it skips clearInterval(), leaving a timer firing every 500ms
+          // for the life of the page. Same shape as restoreStatusSender above,
+          // for the same reason.
           const install = () => {
+            try {
             const WPP = (window as any).WPP;
             if (!WPP || !WPP.on) return false;
             if ((window as any).__winzappUnreadListenerInstalled) return true;
-            (window as any).__winzappUnreadListenerInstalled = true;
             WPP.on('chat.unread_count_changed', (evt: any) => {
               try {
               const chatId = evt?.chat?.id?._serialized || evt?.chat?.id;
@@ -881,23 +892,37 @@ export default class CreateSessionUtil {
                 // silently stop updating everywhere in the app.
               }
             });
+            (window as any).__winzappUnreadListenerInstalled = true;
             return true;
+            } catch (e) {
+              return false;
+            }
           };
           if (install()) return 'installed';
-          // wa-js is injected into the page asynchronously after each
-          // (re)connect — the same reason the MsgKey._serialized and status
-          // sender shims above poll instead of trusting a single attempt.
-          // wireListeners() (which calls this) runs BEFORE isConnected() is
-          // even confirmed, so window.WPP routinely does not exist yet on
-          // this first try. Without retrying, the listener was simply never
-          // installed for the rest of the session — WhatsApp Web's SPA never
-          // fires another 'load' once connected, so the page-reload reinstall
-          // below never got a chance to run either. Measured live: zero
-          // chats-update events for unreadCount over 24+ minutes of active
-          // message traffic in one session.
+          // wa-js is injected asynchronously, so the first try above usually
+          // finds no window.WPP at all — poll instead of giving up, exactly
+          // like the MsgKey._serialized and status sender shims. See this
+          // method's own doc comment for why a single attempt was never
+          // enough here.
           let tries = 0;
           const timer = setInterval(() => {
-            if (install() || ++tries > 60) clearInterval(timer);
+            if (install() || ++tries > 60) {
+              clearInterval(timer);
+              // The evaluate below can only ever log 'scheduled' — it returns
+              // long before this loop resolves — so without this line the log
+              // cannot tell "installed three seconds later" apart from "gave
+              // up after 30s and this session will never see an unread event",
+              // which is exactly the blind spot that let the single-attempt
+              // version go unnoticed for 24 minutes. The page console is
+              // already bridged into log.log for anything tagged
+              // '[browser-evaluate]' (see the page.on('console') handler where
+              // the client is created).
+              console.log(
+                (window as any).__winzappUnreadListenerInstalled
+                  ? `[browser-evaluate] onUnreadCountChanged listener: installed after ${tries} retries`
+                  : '[browser-evaluate] onUnreadCountChanged listener: GAVE UP after 60 retries — wa-js never appeared, unread counts will not update'
+              );
+            }
           }, 500);
           return 'scheduled (wa-js not ready yet)';
         })

--- a/client/main.py
+++ b/client/main.py
@@ -15175,6 +15175,19 @@ class MainWindow(wx.Frame):
             return
         old_count = int(chat.get("unreadCount") or 0)
         if old_count == unread_count:
+            # Logged like every other exit. This one used to be silent, and it
+            # is the one that makes a report impossible to diagnose: the event
+            # shows up in the socket log and then the trail simply stops, with
+            # no way to tell "the badge already agreed with the server" apart
+            # from "the handler never ran at all" (a stalled UI thread, a chat
+            # that failed to resolve). Seen live: a stretch of a session where
+            # every chats-update reached websocket_client's own log and then
+            # produced nothing at all here — this exit is the only one that
+            # could have swallowed them, but nothing written down proved it.
+            logging.info(
+                "[unread] %s: no change (already %s, previous=%s).",
+                normalized, unread_count, previous_unread,
+            )
             return  # no actual change — skip expensive rebuild + save
         # The server sometimes counts own (fromMe) messages — and system events
         # (group promotes, joins/leaves, revokes) — as unread. Correct for both
@@ -15189,6 +15202,11 @@ class MainWindow(wx.Frame):
                 unread_count = _discount_non_countable_unread(records, unread_count)
         old_count = int(chat.get("unreadCount") or 0)
         if old_count == unread_count:
+            logging.info(
+                "[unread] %s: no change after discounting non-countable "
+                "messages (already %s, previous=%s).",
+                normalized, unread_count, previous_unread,
+            )
             return
         # Never resurrect unread count for a conversation the user already read
         # locally (mark_conversation_as_read set it to 0). The server may still
@@ -15292,7 +15310,26 @@ class MainWindow(wx.Frame):
                 # chat.unread_count_changed does exactly that), and with
                 # local_new set the old elif could never be reached at all.
                 local_new = getattr(self, "_new_since_read", {}).get(normalized)
-                if unread_count == 0 and old_count > 0:
+                if unread_count == 0 and _remote_read:
+                    # A read confirmed on another device — the count really
+                    # fell from something (see _remote_read_confirmed) — covers
+                    # the WHOLE chat, including the messages that arrived after
+                    # our local read-ack. That is exactly what separates it
+                    # from the uninformative WA-JS load-time zero the branch
+                    # below defends against, and it has to be checked first or
+                    # the defense swallows the real read.
+                    #
+                    # Reported live: an audio arrived after the conversation
+                    # had been read locally, was then read on the phone, and
+                    # the badge stayed lit at "1 mensagem não lida" — WhatsApp
+                    # Web sent unreadCount=0/previousUnreadCount=1 and this
+                    # branch put the 1 straight back. The other two branches
+                    # (open conversation, and the `unread_count < old_count`
+                    # guard above) already consult _remote_read; this one was
+                    # simply missed, which is why the bug showed up in 1:1
+                    # chats while groups looked fixed.
+                    unread_count = 0
+                elif unread_count == 0 and old_count > 0:
                     unread_count = local_new or old_count
                 elif local_new:
                     unread_count = min(unread_count, local_new)

--- a/tests/test_unread_reread_race.py
+++ b/tests/test_unread_reread_race.py
@@ -279,3 +279,57 @@ class TestOpenConversationSurvivesSpuriousServerZeros:
         stub.on_chat_unread_update(JID, 0)
 
         assert stub.chats[JID]["unreadCount"] == 0
+
+
+class TestReadOnAnotherDeviceAfterALocalRead:
+    """Reported live: a 1:1 chat read locally, then a new audio arrives, then
+    the user reads it on the phone — WinZapp kept showing "1 mensagem não
+    lida" for it.
+
+    WhatsApp Web reports that read as unreadCount=0 with previousUnreadCount=1,
+    which _remote_read_confirmed() recognizes as a genuine read elsewhere. But
+    the read-ack branch (chat["t"] newer than _locally_read_at) restored the
+    badge from _new_since_read without ever consulting it, treating the
+    confirmed read exactly like the uninformative zero WA-JS emits when it
+    loads a chat into the Store. Groups looked fine because they take the
+    `unread_count < old_count` guard, which already checked _remote_read.
+    """
+
+    def test_a_confirmed_remote_read_clears_a_message_newer_than_the_read_ack(self):
+        chat = _chat(t=2000)
+        chat["unreadCount"] = 1
+        stub = _Stub(chat)
+        stub._locally_read_at[JID] = 1000  # read here first...
+        stub._new_since_read[JID] = 1      # ...then one new message arrived
+
+        # ...and then the phone read it: 1 -> 0.
+        stub.on_chat_unread_update(JID, 0, 1)
+
+        assert stub.chats[JID]["unreadCount"] == 0
+
+    def test_an_uninformative_zero_still_keeps_the_badge(self):
+        """The protection this branch exists for is untouched: a zero with no
+        previous count behind it (WA-JS loading the chat into the Store) must
+        still leave what arrived after the read-ack counted."""
+        chat = _chat(t=2000)
+        chat["unreadCount"] = 1
+        stub = _Stub(chat)
+        stub._locally_read_at[JID] = 1000
+        stub._new_since_read[JID] = 1
+
+        stub.on_chat_unread_update(JID, 0, None)
+
+        assert stub.chats[JID]["unreadCount"] == 1
+
+    def test_a_zero_whose_previous_was_also_zero_keeps_the_badge(self):
+        """previousUnreadCount=0 is the load-time signature, not a read: the
+        count did not fall from anything."""
+        chat = _chat(t=2000)
+        chat["unreadCount"] = 3
+        stub = _Stub(chat)
+        stub._locally_read_at[JID] = 1000
+        stub._new_since_read[JID] = 3
+
+        stub.on_chat_unread_update(JID, 0, 0)
+
+        assert stub.chats[JID]["unreadCount"] == 3


### PR DESCRIPTION
## Contexto

Não-lidas que eram lidas no celular continuavam acesas no WinZapp. A branch ataca isso em duas frentes: o listener do lado da API que emite o evento, e a lógica do cliente que decide o que fazer com ele.

## O que mudou

**API (`client/api_patches/src/util/createSessionUtil.ts`)**

O `chat.unread_count_changed` passa a ser instalado com polling (500 ms × 60, mesmo padrão dos shims `MsgKey._serialized` e do status sender) em vez de uma única tentativa. `wireListeners()` roda antes de `isConnected()` ser confirmado, e a SPA do WhatsApp Web nunca dispara um segundo `load` depois de conectada — então uma primeira tentativa falha significava listener inexistente pelo resto da sessão.

Sobre o commit de revisão que veio depois:

- `install()` inteiro dentro de `try/catch`, com a flag `__winzappUnreadListenerInstalled` marcada só depois que `WPP.on(...)` retornou. Um throw vindo do wa-js rejeitava o `evaluate` inteiro na primeira tentativa (matando o agendamento do retry) e, dentro do retry, pulava o `clearInterval()` — deixando um timer disparando a cada 500 ms pelo resto da vida da página.
- O fim do polling agora loga, via a ponte `[browser-evaluate]` já existente: `installed after N retries` ou `GAVE UP after 60 retries`. Antes só existia a linha `scheduled`, e não dava para distinguir "instalou 3 s depois" de "desistiu aos 30 s".

**Cliente (`client/main.py`)**

Uma leitura confirmada em outro aparelho (`unreadCount=0` com `previousUnreadCount>0`) voltava a acender o badge em conversas 1:1. O ramo do read-ack local restaurava o contador em cima de qualquer zero do servidor sem consultar `_remote_read`, tratando a leitura real como o zero sem informação que o WA-JS emite ao carregar o chat no Store. Grupos não mostravam o problema porque a guarda deles já checava `_remote_read`.

Os dois únicos exits mudos de `on_chat_unread_update` também passaram a logar — eram o motivo de o evento sumir do log sem dizer o que tinha acontecido com ele.

## Testes

`2477 passed, 2 skipped`. Três casos novos em `tests/test_unread_reread_race.py`; o principal foi verificado falhando sem o fix (`assert 1 == 0`, exatamente o sintoma relatado) e passando com ele. Os outros dois travam a proteção original: zero sem `previous` e zero com `previous=0` continuam preservando o badge.

## Verificação em sessão real

Sessão pareada, dois runs (reconexão quente e start frio com o Node morto):

- listener instalado nos dois — `onUnreadCountChanged listener: installed`;
- 26+ eventos `chats-update` chegando com `previousUnreadCount` coerente, incluindo leituras remotas (`unread=0 previous=1`);
- `tsc` + Babel compilam, `dist/` regenerado, `api_patches/` e `api/src/` em sincronia (sem drift para o `build.py` detectar).

**Ressalva honesta:** nos dois runs o listener instalou na *primeira* tentativa, então o caminho de polling — o núcleo da mudança na API — não chegou a ser exercitado em sessão real. Ele é defensivo e idêntico ao padrão dos shims vizinhos, mas a afirmação de que o `window.WPP` "routinely" não está pronto nesse ponto não se sustenta com o que foi medido aqui. É plausível que o sintoma original (24 min sem eventos) fosse na verdade o bug do lado cliente corrigido neste PR.
