### PR TITLE
perf+feat: sinc leve, e puxando o histórico inteiro até acabar

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -7605,6 +7605,16 @@ class MainWindow(wx.Frame):
         # what WPPConnect's /blocklist endpoint returns (see get_block_list()).
         self._blocked_contacts = set(self.db.get_metadata_json("blocked_contacts", []))
 
+        # 6b. exhausted_chats — conversations WhatsApp Web has no older history
+        # for. It used to live only in memory (fetch_older_messages() even says
+        # "in-memory" in its own log line), which was fine while the only
+        # consumer was a user scrolling up in one conversation: worst case it
+        # asked once more per session. The deep backfill walks every chat back
+        # to its beginning, so an in-memory-only set would make every relaunch
+        # re-walk an account that is already complete — hundreds of pointless
+        # round-trips through the one Puppeteer page, for ever.
+        self._exhausted_chats = set(self.db.get_metadata_json("exhausted_chats", []))
+
         # 7. my_jid / my_lid — previously only ever set at runtime by an
         # online host-device/self-LID lookup (check_wa_connection_http(),
         # resolve_self_lid()), never persisted or restored. _is_self_jid()
@@ -12872,7 +12882,12 @@ class MainWindow(wx.Frame):
                 # finished while this pass was sleeping.
                 pending = sorted(getattr(self, "_chats_awaiting_messages", set()))
                 names_pending = self._pending_name_resolution()
-                if not pending and not names_pending:
+                # Chats that already hold a full page but whose older history
+                # has never been walked. Without this the loop declared itself
+                # finished the moment every chat had 200 messages, which for a
+                # 20,000-message conversation is 1% of it.
+                deep_pending = self._chats_needing_deep_history()
+                if not pending and not names_pending and not deep_pending:
                     if getattr(self, "_history_still_landing", False):
                         # Nothing to re-query yet, but history is still arriving
                         # — keep the loop alive to notice when it does.
@@ -12880,8 +12895,8 @@ class MainWindow(wx.Frame):
                                      "landing — staying on watch.")
                         delay = self._BACKFILL_FIRST_DELAY
                         continue
-                    logging.info("[backfill] Nothing pending — every chat has a full page "
-                                 "of history (or all there is) and a name.")
+                    logging.info("[backfill] Nothing pending — every chat is walked back to "
+                                 "its beginning (or all there is) and has a name.")
                     return
                 # Names get the same second chance as messages. _run_sync()
                 # resolves LIDs exactly once, while WhatsApp Web is still warming
@@ -12891,9 +12906,44 @@ class MainWindow(wx.Frame):
                 if named:
                     wx.CallAfter(self._schedule_set_chats)
 
+                # ── Deep history ─────────────────────────────────────────
+                # Runs every pass, before the short-page work's own early
+                # exit below, so a session whose chats all hold a full page
+                # still makes progress. Each visit pages a few chats a few
+                # windows further back; a chat that needs more comes back on
+                # the next pass, anchored on whatever is now oldest on disk,
+                # so the walk resumes rather than restarting.
+                deep_stored = 0
+                if deep_pending:
+                    window = deep_pending[:self._DEEP_CHATS_PER_PASS]
+                    logging.info(
+                        "[deep-backfill] Pass %d: walking %d of %d chat(s) further back.",
+                        attempt, len(window), len(deep_pending))
+                    for jid in window:
+                        if getattr(self, "_sync_run_id", 0) != my_run:
+                            return
+                        try:
+                            deep_stored += self.deep_backfill_chat(jid)
+                        except Exception as exc:
+                            logging.warning("[deep-backfill] %s failed: %s", jid, exc)
+                    if deep_stored:
+                        logging.info(
+                            "[deep-backfill] Pass %d stored %d older message(s); "
+                            "%d chat(s) still to walk.",
+                            attempt, deep_stored, len(self._chats_needing_deep_history()))
+                        # Real progress renews the clock, capped by the same
+                        # ceiling everything else respects. Deliberately not an
+                        # unbounded loop: the walk is durable — exhausted_chats
+                        # is persisted and the anchor is read from the database
+                        # — so a budget that runs out costs a resume on the next
+                        # launch, not a restart from the newest page.
+                        deadline = min(hard_deadline,
+                                       max(deadline, time.monotonic() + self._BACKFILL_BUDGET))
+
                 if not pending:
-                    # Only names were outstanding this round.
-                    delay = (self._BACKFILL_FIRST_DELAY if named
+                    # No chat is short of a page; names and/or deep history
+                    # were this round's work.
+                    delay = (self._BACKFILL_FIRST_DELAY if (named or deep_stored)
                              else min(delay * 2, self._BACKFILL_MAX_DELAY))
                     continue
 
@@ -12962,7 +13012,7 @@ class MainWindow(wx.Frame):
                 logging.info(
                     "[backfill] Pass %d: %d chat(s) gained messages, %d no longer pending "
                     "(of %d).", attempt, grew, completed, before)
-                if grew > 0 or completed > 0 or named > 0:
+                if grew > 0 or completed > 0 or named > 0 or deep_stored > 0:
                     # Unread badges, the "is this chat worth showing" decision and
                     # the displayed name all depend on this, so rebuild the list.
                     self._schedule_save()
@@ -16022,8 +16072,111 @@ class MainWindow(wx.Frame):
                     return ""
         return ""
 
-    def fetch_older_messages(self, remote_jid, oldest_msg):
-        """Fetch older messages from server starting before the oldest_msg."""
+    # ── Deep history backfill ────────────────────────────────────────────────
+    # Pages a single chat backwards until WhatsApp Web has nothing older. The
+    # ordinary backfill stops the moment a chat holds one page
+    # (_note_backfill_state: `count >= history_page_target()` retires it), so
+    # a 20,000-message conversation kept exactly 200 and the rest only ever
+    # arrived if the user scrolled up to it by hand.
+    #
+    # Pages per chat per visit. Not unbounded: one enormous conversation must
+    # not hold the queue while 900 others wait, and every page is a request
+    # through the single Puppeteer page the whole app shares. A chat that
+    # needs more comes back on the next pass, from where it stopped — the
+    # anchor is whatever is oldest in the database, so progress is durable
+    # across passes and across restarts.
+    _DEEP_PAGES_PER_VISIT = 5
+    # Chats given a deep visit per backfill pass. Small on purpose: with
+    # _DEEP_PAGES_PER_VISIT pages each and a pause between pages, a pass is
+    # already tens of seconds of background traffic, and the ordinary
+    # short-page backfill shares the same pass and the same page.
+    _DEEP_CHATS_PER_PASS = 8
+    # Pause between pages of the same chat. The scroll-up path has a user
+    # waiting and takes none; this has nobody waiting and is competing with
+    # sends, media and live traffic for the page, so it yields.
+    _DEEP_PAGE_DELAY = 1.0
+
+    def _oldest_stored_message(self, remote_jid: str) -> "dict | None":
+        """The oldest message on disk for a chat — the anchor to page before.
+
+        Read from SQLite rather than from self.chats: the in-memory record
+        list is the newest page only, so anchoring on it would re-request the
+        same window on every visit and never advance.
+        """
+        try:
+            rows = self.db.get_messages_asc(remote_jid, limit=1, offset=0)
+        except Exception as exc:
+            logging.warning("[deep-backfill] Could not read oldest message for %s: %s",
+                            remote_jid, exc)
+            return None
+        return rows[0] if rows else None
+
+    def deep_backfill_chat(self, remote_jid: str) -> int:
+        """Page one chat backwards. Returns how many messages were stored.
+
+        Stops on the first page that comes back empty — fetch_older_messages()
+        marks the chat exhausted there (or asks the phone for older history
+        and leaves it re-queryable, in which case the next pass picks up the
+        reply). Also stops when the per-visit page budget runs out, and when
+        the connection drops.
+        """
+        stored = 0
+        for _ in range(self._DEEP_PAGES_PER_VISIT):
+            if not getattr(self, "_wa_connected", False) or getattr(self, "offline_mode", False):
+                break
+            if remote_jid in getattr(self, "_exhausted_chats", set()):
+                break
+            anchor = self._oldest_stored_message(remote_jid)
+            if not anchor:
+                # Nothing stored at all: this is the ordinary backfill's job,
+                # not ours — it has no anchor to page before.
+                break
+            page = self.fetch_older_messages(remote_jid, anchor, store_only=True)
+            if not page:
+                break
+            stored += len(page)
+            time.sleep(self._DEEP_PAGE_DELAY)
+        return stored
+
+    def _chats_needing_deep_history(self) -> list:
+        """Chats holding a full page whose older history has not been walked.
+
+        The complement of the ordinary backfill's queue: that one handles
+        chats *short* of a page, this one handles the chats it retires.
+        """
+        exhausted = getattr(self, "_exhausted_chats", set())
+        target = self.history_page_target()
+        out = []
+        for jid, chat in list(self.chats.items()):
+            if jid in exhausted or jid in self._deleted_chats:
+                continue
+            records = (chat.get("messages", {}).get("messages", {}).get("records")) or []
+            if len(records) >= target:
+                out.append(jid)
+        return out
+
+    def _persist_exhausted_chats(self):
+        """Write the exhausted-chat set to DB metadata. Best effort — losing it
+        only costs one wasted round-trip per chat on the next launch."""
+        try:
+            if getattr(self, "db", None) is not None:
+                self.db.set_metadata_json(
+                    "exhausted_chats", sorted(getattr(self, "_exhausted_chats", set())))
+        except Exception as exc:
+            logging.warning("[history] Could not persist exhausted_chats: %s", exc)
+
+    def fetch_older_messages(self, remote_jid, oldest_msg, store_only: bool = False):
+        """Fetch older messages from server starting before the oldest_msg.
+
+        `store_only` writes the page to SQLite without growing the chat's
+        in-memory record list. The scroll-up path needs that list to grow —
+        the open conversation renders from it — but the deep backfill walks
+        chats back to their very beginning, and appending there would hold
+        every message of every chat in RAM at once. A 935-chat account with
+        20k-message conversations is millions of dicts; nothing needs them
+        resident, and navigate_to_conversation() reloads the page it renders
+        from the database anyway (see conversations.py).
+        """
         remote_jid = self._normalize_jid(remote_jid)
 
         # Check if history is already marked as exhausted in-memory
@@ -16128,6 +16281,7 @@ class MainWindow(wx.Frame):
                         )
                     else:
                         self._exhausted_chats.add(remote_jid)
+                        self._persist_exhausted_chats()
                         logging.info(
                             "[fetch_older_messages] Marked history as exhausted "
                             "in-memory for %s (older-message request %s).",
@@ -16146,6 +16300,22 @@ class MainWindow(wx.Frame):
                             pass
                 
                 if fetched_messages:
+                    if store_only:
+                        # Straight to disk, nothing kept resident. Deliberately
+                        # not routed through the branch below even for the
+                        # dedup: that one dedups against the in-memory page,
+                        # which is the newest 200 and cannot overlap a window
+                        # anchored strictly before the oldest we hold. The
+                        # message table's own (message_id, remote_jid) primary
+                        # key is what makes a repeat harmless anyway.
+                        try:
+                            self.db.insert_messages_batch(remote_jid, fetched_messages)
+                        except Exception as e:
+                            logging.warning(
+                                "[fetch_older_messages] store-only save failed for %s: %s",
+                                remote_jid, e)
+                            return []
+                        return fetched_messages
                     # Update local database/memory
                     chat = self.chats.get(remote_jid, {})
                     if chat:

--- a/client/main.py
+++ b/client/main.py
@@ -9192,8 +9192,27 @@ class MainWindow(wx.Frame):
             if jid.endswith("@lid") and jid not in getattr(self, "_lid_to_phone", {})
         ]
         if unresolved_lids:
-            logging.info(f"[Sync] Resolving {len(unresolved_lids)} unresolved @lid chats via API...")
-            self.resolve_lid_jids_via_api(unresolved_lids)
+            # One chunk here, the rest to the backfill. This pass is serial by
+            # design — resolve_lid_jids_via_api() sleeps 0.5 s per JID so it
+            # cannot hammer the single Puppeteer page — and it sits between
+            # the message phase and the "conversations synchronized"
+            # announcement, so its cost is time the user waits with no idea
+            # anything is happening. Measured on a live sync: 728 unresolved
+            # LIDs, six and a half minutes, on a sync whose message phase took
+            # 58 seconds.
+            #
+            # Nothing is dropped. _backfill_names() already resolves exactly
+            # this list, in chunks of the same size, on its own thread, with
+            # an adaptive delay — the chunked-and-paced pass this used to
+            # duplicate serially. The backfill scheduler below is what
+            # guarantees it runs.
+            head = unresolved_lids[:self._BACKFILL_CHUNK]
+            logging.info(
+                "[Sync] Resolving %d of %d unresolved @lid chat(s) via API now; "
+                "the backfill takes the remaining %d in the background.",
+                len(head), len(unresolved_lids), len(unresolved_lids) - len(head),
+            )
+            self.resolve_lid_jids_via_api(head)
             self.chats = self.deduplicate_chats(self.chats)
 
         # Conversations are fully sorted as soon as messages are synced.
@@ -9286,10 +9305,19 @@ class MainWindow(wx.Frame):
         # on its way — and it is the loop that decides when to stop.
         pending = len(getattr(self, "_chats_awaiting_messages", set()))
         still_landing = self.refresh_history_still_landing(context="after initial sync")
-        if pending or still_landing:
+        # Unresolved names are a third reason to run, and until the inline
+        # pass above was capped there was never a case where they were the
+        # ONLY reason — it resolved every one of them before getting here, at
+        # the cost of blocking the sync for minutes. Now that it hands the
+        # remainder over, leaving this condition on messages alone would strand
+        # them: a chat list where every chat holds a full page but hundreds
+        # still show a raw @lid, with nothing left to fix it this session.
+        unnamed = len(self._pending_name_resolution())
+        if pending or still_landing or unnamed:
             logging.info(
                 "[backfill] Scheduling backfill: %d chat(s) short of a full page, "
-                "history still landing=%s.", pending, still_landing)
+                "%d still unnamed, history still landing=%s.",
+                pending, unnamed, still_landing)
             existing = getattr(self, "_backfill_thread", None)
             if existing is None or not existing.is_alive():
                 self._backfill_thread = threading.Thread(
@@ -11540,13 +11568,21 @@ class MainWindow(wx.Frame):
                                 else:
                                     name = self.i18n.t("unknown_contact")
             
-            # Detailed logging for name resolution debugging
+            # Name-resolution tracing. DEBUG, not INFO, and with lazy %-args
+            # rather than an f-string, because both halves of that mattered:
+            # this runs once per chat inside _compute_chat_lists(), which the
+            # chat list rebuilds on every mapping learned. Measured on a live
+            # 935-chat sync: 336,741 of the session's 348,332 log lines came
+            # from this one call — 97% of the log, 74 MB of the 77 MB, roughly
+            # 690 synchronous disk writes a second sustained for eight
+            # minutes. An f-string would still be built on every call even
+            # with the level raised, so the format arguments stay deferred.
             if jid.endswith("@lid") or name == self.i18n.t("unknown_contact"):
-                logging.info(
-                    f"[Name Resolution] jid={jid} phone_jid={phone_jid} "
-                    f"resolved_name={resolved_name} "
-                    f"msg_name={msg_push} "
-                    f"chat_name={chat.get('name')} push_name={chat.get('pushName')} -> final_name='{name}'"
+                logging.debug(
+                    "[Name Resolution] jid=%s phone_jid=%s resolved_name=%s "
+                    "msg_name=%s chat_name=%s push_name=%s -> final_name=%r",
+                    jid, phone_jid, resolved_name, msg_push,
+                    chat.get("name"), chat.get("pushName"), name,
                 )
             if my_jid and not jid.endswith("@g.us") and self._is_self_jid(jid):
                 name = self.i18n.t("self_chat_name")
@@ -12118,6 +12154,9 @@ class MainWindow(wx.Frame):
             
             lids_to_resolve = set()
             phones_to_resolve = set()
+            # Mappings learned by this scan, so the single end-of-scan refresh
+            # below fires even when no contact record happened to change.
+            mapped = 0
             # Senders are collected separately and capped: a busy account can
             # hold thousands of distinct group participants, and every one of
             # them would otherwise become an API round-trip through the single
@@ -12144,12 +12183,17 @@ class MainWindow(wx.Frame):
                     alt = key.get("remoteJidAlt", "")
                     participant = key.get("participant", "")
 
+                    # defer_ui: this walks every message of every chat, so a
+                    # refresh per mapping is the same rebuild storm
+                    # resolve_lid_jids_via_api() had. One refresh at the end.
                     if alt and alt.endswith("@s.whatsapp.net"):
                         if remote.endswith("@lid") and self._lid_to_phone.get(remote) != alt:
-                            self.register_jid_mapping(remote, alt)
+                            self.register_jid_mapping(remote, alt, defer_ui=True)
+                            mapped += 1
                     elif alt and alt.endswith("@lid") and remote.endswith("@s.whatsapp.net"):
                         if self._lid_to_phone.get(alt) != remote:
-                            self.register_jid_mapping(alt, remote)
+                            self.register_jid_mapping(alt, remote, defer_ui=True)
+                            mapped += 1
 
                     # Sender of a group message. Only mentioned JIDs used to be
                     # collected here, so a participant whose @lid we cannot
@@ -12229,6 +12273,11 @@ class MainWindow(wx.Frame):
                      except Exception as e:
                          logging.error(f"[Mentions Scan] Error saving contacts incrementally: {e}")
                          self.save_data(self.chats, self.contacts)
+                if updated_contacts or mapped:
+                     # Was gated on updated_contacts alone, which is no longer
+                     # enough now that the per-mapping refreshes are deferred:
+                     # a scan that learned mappings but changed no contact
+                     # record would otherwise never refresh the list at all.
                      wx.CallAfter(self._schedule_set_chats)
                      wx.CallAfter(self._schedule_refresh_active_messages)
             
@@ -16362,8 +16411,19 @@ class MainWindow(wx.Frame):
 
         threading.Thread(target=_resolve, daemon=True).start()
 
-    def register_jid_mapping(self, lid_jid, phone_jid, save=True):
-        """Register a bidirectional mapping between @lid and @s.whatsapp.net, and persist it."""
+    def register_jid_mapping(self, lid_jid, phone_jid, save=True, defer_ui=False):
+        """Register a bidirectional mapping between @lid and @s.whatsapp.net, and persist it.
+
+        `defer_ui` suppresses this call's own chat-list refresh, for callers
+        resolving a whole batch: they schedule one refresh when the batch
+        finishes instead of one per mapping. Measured on a live 935-chat
+        sync, resolve_lid_jids_via_api() learned 1245 mappings in eight
+        minutes and each one scheduled a rebuild — _schedule_set_chats()
+        debounces at 300 ms, so that still came to roughly 380 full
+        recomputations of a 935-chat list, each resolving every chat's name.
+        The live message path (on_new_message) deliberately does NOT pass
+        this: a single arriving message must still refresh the list at once.
+        """
         if not lid_jid or not phone_jid:
             return
         if not lid_jid.endswith("@lid") or not phone_jid.endswith("@s.whatsapp.net"):
@@ -16416,7 +16476,8 @@ class MainWindow(wx.Frame):
                     logging.warning("[LID Mapping] Failed to save mapping incrementally: %s", exc)
                     # Fallback to save_data if incremental save fails
                     self.save_data(self.chats, self.contacts)
-            wx.CallAfter(self._schedule_set_chats)
+            if not defer_ui:
+                wx.CallAfter(self._schedule_set_chats)
 
     def resolve_lid_jids_via_api(self, jids):
         """Resolve a list of @lid JIDs to phone JIDs using WPPConnect contact endpoint."""
@@ -16500,7 +16561,7 @@ class MainWindow(wx.Frame):
                         if pn_jid:
                             canonical_jid = self._normalize_jid(pn_jid)
                             if canonical_jid and canonical_jid.endswith("@s.whatsapp.net"):
-                                self.register_jid_mapping(lid_jid, canonical_jid, save=False)
+                                self.register_jid_mapping(lid_jid, canonical_jid, save=False, defer_ui=True)
                                 try:
                                     self.db.set_lid_mapping(lid_jid, canonical_jid)
                                 except Exception as exc:
@@ -16566,7 +16627,7 @@ class MainWindow(wx.Frame):
                         if profile_pn_jid:
                             profile_canonical = self._normalize_jid(profile_pn_jid)
                             if profile_canonical and profile_canonical.endswith("@s.whatsapp.net"):
-                                self.register_jid_mapping(lid_jid, profile_canonical, save=False)
+                                self.register_jid_mapping(lid_jid, profile_canonical, save=False, defer_ui=True)
                                 try:
                                     self.db.set_lid_mapping(lid_jid, profile_canonical)
                                 except Exception as exc:

--- a/tests/test_deep_history_backfill.py
+++ b/tests/test_deep_history_backfill.py
@@ -1,0 +1,373 @@
+"""Tests for walking a chat's history back to its beginning.
+
+The ordinary backfill retires a chat the moment it holds one page
+(_note_backfill_state: `count >= history_page_target()`), so a conversation
+with 20,000 messages kept exactly 200 and the rest only ever arrived if the
+user happened to scroll up to it by hand. deep_backfill_chat() pages
+backwards until WhatsApp Web has nothing older.
+
+Three properties matter and each has a way of going quietly wrong:
+
+* It must stop. The stop signal is fetch_older_messages() answering with an
+  empty page, which is also where the chat gets marked exhausted.
+* It must not hold the account in RAM. Paging a 935-chat account back to the
+  beginning is millions of message dicts; store_only writes them to SQLite
+  and keeps none.
+* It must resume, not restart. The anchor is read from the database and
+  exhausted chats are persisted, so a relaunch continues the walk instead of
+  re-requesting from the newest page for ever.
+
+MainWindow is a wx.Frame, so the methods are bound to a stub carrying only
+what they touch — the pattern the rest of this suite uses.
+"""
+
+import types
+
+import pytest
+
+import main
+from main import MainWindow
+
+
+def _msg(i):
+    return {"key": {"id": f"m{i}", "remoteJid": "chat@g.us"},
+            "messageTimestamp": 1_700_000_000 + i}
+
+
+class _DB:
+    def __init__(self, oldest_by_jid=None):
+        self.oldest = oldest_by_jid or {}
+        self.batches = []
+        self.metadata = {}
+
+    def get_messages_asc(self, jid, limit=200, offset=0):
+        got = self.oldest.get(jid)
+        return [got] if got else []
+
+    def insert_messages_batch(self, jid, msgs):
+        self.batches.append((jid, len(msgs)))
+
+    def set_metadata_json(self, key, value):
+        self.metadata[key] = value
+
+
+class _Stub:
+    def __init__(self, pages, oldest=None):
+        # pages: list of responses fetch_older_messages() will return, in order
+        self._pages = list(pages)
+        self._wa_connected = True
+        self.offline_mode = False
+        self.db = _DB({"chat@g.us": oldest} if oldest else {})
+        self._exhausted_chats = set()
+        self._deleted_chats = set()
+        self.chats = {}
+        self.settings = {"user_interface": {"messages_page_size": 200}}
+        self.calls = []
+
+    def fetch_older_messages(self, jid, anchor, store_only=False):
+        self.calls.append({"jid": jid, "anchor": anchor, "store_only": store_only})
+        if not self._pages:
+            return []
+        page = self._pages.pop(0)
+        if page:
+            self.db.insert_messages_batch(jid, page)
+            # the real one advances the anchor as it stores
+            self.db.oldest[jid] = page[0]
+        else:
+            self._exhausted_chats.add(jid)
+        return page
+
+
+def _make(pages, oldest=None):
+    stub = _Stub(pages, oldest)
+    for name in ("deep_backfill_chat", "_oldest_stored_message",
+                 "_chats_needing_deep_history", "history_page_target",
+                 "_persist_exhausted_chats"):
+        stub_attr = MainWindow.__dict__[name]
+        setattr(stub, name, types.MethodType(stub_attr, stub))
+    for const in ("_DEEP_PAGES_PER_VISIT", "_DEEP_PAGE_DELAY",
+                  "_DEEP_CHATS_PER_PASS"):
+        setattr(stub, const, getattr(MainWindow, const))
+    return stub
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(main.time, "sleep", lambda *_a: None)
+
+
+class TestWalkingOneChatBack:
+    def test_it_pages_until_the_history_runs_out(self):
+        """Two full pages then an empty one: it stops on the empty answer
+        rather than on the visit budget."""
+        stub = _make([[_msg(3), _msg(4)], [_msg(1), _msg(2)], []], oldest=_msg(5))
+        stored = stub.deep_backfill_chat("chat@g.us")
+        assert stored == 4
+        assert len(stub.calls) == 3
+        assert "chat@g.us" in stub._exhausted_chats
+
+    def test_the_visit_budget_caps_one_chat(self):
+        """One enormous conversation must not hold the queue while the rest
+        of the account waits. It comes back next pass."""
+        stub = _make([[_msg(i)] for i in range(50)], oldest=_msg(99))
+        stub.deep_backfill_chat("chat@g.us")
+        assert len(stub.calls) == MainWindow._DEEP_PAGES_PER_VISIT
+        assert "chat@g.us" not in stub._exhausted_chats
+
+    def test_every_page_is_stored_without_being_kept_in_memory(self):
+        stub = _make([[_msg(3), _msg(4)], []], oldest=_msg(5))
+        stub.deep_backfill_chat("chat@g.us")
+        assert all(c["store_only"] for c in stub.calls), \
+            "a deep page kept in RAM defeats the whole point"
+        assert stub.db.batches == [("chat@g.us", 2)]
+
+    def test_an_already_exhausted_chat_is_not_asked_again(self):
+        """This is what makes a relaunch cheap instead of a full re-walk."""
+        stub = _make([[_msg(1)]], oldest=_msg(5))
+        stub._exhausted_chats.add("chat@g.us")
+        assert stub.deep_backfill_chat("chat@g.us") == 0
+        assert stub.calls == []
+
+    def test_a_chat_with_nothing_stored_is_left_to_the_ordinary_backfill(self):
+        """No anchor to page before — that queue handles it, not this one."""
+        stub = _make([[_msg(1)]], oldest=None)
+        assert stub.deep_backfill_chat("chat@g.us") == 0
+        assert stub.calls == []
+
+    def test_it_stops_when_the_connection_drops(self):
+        stub = _make([[_msg(1)], [_msg(2)]], oldest=_msg(5))
+        stub._wa_connected = False
+        assert stub.deep_backfill_chat("chat@g.us") == 0
+        assert stub.calls == []
+
+    def test_it_stops_in_offline_mode(self):
+        stub = _make([[_msg(1)]], oldest=_msg(5))
+        stub.offline_mode = True
+        assert stub.deep_backfill_chat("chat@g.us") == 0
+
+    def test_the_anchor_comes_from_the_database_not_from_memory(self):
+        """Anchoring on the in-memory list would re-request the newest window
+        every visit and never advance, because that list is the newest page."""
+        stub = _make([[_msg(3)], []], oldest=_msg(5))
+        stub.chats = {"chat@g.us": {"messages": {"messages": {"records": [_msg(9)]}}}}
+        stub.deep_backfill_chat("chat@g.us")
+        assert stub.calls[0]["anchor"] == _msg(5)
+
+
+class TestChoosingWhichChatsNeedIt:
+    def _chat(self, n):
+        return {"messages": {"messages": {"records": [_msg(i) for i in range(n)]}}}
+
+    def test_a_chat_holding_a_full_page_is_queued(self):
+        stub = _make([])
+        stub.chats = {"full@g.us": self._chat(200)}
+        assert stub._chats_needing_deep_history() == ["full@g.us"]
+
+    def test_a_chat_short_of_a_page_belongs_to_the_other_queue(self):
+        stub = _make([])
+        stub.chats = {"short@g.us": self._chat(15)}
+        assert stub._chats_needing_deep_history() == []
+
+    def test_an_exhausted_chat_is_not_queued(self):
+        stub = _make([])
+        stub.chats = {"done@g.us": self._chat(200)}
+        stub._exhausted_chats.add("done@g.us")
+        assert stub._chats_needing_deep_history() == []
+
+    def test_a_deleted_chat_is_not_queued(self):
+        stub = _make([])
+        stub.chats = {"gone@g.us": self._chat(200)}
+        stub._deleted_chats.add("gone@g.us")
+        assert stub._chats_needing_deep_history() == []
+
+
+class TestExhaustionSurvivesARestart:
+    def test_marking_a_chat_exhausted_persists_it(self):
+        stub = _make([])
+        stub._exhausted_chats.update({"b@g.us", "a@g.us"})
+        stub._persist_exhausted_chats()
+        assert stub.db.metadata["exhausted_chats"] == ["a@g.us", "b@g.us"]
+
+    def test_persisting_without_a_database_is_not_fatal(self):
+        stub = _make([])
+        stub.db = None
+        stub._persist_exhausted_chats()   # must not raise
+
+
+class _LoopStub:
+    """Drives the real _backfill_empty_chats() for one pass.
+
+    The wiring — whether the loop still runs when only deep work is left, and
+    whether it calls the walk at all — lives in that method and nowhere else,
+    so testing deep_backfill_chat() in isolation cannot reach it. That gap is
+    exactly how two defences shipped untested earlier in this branch.
+    """
+
+    def __init__(self, deep_pending, pending=(), names=()):
+        import threading
+        self._ui_ready_event = threading.Event()
+        self._ui_ready_event.set()
+        self._sync_run_id = 1
+        self._wa_connected = True
+        self._history_still_landing = False
+        self._chats_awaiting_messages = set(pending)
+        self._names = list(names)
+        self._deep_pending = list(deep_pending)
+        self.walked = []
+        self.returned_early = False
+        self._passes = 0
+
+    # collaborators the loop calls
+    def refresh_history_still_landing(self, context=""):
+        return False
+
+    def _pending_name_resolution(self):
+        return list(self._names)
+
+    def _backfill_names(self):
+        return 0
+
+    def _chats_needing_deep_history(self):
+        return list(self._deep_pending)
+
+    def deep_backfill_chat(self, jid):
+        self.walked.append(jid)
+        # One pass is enough; stop the loop the way a shutdown would.
+        self._ui_ready_event.clear()
+        return 1
+
+    def _local_record_count(self, jid):
+        return 0
+
+    def _resolve_backfill_target(self, jid):
+        return None, None
+
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return lambda *a, **kw: None
+
+
+def _loop(deep_pending, pending=(), names=()):
+    stub = _LoopStub(deep_pending, pending, names)
+    stub._backfill_empty_chats = types.MethodType(
+        MainWindow.__dict__["_backfill_empty_chats"], stub)
+    for const in ("_BACKFILL_BUDGET", "_BACKFILL_LANDING_BUDGET",
+                  "_BACKFILL_FIRST_DELAY", "_BACKFILL_MAX_DELAY",
+                  "_BACKFILL_CHUNK", "_BACKFILL_WORKERS",
+                  "_DEEP_CHATS_PER_PASS"):
+        setattr(stub, const, getattr(MainWindow, const))
+    stub._backfill_empty_chats()
+    return stub
+
+
+class TestTheLoopActuallyRunsTheWalk:
+    def test_deep_work_alone_keeps_the_loop_alive(self):
+        """Every chat has a full page and a name, so the old exit condition
+        called that "nothing pending" and returned — which is precisely the
+        state a 20,000-message account is in after the first sync."""
+        stub = _loop(deep_pending=["a@g.us", "b@g.us"])
+        assert stub.walked, "the loop returned without walking anything"
+
+    def test_the_walk_is_chunked_per_pass(self):
+        stub = _loop(deep_pending=[f"{i}@g.us" for i in range(50)])
+        assert len(stub.walked) <= MainWindow._DEEP_CHATS_PER_PASS
+
+    def test_nothing_at_all_still_ends_the_loop(self):
+        stub = _loop(deep_pending=[])
+        assert stub.walked == []
+
+
+class _FetchStub:
+    """Drives the real fetch_older_messages() far enough to reach the branch
+    that decides whether a page is kept in memory."""
+
+    def __init__(self, returned):
+        self._returned = returned
+        self._wa_connected = True
+        self._exhausted_chats = set()
+        self._older_requested_chats = set()
+        self.chats = {"chat@g.us": {"messages": {"messages": {"records": [_msg(9)]}}}}
+        self.settings = {"user_interface": {"messages_page_size": 200}}
+        self.wpp_server, self.wpp_port, self.token = "http://x", 1, "t"
+        self.batched = []
+        self.upserted = []
+        self.full_saves = 0
+        self.ws = self
+
+    # message normalisation, reduced to identity
+    def _normalize_wpp_message(self, m):
+        return m
+
+    def _extract_lid_mapping(self, m):
+        pass
+
+    def _normalize_jid(self, jid):
+        return jid
+
+    def _resolve_jid_for_msg_key(self, jid):
+        return jid
+
+    def _serialize_msg_id(self, jid, key):
+        return f"false_{jid}_{key.get('id', '')}"
+
+    class _DB2:
+        def __init__(self, outer):
+            self.outer = outer
+
+        def insert_messages_batch(self, jid, msgs):
+            self.outer.batched.append((jid, len(msgs)))
+
+        def upsert_chat(self, jid, chat):
+            self.outer.upserted.append(jid)
+
+    def save_data(self, *a, **kw):
+        self.full_saves += 1
+
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return lambda *a, **kw: None
+
+
+def _fetch_stub(monkeypatch, returned):
+    stub = _FetchStub(returned)
+    stub.db = _FetchStub._DB2(stub)
+    stub.fetch_older_messages = types.MethodType(
+        MainWindow.__dict__["fetch_older_messages"], stub)
+
+    class _Resp:
+        status_code = 200
+        text = ""
+
+        @staticmethod
+        def json():
+            return {"response": returned}
+
+    monkeypatch.setattr(main.requests, "get", lambda *a, **kw: _Resp())
+    return stub
+
+
+class TestStoreOnlyKeepsNothingResident:
+    """The branch that makes the deep walk affordable. Without it, paging a
+    935-chat account back to its beginning appends every message to
+    self.chats — millions of dicts held for nothing, since the open
+    conversation reloads its page from SQLite anyway."""
+
+    def test_store_only_writes_to_disk_without_growing_the_record_list(self, monkeypatch):
+        stub = _fetch_stub(monkeypatch, [_msg(1), _msg(2)])
+        before = list(stub.chats["chat@g.us"]["messages"]["messages"]["records"])
+        got = stub.fetch_older_messages("chat@g.us", _msg(5), store_only=True)
+        assert len(got) == 2
+        assert stub.batched == [("chat@g.us", 2)], "the page must still reach the database"
+        assert stub.chats["chat@g.us"]["messages"]["messages"]["records"] == before, \
+            "store_only kept the page in memory"
+        assert stub.upserted == [], "no chat rewrite is needed for a store-only page"
+
+    def test_the_scroll_up_path_still_grows_the_list(self, monkeypatch):
+        """The user is looking at those records — that path must not change."""
+        stub = _fetch_stub(monkeypatch, [_msg(1), _msg(2)])
+        stub.fetch_older_messages("chat@g.us", _msg(5))
+        records = stub.chats["chat@g.us"]["messages"]["messages"]["records"]
+        assert len(records) == 3
+        assert stub.batched == [("chat@g.us", 2)]

--- a/tests/test_lid_mapping_defer_ui.py
+++ b/tests/test_lid_mapping_defer_ui.py
@@ -1,0 +1,107 @@
+"""Tests for register_jid_mapping()'s deferred chat-list refresh.
+
+Every learned @lid -> phone mapping used to schedule a chat-list rebuild.
+_schedule_set_chats() debounces at 300 ms, which is right for a message
+arriving on its own and useless against a batch: measured on a live 935-chat
+sync, resolve_lid_jids_via_api() learned 1245 mappings over eight minutes and
+that still came to roughly 380 full recomputations of the list, each one
+resolving the name of all 935 chats.
+
+`defer_ui` lets a batch caller suppress the per-mapping refresh and schedule
+one when it finishes. The live message path must NOT pass it — a single
+arriving message still has to refresh the list immediately — so both
+directions are pinned here.
+
+MainWindow is a wx.Frame and cannot be instantiated without a running wx.App,
+so the method is bound to a plain stub, as elsewhere in this suite.
+"""
+
+import types
+
+import pytest
+
+import main
+from main import MainWindow
+
+
+class _DB:
+    def set_lid_mapping(self, *a, **kw):
+        pass
+
+    def upsert_contacts_batch(self, *a, **kw):
+        pass
+
+
+class _Stub:
+    def __init__(self):
+        self.contacts = {}
+        self.chats = {}
+        self.db = _DB()
+        self.my_lid = ""
+        self.my_jid = ""
+        self._lid_to_phone = {}
+        self._phone_to_lid = {}
+        self._unresolvable_lids = set()
+        self.refreshes = 0
+
+    def _is_self_jid(self, jid):
+        return False
+
+    def _schedule_set_chats(self):
+        self.refreshes += 1
+
+
+LID = "111222333444555@lid"
+PHONE = "5511999999999@s.whatsapp.net"
+
+
+@pytest.fixture
+def stub(monkeypatch):
+    monkeypatch.setattr(main.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+    s = _Stub()
+    s.register_jid_mapping = types.MethodType(
+        MainWindow.__dict__["register_jid_mapping"], s)
+    return s
+
+
+class TestRegisterJidMapping:
+    def test_a_single_mapping_refreshes_the_list(self, stub):
+        """The live path: a message arrives carrying a new mapping and the
+        chat list must pick the name up at once."""
+        stub.register_jid_mapping(LID, PHONE)
+        assert stub._lid_to_phone[LID] == PHONE
+        assert stub.refreshes == 1
+
+    def test_defer_ui_learns_the_mapping_but_does_not_refresh(self, stub):
+        stub.register_jid_mapping(LID, PHONE, defer_ui=True)
+        assert stub._lid_to_phone[LID] == PHONE, "the mapping itself must still be learned"
+        assert stub._phone_to_lid[PHONE] == LID
+        assert stub.refreshes == 0
+
+    def test_a_batch_costs_one_refresh_instead_of_one_each(self, stub):
+        """The shape that mattered: 60 mappings in a row, as the backfill's
+        chunk resolves them."""
+        for i in range(60):
+            stub.register_jid_mapping(f"{i:015d}@lid", f"55119999{i:05d}@s.whatsapp.net",
+                                      defer_ui=True)
+        assert len(stub._lid_to_phone) == 60
+        assert stub.refreshes == 0
+        # …and the caller schedules exactly one when the batch ends.
+        stub._schedule_set_chats()
+        assert stub.refreshes == 1
+
+    def test_the_same_mapping_twice_refreshes_once(self, stub):
+        """Unchanged behaviour: the refresh has always been inside the
+        "this is new" branch."""
+        stub.register_jid_mapping(LID, PHONE)
+        stub.register_jid_mapping(LID, PHONE)
+        assert stub.refreshes == 1
+
+    def test_defer_ui_still_persists_the_mapping(self, stub):
+        """save and defer_ui are independent — deferring the UI must not
+        quietly stop the mapping reaching the database, or it would be gone
+        on the next launch."""
+        written = []
+        stub.db.set_lid_mapping = lambda l, p: written.append((l, p))
+        stub.register_jid_mapping(LID, PHONE, defer_ui=True)
+        assert written == [(LID, PHONE)]

--- a/tests/test_run_sync_broken_store.py
+++ b/tests/test_run_sync_broken_store.py
@@ -67,6 +67,9 @@ class _Stub:
         self._chats_awaiting_messages = set()
         self._lid_to_phone = {}
         self._history_still_landing = False
+        self.unnamed = []
+        # __getattr__ would hand back a lambda, which has no is_alive().
+        self._backfill_thread = None
 
         # what the test inspects
         self.fetches = 0
@@ -75,6 +78,8 @@ class _Stub:
         self.wa_web_probes = 0
         self.restarted = False
         self.message_sync_ran = 0
+        self.lid_batches = []
+        self.backfill_started = False
 
     # ── the two calls the loop actually makes ────────────────────────
     def get_remote_chats(self, chats, persist_full=True, notify_errors=True,
@@ -103,6 +108,15 @@ class _Stub:
 
     def sync_remote_chats(self):
         self.message_sync_ran += 1
+
+    def _pending_name_resolution(self):
+        return list(self.unnamed)
+
+    def resolve_lid_jids_via_api(self, jids):
+        self.lid_batches.append(len(jids))
+
+    def _backfill_empty_chats(self):
+        self.backfill_started = True
 
     # ── collaborators whose return value the loop uses ───────────────
     def normalize_chats(self, chats):
@@ -138,7 +152,7 @@ def _make(counts, wa_web, local_chats=0, high_water=0):
     for const in ("_CHAT_ABSOLUTE_MAX_ATTEMPTS", "_CHAT_ATTEMPT_EXTENSION",
                   "_STORE_PLAUSIBLE_RATIO", "_BROKEN_STORE_CONFIRM",
                   "_BROKEN_STORE_REPAIR_ROUNDS", "_DEEP_SYNC_TOP_N",
-                  "_DEEP_SYNC_COUNT"):
+                  "_DEEP_SYNC_COUNT", "_BACKFILL_CHUNK"):
         setattr(stub, const, getattr(MainWindow, const))
     return stub
 
@@ -244,3 +258,58 @@ class TestTheProbeIsNotChatty:
         stub = _make([931, 931], wa_web=937, local_chats=931)
         stub._run_sync()
         assert stub.wa_web_probes == 0
+
+
+class TestTheSyncDoesNotBlockOnNameResolution:
+    """The inline @lid pass used to resolve every unresolved name before the
+    "conversations synchronized" announcement, serially, sleeping 0.5 s per
+    JID so as not to hammer the single Puppeteer page.
+
+    Measured on a live 935-chat sync: 728 unresolved LIDs, six and a half
+    minutes — on a sync whose message phase took 58 seconds. The user waits
+    that out with nothing announced. _backfill_names() already resolves the
+    same list in chunks of the same size, on its own thread, with an adaptive
+    delay, so the serial pass was duplicating paced work with unpaced work.
+    """
+
+    def _synced(self, unnamed):
+        stub = _make([931, 931], wa_web=937, local_chats=931)
+        stub.chats = {f"{i}@lid": {"remoteJid": f"{i}@lid"} for i in range(unnamed)}
+        stub.unnamed = [f"{i}@lid" for i in range(unnamed)]
+        stub._run_sync()
+        return stub
+
+    def test_only_one_chunk_is_resolved_inline(self):
+        stub = self._synced(728)
+        assert stub.lid_batches == [MainWindow._BACKFILL_CHUNK]
+
+    def test_a_small_account_is_still_fully_resolved_inline(self):
+        """Below one chunk there is nothing to defer, so behaviour is
+        unchanged for the accounts that were never slow."""
+        stub = self._synced(12)
+        assert stub.lid_batches == [12]
+
+    def test_the_remainder_is_handed_to_the_backfill(self):
+        """The half that makes capping safe. Without it the leftover names
+        would simply never resolve this session."""
+        stub = self._synced(728)
+        assert stub.backfill_started is True
+
+    def test_names_alone_are_enough_to_start_the_backfill(self):
+        """The scheduler used to look only at chats short of messages. That
+        was fine while the inline pass resolved every name before reaching
+        here; it is not fine now. A chat list where every chat holds a full
+        page but hundreds show a raw @lid must still get its backfill."""
+        stub = _make([931, 931], wa_web=937, local_chats=931)
+        stub._chats_awaiting_messages = set()      # nothing short of a page
+        stub.unnamed = [f"{i}@lid" for i in range(200)]
+        stub._run_sync()
+        assert stub.backfill_started is True
+
+    def test_nothing_pending_starts_nothing(self):
+        stub = _make([931, 931], wa_web=937, local_chats=931)
+        stub._chats_awaiting_messages = set()
+        stub.unnamed = []
+        stub._run_sync()
+        assert stub.backfill_started is False
+        assert stub.lid_batches == []


### PR DESCRIPTION
Dois commits, ambos medidos no log de campo da conta de **937 conversas** (sessão de 12 min, 348 mil linhas). Base: a correção de store quebrado já mergeada (#60).

## 1. `perf`: o sync parar de foder o PC

**97% do log — 336.741 de 348.332 linhas, 74 MB de 77 MB — saía de UMA chamada de logging** (`main.py:11545`, marcada no próprio código como *"Detailed logging for name resolution debugging"*). ~690 gravações síncronas em disco por segundo, sustentadas por 8 minutos.

| minuto | linhas | vindas dessa linha |
|---|---|---|
| 21:03 | 41.695 | 41.283 (99%) |
| 21:04 | 42.129 | 41.700 (99%) |
| 21:05 | 41.732 | 41.283 (99%) |

A cadeia: `resolve_lid_jids_via_api()` resolvia **728 @lid em série, 0,5 s cada (6,5 min)**; cada resolução chamava `register_jid_mapping()`, que agendava um rebuild da lista; o debounce de 300 ms ainda deixava passar **~380 recomputações completas** de uma lista de 935 conversas; cada recomputação resolvia o nome de todas e logava uma linha por não resolvido.

- Linha vira `DEBUG`, com args `%`-lazy (com f-string a string seria montada nas 336 mil chamadas mesmo com o nível levantado).
- `register_jid_mapping()` ganha `defer_ui`, usado pelos dois caminhos em lote. **O caminho de mensagem ao vivo não passa a flag** — uma mensagem que chega sozinha continua atualizando a lista na hora.
- A passagem inline de @lid resolve um bloco e entrega o resto ao backfill, que já resolve essa lista em blocos, em thread própria, com delay adaptativo. Ela ficava **entre a fase de mensagens e o anúncio de "sincronizado"**: 6,5 min de espera muda numa sinc cuja fase de mensagens levou 58 s.

Nada é perdido: o agendador do backfill passa a considerar nomes pendentes como terceiro motivo para rodar. Sem isso, com a passagem inline limitada, centenas de conversas ficariam com @lid cru e nada para corrigir na sessão.

## 2. `feat`: puxar o histórico inteiro, de verdade

O backfill aposentava a conversa assim que ela tinha **uma página**. Uma conversa de 20.000 mensagens ficava com **200** — 1% dela. O resto só chegava se o usuário rolasse até lá na mão.

`deep_backfill_chat()` pagina para trás até acabar, reusando `fetch_older_messages()` (a paginação ancorada `direction=before&id=` já existia e consulta o IndexedDB, não a coleção em memória).

Três coisas tinham que vir junto, senão isso vira um tiro no pé:

- **Memória.** `fetch_older_messages()` faz `all_records = new_records + local_records`. Andar 935 conversas até o início por ali são milhões de dicts residentes. `store_only` grava no SQLite e não guarda nada — `navigate_to_conversation()` já recarrega do banco a página que renderiza.
- **Retomada.** `_exhausted_chats` vivia só em memória (a própria linha de log dizia *"in-memory"*). Toda reabertura re-andaria uma conta já pronta. Agora persiste em metadata e carrega no `prepare_sync`.
- **Ritmo.** Teto de páginas por visita e de conversas por passe, com pausa entre páginas — a caminhada divide a única página do Puppeteer com envios, mídias e tráfego ao vivo.

A âncora vem do **banco** (`get_messages_asc`), não de `self.chats`: a lista em memória é a página mais recente, então ancorar nela re-pediria a mesma janela e nunca avançaria.

**Não é laço infinito.** O orçamento renova enquanto há progresso, limitado pelo mesmo teto de sempre — porque o progresso é durável: um orçamento que acaba custa uma *retomada* no próximo lançamento, não um recomeço.

## Testes

**2558 passando.** Conferido sabotando cada defesa em separado:

| sabotagem | testes que caem |
|---|---|
| corte da passagem inline | 1 |
| condição do backfill (nomes) | 2 |
| `defer_ui` | 2 |
| `store_only` passado | 1 |
| exaustos pulados | 1 |
| teto por visita | 1 |
| fiação no laço do backfill | 1 |
| âncora vinda do banco | 4 |
| ramo `store_only` real | 1 |

Duas rodadas de verificação pegaram testes **vacuosos** meus — `defer_ui` e o ramo `store_only` real não eram cobertos por nada. `test_lid_mapping_defer_ui.py` e `TestStoreOnlyKeepsNothingResident` existem por causa disso. É a mesma armadilha que `7da08f8` documenta, e é por isso que a fiação do `_backfill_empty_chats` ganhou teste próprio: testar `deep_backfill_chat()` isolado não alcança o laço.

## O que ainda NÃO está resolvido

- **Reabertura ainda re-consulta todas as conversas.** `sync_remote_chats` pede as 200 mais recentes de **cada** conversa em **toda** rodada. Não existe marca por conversa de "até onde sincronizei". Isso é o watermark — pilar 3 da proposta de arquitetura, não entra aqui.
- **`self.chats` ainda carrega mensagem em memória** na página mais recente. O `store_only` impede a caminhada profunda de piorar isso, mas não resolve o boot (medido: 10,6 s para 800 conversas).

## Como testar ao vivo

```
grep -E "deep-backfill|backfill\] Pass|Name Resolution|Resolving .* of .* unresolved" log.log
```

- O `log.log` deve ficar em ordens de grandeza menor (era 77 MB em 12 min).
- `[Sync] Resolving 60 of 728 unresolved @lid chat(s)` em vez de travar em 728.
- `[deep-backfill] Pass N: walking 8 of M chat(s) further back` aparecendo e `M` diminuindo passe a passe.
- Fechar e reabrir: as conversas já caminhadas **não** devem reaparecer no `deep-backfill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWZCJFmXULHDzRZM3Q6Ekt
