### PR TITLE
Corrija três problemas: bate-papos esgotados, atualização inacessível e progresso âncora

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -3280,6 +3280,7 @@ class MainWindow(wx.Frame):
             # state the user set locally on top of them (see
             # clear_local_data()'s own docstring).
             self.clear_local_data(wipe_metadata=False)
+            self._forget_history_exhaustion()
             try:
                 media_failed_path = data_path("media_failed.json")
                 if os.path.isfile(media_failed_path):
@@ -7606,14 +7607,30 @@ class MainWindow(wx.Frame):
         self._blocked_contacts = set(self.db.get_metadata_json("blocked_contacts", []))
 
         # 6b. exhausted_chats — conversations WhatsApp Web has no older history
-        # for. It used to live only in memory (fetch_older_messages() even says
-        # "in-memory" in its own log line), which was fine while the only
+        # for. It used to live only in memory, which was fine while the only
         # consumer was a user scrolling up in one conversation: worst case it
         # asked once more per session. The deep backfill walks every chat back
         # to its beginning, so an in-memory-only set would make every relaunch
         # re-walk an account that is already complete — hundreds of pointless
         # round-trips through the one Puppeteer page, for ever.
         self._exhausted_chats = set(self.db.get_metadata_json("exhausted_chats", []))
+        # …and the timestamps of the older-history requests that justify those
+        # entries. Persisted for the reason _OLDER_REQUEST_GRACE explains: a
+        # durable "this chat is finished" may only be written once the phone has
+        # had longer than its reply window to answer, and nothing in a single
+        # session can establish that. Tolerates the legacy list form (the set
+        # this used to be) by treating those entries as asked long ago, which is
+        # true — they were written by an earlier run.
+        _asked = self.db.get_metadata_json("older_history_requested", {})
+        if isinstance(_asked, dict):
+            self._older_requested_chats = {
+                jid: float(ts) for jid, ts in _asked.items()
+                if isinstance(ts, (int, float))
+            }
+        elif isinstance(_asked, list):
+            self._older_requested_chats = {jid: 0.0 for jid in _asked}
+        else:
+            self._older_requested_chats = {}
 
         # 7. my_jid / my_lid — previously only ever set at runtime by an
         # online host-device/self-LID lookup (check_wa_connection_http(),
@@ -12254,9 +12271,12 @@ class MainWindow(wx.Frame):
                 logging.info(f"[Mentions Scan] Found {len(lids_to_resolve)} unresolved LIDs.")
                 self.resolve_lid_jids_via_api(list(lids_to_resolve))
                 
+            # Declared out here, not inside the `if` below: the end-of-scan
+            # refresh reads it, and that refresh has to run whether or not there
+            # were any mentioned phone JIDs to resolve.
+            updated_contacts = {}
             if phones_to_resolve:
                 logging.info(f"[Mentions Scan] Found {len(phones_to_resolve)} unresolved mentioned phone JIDs.")
-                updated_contacts = {}
                 for p_jid in list(phones_to_resolve):
                     try:
                          res = self.get_contact_profile(p_jid)
@@ -12283,13 +12303,19 @@ class MainWindow(wx.Frame):
                      except Exception as e:
                          logging.error(f"[Mentions Scan] Error saving contacts incrementally: {e}")
                          self.save_data(self.chats, self.contacts)
-                if updated_contacts or mapped:
-                     # Was gated on updated_contacts alone, which is no longer
-                     # enough now that the per-mapping refreshes are deferred:
-                     # a scan that learned mappings but changed no contact
-                     # record would otherwise never refresh the list at all.
-                     wx.CallAfter(self._schedule_set_chats)
-                     wx.CallAfter(self._schedule_refresh_active_messages)
+            # Outside `if phones_to_resolve:` — it was written inside it, which
+            # made it unreachable in precisely the case `mapped` exists for.
+            # The two are fed by unrelated passes: `mapped` counts @lid <-> phone
+            # pairs learned from remoteJidAlt while walking the messages, while
+            # phones_to_resolve holds *mentioned* phone JIDs that still need a
+            # name. A scan that learns mappings, needs no @lid lookup (so
+            # resolve_lid_jids_via_api()'s own unconditional refresh never fires)
+            # and finds no unnamed mention refreshed nothing at all — with the
+            # per-mapping refreshes deferred, the list kept showing raw @lid
+            # until something unrelated happened to rebuild it.
+            if updated_contacts or mapped:
+                wx.CallAfter(self._schedule_set_chats)
+                wx.CallAfter(self._schedule_refresh_active_messages)
             
             logging.info("[Mentions Scan] Scan and resolution of cached messages completed.")
 
@@ -13182,8 +13208,15 @@ class MainWindow(wx.Frame):
         The 60 s timeout is not generosity — a timeout here returns False, and
         the caller in fetch_older_messages() reads False as "the request never
         went out" and drops the chat into _exhausted_chats, which stops it from
-        ever being re-queried this session. Timing out early therefore
-        permanently writes off exactly the chats that still have history coming.
+        ever being re-queried. Timing out early therefore writes off exactly the
+        chats that still have history coming.
+
+        That used to be bounded by the session, because _exhausted_chats died
+        with the process. It no longer is: the set is persisted, so the write-off
+        outlives the run and takes the user's own scroll-up with it. What keeps
+        the two apart now is _OLDER_REQUEST_GRACE — the write-off is only made
+        durable once this request has had far longer than its reply window to be
+        answered. See that constant.
         """
         if not getattr(self, "_wa_connected", False):
             return False
@@ -16148,14 +16181,28 @@ class MainWindow(wx.Frame):
             return None
         return rows[0] if rows else None
 
+    @staticmethod
+    def _anchor_identity(msg: "dict | None") -> tuple:
+        """Which message an anchor read actually landed on.
+
+        Identity rather than timestamp order because two messages can share a
+        second, and get_messages_asc() breaks that tie on message_id. It only
+        ever has to answer "is this still the same message as before": the
+        oldest row can only stay put or move further back, since storing a
+        page adds rows and never removes any.
+        """
+        key = (msg or {}).get("key") or {}
+        return (int((msg or {}).get("messageTimestamp") or 0), str(key.get("id") or ""))
+
     def deep_backfill_chat(self, remote_jid: str) -> int:
         """Page one chat backwards. Returns how many messages were stored.
 
         Stops on the first page that comes back empty — fetch_older_messages()
         marks the chat exhausted there (or asks the phone for older history
         and leaves it re-queryable, in which case the next pass picks up the
-        reply). Also stops when the per-visit page budget runs out, and when
-        the connection drops.
+        reply). Also stops when the page brings back nothing older than we
+        already had, when the per-visit page budget runs out, and when the
+        connection drops.
         """
         stored = 0
         for _ in range(self._DEEP_PAGES_PER_VISIT):
@@ -16168,8 +16215,41 @@ class MainWindow(wx.Frame):
                 # Nothing stored at all: this is the ordinary backfill's job,
                 # not ours — it has no anchor to page before.
                 break
+            before = self._anchor_identity(anchor)
             page = self.fetch_older_messages(remote_jid, anchor, store_only=True)
             if not page:
+                break
+            # Did the walk actually walk? A full page is not the same thing as
+            # progress, and the difference is not hypothetical: /get-messages
+            # resolves the anchor id inside the page, and when it cannot find
+            # it there, deviceController.ts deliberately re-anchors on
+            # `originalOldestId` — the oldest message the *page* happens to
+            # hold — instead of answering empty. Our anchor comes from SQLite,
+            # and the whole point of this walk is to accumulate history on disk
+            # that the page no longer keeps in memory, so the further a chat is
+            # walked the likelier that fallback becomes: it answers with the
+            # span between what we already stored and what the page holds,
+            # every row of which the messages table's primary key then drops.
+            # The anchor does not move, the next iteration re-reads it, and the
+            # same window comes back — five times a visit, every pass, for ever.
+            #
+            # Counting the returned page as `stored` made that worse than
+            # wasteful: _backfill_empty_chats() renews its whole budget on
+            # `deep_stored`, so re-reading what we already have kept the thread
+            # alive and the shared Puppeteer page busy for the full four-hour
+            # ceiling without a single new message being written.
+            # An unreadable anchor counts as "did not move": without a reading
+            # to compare, there is nothing to justify another four pages.
+            after = self._oldest_stored_message(remote_jid)
+            if after is None or self._anchor_identity(after) == before:
+                logging.warning(
+                    "[deep-backfill] %s: a page of %d message(s) contained nothing "
+                    "older than the anchor we asked before — the anchor did not "
+                    "move, so this visit stops rather than re-reading the same "
+                    "window. (Check log.log for '[browser-evaluate] Anchor not "
+                    "found after walkback' — that is this, named from the page's "
+                    "side.)", remote_jid, len(page),
+                )
                 break
             stored += len(page)
             time.sleep(self._DEEP_PAGE_DELAY)
@@ -16192,6 +16272,27 @@ class MainWindow(wx.Frame):
                 out.append(jid)
         return out
 
+    # How long request_older_messages() gets to be answered before an empty
+    # page is durable evidence that a chat really has no more history.
+    #
+    # The request is fire-and-forget: the phone replies with a history-sync
+    # chunk minutes later, never in the response (see that method's own
+    # docstring). The backfill revisits a chat about 30 seconds after the ask,
+    # so the second empty page — which is what writes the chat off — arrives an
+    # order of magnitude sooner than the answer it is judging. That was
+    # survivable while _exhausted_chats died with the process; now that it is
+    # persisted, a write-off made inside that window is permanent, and
+    # fetch_older_messages()' early return means the user scrolling up in that
+    # conversation gets nothing, in every future session.
+    #
+    # Set well past "minutes later" on purpose. Waiting costs a handful of
+    # empty round-trips per chat; being wrong costs the conversation's history
+    # for good. _older_requested_chats is persisted alongside the exhausted
+    # set, so in practice the bar is cleared on the next launch rather than
+    # inside one session: one extra walk of an already-complete account buys
+    # evidence that outlived the reply window.
+    _OLDER_REQUEST_GRACE = 15 * 60
+
     def _persist_exhausted_chats(self):
         """Write the exhausted-chat set to DB metadata. Best effort — losing it
         only costs one wasted round-trip per chat on the next launch."""
@@ -16201,6 +16302,45 @@ class MainWindow(wx.Frame):
                     "exhausted_chats", sorted(getattr(self, "_exhausted_chats", set())))
         except Exception as exc:
             logging.warning("[history] Could not persist exhausted_chats: %s", exc)
+
+    def _forget_history_exhaustion(self):
+        """Drop everything remembered about chats having no older history.
+
+        Called by the F5 resync. clear_local_data(wipe_metadata=False) keeps
+        system_metadata on purpose — that is where the user's own
+        cleared/deleted/archived/muted state lives — but these two entries are
+        not user state: they are a cached conclusion about what WhatsApp Web
+        was willing to hand over, and the messages they gate were just wiped
+        along with everything else. Keeping them would leave every walked-out
+        chat holding nothing but the page this resync re-fetches, with the deep
+        backfill skipping it and fetch_older_messages() early-returning on it.
+
+        It is also the only escape from a conclusion reached wrongly, and
+        "resync everything" is where a user would look for it. Pulled out of
+        _resync_all_worker() so it can be tested without a wx.App — that method
+        is otherwise all UI teardown.
+        """
+        self._exhausted_chats = set()
+        self._older_requested_chats = {}
+        self._persist_exhausted_chats()
+        self._persist_older_requested()
+
+    def _persist_older_requested(self):
+        """Write the "already asked the phone for older history" map to DB
+        metadata. Best effort, same as _persist_exhausted_chats().
+
+        Persisted for one reason only: it is what lets an empty page be told
+        apart from an empty page *that has already outlived the phone's reply
+        window*. Kept in memory alone — as it was — that distinction cannot
+        survive the session, and the exhausted set it gates is durable.
+        """
+        try:
+            if getattr(self, "db", None) is not None:
+                self.db.set_metadata_json(
+                    "older_history_requested",
+                    dict(getattr(self, "_older_requested_chats", {})))
+        except Exception as exc:
+            logging.warning("[history] Could not persist older_history_requested: %s", exc)
 
     def fetch_older_messages(self, remote_jid, oldest_msg, store_only: bool = False):
         """Fetch older messages from server starting before the oldest_msg.
@@ -16304,12 +16444,16 @@ class MainWindow(wx.Frame):
                     if not hasattr(self, "_exhausted_chats"):
                         self._exhausted_chats = set()
                     if not hasattr(self, "_older_requested_chats"):
-                        self._older_requested_chats = set()
-                    already_asked = remote_jid in self._older_requested_chats
+                        self._older_requested_chats = {}
+                    asked_at = self._older_requested_chats.get(remote_jid)
+                    asked_now = asked_at is None
                     requested = False
-                    if not already_asked:
-                        self._older_requested_chats.add(remote_jid)
+                    if asked_now:
+                        asked_at = time.time()
+                        self._older_requested_chats[remote_jid] = asked_at
+                        self._persist_older_requested()
                         requested = self.request_older_messages(remote_jid)
+                    waited = max(0.0, time.time() - asked_at)
                     if requested:
                         logging.info(
                             "[fetch_older_messages] No local history left for %s — "
@@ -16317,13 +16461,32 @@ class MainWindow(wx.Frame):
                             "re-queryable so the reply can be picked up.", remote_jid,
                         )
                     else:
+                        # In-memory always, so the chat leaves the deep-backfill
+                        # queue at the same rate it always did. Persisted only
+                        # once the phone has genuinely had its chance: the
+                        # request above is answered by a history-sync chunk
+                        # minutes later, and _exhausted_chats is now durable, so
+                        # a write-off made 30 seconds after the ask (the backfill
+                        # pass cadence) used to become permanent — the chat was
+                        # early-returned at the top of this method for ever,
+                        # which also silently killed the user scrolling up in it.
+                        # `waited` clears the bar on the next session rather than
+                        # inside this one, since _older_requested_chats is
+                        # persisted too: one extra walk of an already-complete
+                        # account, in exchange for never writing a chat off on
+                        # evidence younger than the reply it is waiting for.
                         self._exhausted_chats.add(remote_jid)
-                        self._persist_exhausted_chats()
+                        durable = waited >= self._OLDER_REQUEST_GRACE
+                        if durable:
+                            self._persist_exhausted_chats()
                         logging.info(
-                            "[fetch_older_messages] Marked history as exhausted "
-                            "in-memory for %s (older-message request %s).",
+                            "[fetch_older_messages] Marked history as exhausted for %s "
+                            "(%s). The phone was asked %.0fs ago; older-message request "
+                            "%s.",
                             remote_jid,
-                            "already sent earlier" if already_asked else "not sent",
+                            "persisted" if durable else "this session only",
+                            waited,
+                            "just attempted and failed" if asked_now else "sent earlier",
                         )
 
                 fetched_messages = []

--- a/tests/test_deep_history_backfill.py
+++ b/tests/test_deep_history_backfill.py
@@ -52,9 +52,14 @@ class _DB:
 
 
 class _Stub:
-    def __init__(self, pages, oldest=None):
+    def __init__(self, pages, oldest=None, advances=True):
         # pages: list of responses fetch_older_messages() will return, in order
         self._pages = list(pages)
+        # advances=False models the page re-anchoring on its own oldest loaded
+        # message instead of on the id we asked for: a full page comes back,
+        # every row of it is already stored, and the anchor stays put. See
+        # deviceController.ts's `originalOldestId` fallback.
+        self._advances = advances
         self._wa_connected = True
         self.offline_mode = False
         self.db = _DB({"chat@g.us": oldest} if oldest else {})
@@ -71,20 +76,24 @@ class _Stub:
         page = self._pages.pop(0)
         if page:
             self.db.insert_messages_batch(jid, page)
-            # the real one advances the anchor as it stores
-            self.db.oldest[jid] = page[0]
+            if self._advances:
+                # the real one advances the anchor as it stores
+                self.db.oldest[jid] = page[0]
         else:
             self._exhausted_chats.add(jid)
         return page
 
 
-def _make(pages, oldest=None):
-    stub = _Stub(pages, oldest)
+def _make(pages, oldest=None, advances=True):
+    stub = _Stub(pages, oldest, advances)
     for name in ("deep_backfill_chat", "_oldest_stored_message",
                  "_chats_needing_deep_history", "history_page_target",
-                 "_persist_exhausted_chats"):
-        stub_attr = MainWindow.__dict__[name]
-        setattr(stub, name, types.MethodType(stub_attr, stub))
+                 "_persist_exhausted_chats", "_anchor_identity"):
+        raw = MainWindow.__dict__[name]
+        if isinstance(raw, (staticmethod, classmethod)):
+            setattr(stub, name, getattr(MainWindow, name))
+        else:
+            setattr(stub, name, types.MethodType(raw, stub))
     for const in ("_DEEP_PAGES_PER_VISIT", "_DEEP_PAGE_DELAY",
                   "_DEEP_CHATS_PER_PASS"):
         setattr(stub, const, getattr(MainWindow, const))
@@ -371,3 +380,66 @@ class TestStoreOnlyKeepsNothingResident:
         records = stub.chats["chat@g.us"]["messages"]["messages"]["records"]
         assert len(records) == 3
         assert stub.batched == [("chat@g.us", 2)]
+
+
+class TestAPageThatDoesNotAdvanceTheAnchor:
+    """A full page is not the same thing as progress.
+
+    /get-messages resolves the anchor id inside the page, and when it cannot
+    find it there, deviceController.ts re-anchors on `originalOldestId` — the
+    oldest message the *page* holds — rather than answering empty. Our anchor
+    is read from SQLite, and this walk exists precisely to accumulate history
+    on disk that the page no longer keeps in memory, so the further a chat is
+    walked the likelier that fallback gets. It answers with the span between
+    what we already stored and what the page holds; the messages table's
+    primary key drops every row of it; the anchor stays put.
+
+    Counting that as `stored` is what made it expensive rather than merely
+    useless: _backfill_empty_chats() renews its entire budget on `deep_stored`,
+    so re-reading stored history kept the thread alive and the shared Puppeteer
+    page busy for the whole four-hour ceiling, writing nothing.
+    """
+
+    def test_the_visit_stops_on_the_first_such_page(self):
+        stub = _make([[_msg(3), _msg(4)]] * 10, oldest=_msg(5), advances=False)
+        stub.deep_backfill_chat("chat@g.us")
+        assert len(stub.calls) == 1, (
+            "re-reading the same window four more times is the worst possible "
+            "use of a budget the walk is already short of")
+
+    def test_it_does_not_count_as_progress(self):
+        """The number the backfill loop renews its budget from."""
+        stub = _make([[_msg(3), _msg(4)]] * 10, oldest=_msg(5), advances=False)
+        assert stub.deep_backfill_chat("chat@g.us") == 0
+
+    def test_the_chat_is_not_written_off_either(self):
+        """Nothing was learned about whether history remains — only that this
+        answer was useless. Marking it exhausted would be durable and wrong."""
+        stub = _make([[_msg(3), _msg(4)]] * 10, oldest=_msg(5), advances=False)
+        stub.deep_backfill_chat("chat@g.us")
+        assert "chat@g.us" not in stub._exhausted_chats
+
+    def test_a_walk_that_does_advance_is_untouched(self):
+        """The guard must not fire on the normal path — same case as
+        test_it_pages_until_the_history_runs_out, asserted against the new
+        early exit."""
+        stub = _make([[_msg(3), _msg(4)], [_msg(1), _msg(2)], []], oldest=_msg(5))
+        assert stub.deep_backfill_chat("chat@g.us") == 4
+        assert len(stub.calls) == 3
+
+
+class TestAnchorIdentity:
+    def test_two_messages_in_the_same_second_are_told_apart(self):
+        """get_messages_asc() breaks a timestamp tie on message_id, so the
+        anchor can legitimately move between two messages sharing a second."""
+        a = {"key": {"id": "m1"}, "messageTimestamp": 1_700_000_000}
+        b = {"key": {"id": "m2"}, "messageTimestamp": 1_700_000_000}
+        assert MainWindow._anchor_identity(a) != MainWindow._anchor_identity(b)
+
+    def test_the_same_message_reads_the_same_twice(self):
+        a = {"key": {"id": "m1"}, "messageTimestamp": 1_700_000_000}
+        assert MainWindow._anchor_identity(a) == MainWindow._anchor_identity(dict(a))
+
+    def test_a_missing_reading_does_not_raise(self):
+        assert MainWindow._anchor_identity(None) == (0, "")
+        assert MainWindow._anchor_identity({}) == (0, "")

--- a/tests/test_exhausted_chats_durability.py
+++ b/tests/test_exhausted_chats_durability.py
@@ -1,0 +1,257 @@
+"""Tests for when "this chat has no older history" is allowed to become durable.
+
+fetch_older_messages() writes a chat off when WhatsApp Web answers with an
+empty page. WhatsApp only pushes a bounded window of history to a linked
+device, so an empty page usually means "this device has no more", not "this
+conversation has no more" — hence request_older_messages(), which asks the
+phone. The phone replies with a history-sync chunk *minutes later*, never in
+that response.
+
+The deep backfill revisits a chat roughly 30 seconds after the ask, so the
+second empty page — the one that writes the chat off — arrives an order of
+magnitude before the answer it is judging. That was survivable while
+_exhausted_chats died with the process. Once it was persisted, the same
+premature write-off became permanent: fetch_older_messages() early-returns on
+an exhausted chat, and that early return is shared with the user scrolling up,
+so the conversation stopped loading older messages in every future session,
+with no removal path anywhere in the code and F5 preserving the metadata.
+
+So: mark in memory as eagerly as before (the deep-backfill queue has to drain
+at the same rate), but only persist once the request has had longer than its
+reply window. _older_requested_chats is persisted too, which is what lets the
+bar be cleared on a later launch rather than inside one session.
+
+MainWindow is a wx.Frame and cannot be instantiated without a running wx.App,
+so the method is bound to a plain stub, as elsewhere in this suite.
+"""
+
+import types
+
+import pytest
+
+import main
+from main import MainWindow
+
+
+GRACE = MainWindow._OLDER_REQUEST_GRACE
+JID = "5511999999999@s.whatsapp.net"
+ANCHOR = {"key": {"id": "m1", "remoteJid": JID}, "messageTimestamp": 1_700_000_000}
+
+
+class _DB:
+    def __init__(self):
+        self.metadata = {}
+
+    def set_metadata_json(self, key, value):
+        self.metadata[key] = value
+
+
+class _Response:
+    """An empty 200 — the shape that triggers the write-off branch."""
+
+    status_code = 200
+
+    @staticmethod
+    def json():
+        return {"response": []}
+
+
+class _Stub:
+    def __init__(self, ask_succeeds=True):
+        self.db = _DB()
+        self._exhausted_chats = set()
+        self._older_requested_chats = {}
+        self._phone_to_lid = {}
+        self._lid_to_phone = {}
+        self.settings = {"user_interface": {"messages_page_size": 200}}
+        self.wpp_server = "http://127.0.0.1"
+        self.wpp_port = 6300
+        self.token = "tok"
+        self.ws = None
+        self._ask_succeeds = ask_succeeds
+        self.asks = []
+
+    def request_older_messages(self, jid, timeout=60):
+        self.asks.append(jid)
+        return self._ask_succeeds
+
+    def _resolve_jid_for_msg_key(self, jid):
+        return jid
+
+    def _serialize_msg_id(self, jid, key):
+        return f"false_{jid}_{key.get('id', '')}"
+
+
+def _make(ask_succeeds=True):
+    stub = _Stub(ask_succeeds)
+    for name in ("fetch_older_messages", "_persist_exhausted_chats",
+                 "_persist_older_requested", "_forget_history_exhaustion",
+                 "_normalize_jid"):
+        raw = MainWindow.__dict__[name]
+        if isinstance(raw, (staticmethod, classmethod)):
+            setattr(stub, name, getattr(MainWindow, name))
+        else:
+            setattr(stub, name, types.MethodType(raw, stub))
+    stub._OLDER_REQUEST_GRACE = MainWindow._OLDER_REQUEST_GRACE
+    return stub
+
+
+@pytest.fixture(autouse=True)
+def _empty_page(monkeypatch):
+    monkeypatch.setattr(main.requests, "get", lambda *a, **kw: _Response())
+
+
+class TestTheFirstEmptyPage:
+    def test_it_asks_the_phone_and_writes_nothing_off(self):
+        """Unchanged behaviour: the ask goes out and the chat stays
+        re-queryable so the reply can be picked up."""
+        stub = _make()
+        stub.fetch_older_messages(JID, ANCHOR)
+        assert stub.asks == [JID]
+        assert JID not in stub._exhausted_chats
+        assert "exhausted_chats" not in stub.db.metadata
+
+    def test_the_ask_is_recorded_and_persisted(self):
+        """The timestamp is the whole mechanism: an empty page can only be
+        judged against how long ago the phone was asked, and that has to
+        outlive the session."""
+        stub = _make()
+        stub.fetch_older_messages(JID, ANCHOR)
+        assert JID in stub._older_requested_chats
+        assert JID in stub.db.metadata["older_history_requested"]
+
+
+class TestTheSecondEmptyPageInsideTheReplyWindow:
+    """The captured failure: a backfill pass revisits the chat ~30 s after the
+    ask, long before the phone's history-sync chunk lands."""
+
+    def test_it_marks_in_memory_so_the_queue_still_drains(self):
+        stub = _make()
+        stub.fetch_older_messages(JID, ANCHOR)          # asks
+        stub.fetch_older_messages(JID, ANCHOR)          # 30 s later, still empty
+        assert JID in stub._exhausted_chats, (
+            "the deep-backfill queue must drain at the same rate it always did")
+
+    def test_it_does_NOT_persist(self):
+        stub = _make()
+        stub.fetch_older_messages(JID, ANCHOR)
+        stub.fetch_older_messages(JID, ANCHOR)
+        assert "exhausted_chats" not in stub.db.metadata, (
+            "a write-off made inside the reply window must not outlive the "
+            "session — it is what silently killed scroll-up for good")
+
+    def test_the_phone_is_not_asked_twice(self):
+        stub = _make()
+        stub.fetch_older_messages(JID, ANCHOR)
+        stub.fetch_older_messages(JID, ANCHOR)
+        assert stub.asks == [JID]
+
+
+class TestOnceTheReplyWindowHasPassed:
+    """The next launch: _older_requested_chats came back from metadata, so the
+    ask is provably older than anything the phone still owes."""
+
+    def test_it_persists(self, monkeypatch):
+        stub = _make()
+        stub._older_requested_chats[JID] = main.time.time() - (GRACE + 1)
+        stub.fetch_older_messages(JID, ANCHOR)
+        assert JID in stub._exhausted_chats
+        assert stub.db.metadata["exhausted_chats"] == [JID]
+
+    def test_a_legacy_entry_counts_as_asked_long_ago(self):
+        """prepare_sync maps the old list form to timestamp 0.0 — those asks
+        were made by an earlier run, which is exactly the evidence wanted."""
+        stub = _make()
+        stub._older_requested_chats[JID] = 0.0
+        stub.fetch_older_messages(JID, ANCHOR)
+        assert stub.db.metadata["exhausted_chats"] == [JID]
+
+    def test_an_exhausted_chat_is_never_queried_again(self):
+        """Unchanged, and the reason the write-off has to be right: this early
+        return is shared with the user scrolling up, not just the backfill."""
+        stub = _make()
+        stub._exhausted_chats.add(JID)
+        assert stub.fetch_older_messages(JID, ANCHOR) == []
+        assert stub.asks == []
+
+
+class TestAFailedAskIsNotDurableEvidenceEither:
+    def test_a_request_that_never_went_out_marks_only_in_memory(self):
+        """request_older_messages() returning False covers a 60 s timeout and a
+        dropped connection. Its own docstring calls this out as writing off
+        exactly the chats that still have history coming."""
+        stub = _make(ask_succeeds=False)
+        stub.fetch_older_messages(JID, ANCHOR)
+        assert JID in stub._exhausted_chats
+        assert "exhausted_chats" not in stub.db.metadata
+
+
+class TestTheUserCanUndoIt:
+    """F5 keeps system_metadata so local cleared/archived/muted state survives.
+    These two entries must not ride along on that — they are a cached
+    conclusion about WhatsApp Web, and F5 is the only escape from one that was
+    reached wrongly."""
+
+    def test_the_resync_forgets_the_exhausted_set(self):
+        stub = _make()
+        stub._exhausted_chats.add(JID)
+        stub._older_requested_chats[JID] = 1.0
+        stub._forget_history_exhaustion()
+        assert stub._exhausted_chats == set()
+        assert stub._older_requested_chats == {}
+
+    def test_it_clears_the_persisted_copies_too(self):
+        """Only clearing memory would let prepare_sync() bring them straight
+        back on the next launch."""
+        stub = _make()
+        stub._exhausted_chats.add(JID)
+        stub._older_requested_chats[JID] = 1.0
+        stub._forget_history_exhaustion()
+        assert stub.db.metadata["exhausted_chats"] == []
+        assert stub.db.metadata["older_history_requested"] == {}
+
+    def test_the_chat_is_queryable_again_afterwards(self):
+        stub = _make()
+        stub._exhausted_chats.add(JID)
+        stub._forget_history_exhaustion()
+        stub.fetch_older_messages(JID, ANCHOR)
+        assert stub.asks == [JID], "the early return must be gone"
+
+    def test_the_resync_worker_actually_calls_it(self):
+        """The helper working is not the same as it being wired up, and
+        _resync_all_worker() is all wx teardown — it cannot be bound to a stub
+        the way the rest of this file is. Two commits on this branch already
+        shipped a defence that no test reached; read the call out of the source
+        instead of leaving the wiring uncovered.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        # getsource() on a method keeps its class indentation, which ast
+        # rejects on its own.
+        tree = ast.parse(textwrap.dedent(
+            inspect.getsource(MainWindow._resync_all_worker)))
+        called = {
+            node.func.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        assert "_forget_history_exhaustion" in called, (
+            "F5 must forget the exhausted set, or a wrongly walked-out chat has "
+            "no escape at all")
+        assert "clear_local_data" in called, "premise check: this is still the F5 worker"
+
+
+class TestTheGraceIsNotSoLongItStopsPersistingAtAll:
+    def test_a_genuinely_finished_chat_still_becomes_durable(self):
+        """The point of persisting at all: an account already walked to its
+        beginning must not be re-walked on every relaunch."""
+        stub = _make()
+        stub.fetch_older_messages(JID, ANCHOR)
+        # …relaunch: the map came back from metadata, the clock moved on.
+        reborn = _make()
+        reborn._older_requested_chats = {
+            j: t - (GRACE + 60) for j, t in stub._older_requested_chats.items()}
+        reborn.fetch_older_messages(JID, ANCHOR)
+        assert reborn.db.metadata["exhausted_chats"] == [JID]

--- a/tests/test_mentions_scan_refresh.py
+++ b/tests/test_mentions_scan_refresh.py
@@ -1,0 +1,159 @@
+"""Tests for the single chat-list refresh at the end of the mentions scan.
+
+The scan walks every message of every chat, so the per-mapping refresh
+register_jid_mapping() normally schedules is a rebuild storm — the same one
+resolve_lid_jids_via_api() had. It therefore passes defer_ui=True and owes the
+list exactly one refresh when it finishes.
+
+That refresh is gated on `updated_contacts or mapped`, and `mapped` is there
+for one case in particular: a scan that learned @lid <-> phone mappings but
+changed no contact record. The gate was written *inside* `if phones_to_resolve:`,
+which made it unreachable in precisely that case — the two are fed by unrelated
+passes. `mapped` counts pairs found on `key.remoteJidAlt` while walking the
+messages; `phones_to_resolve` holds *mentioned* phone JIDs that still need a
+name. A scan that learns mappings, needs no @lid lookup (so
+resolve_lid_jids_via_api()'s own unconditional refresh never fires) and finds no
+unnamed mention refreshed nothing at all, and the list kept showing raw @lid
+until something unrelated happened to rebuild it.
+
+MainWindow is a wx.Frame and cannot be instantiated without a running wx.App,
+so the method is bound to a plain stub, as elsewhere in this suite.
+"""
+
+import types
+
+import pytest
+
+import main
+from main import MainWindow
+
+
+LID = "111222333444555@lid"
+PHONE = "5511999999999@s.whatsapp.net"
+
+
+def _chat_with_alt(lid=LID, alt=PHONE):
+    """A stored message carrying the @lid <-> phone bridge in its own key —
+    the shape that needs no API lookup at all."""
+    return {
+        "remoteJid": lid,
+        "messages": {"messages": {"records": [
+            {"key": {"id": "m1", "remoteJid": lid, "remoteJidAlt": alt}},
+        ]}},
+    }
+
+
+class _Stub:
+    def __init__(self, chats):
+        self.chats = chats
+        self.contacts = {}
+        self._lid_to_phone = {}
+        self._phone_to_lid = {}
+        self.refreshes = 0
+        self.message_refreshes = 0
+        self.mapped_calls = []
+        self.resolved_lid_batches = []
+        self.profile_lookups = []
+
+    # ── what the scan calls out to ───────────────────────────────────
+    def register_jid_mapping(self, lid_jid, phone_jid, save=True, defer_ui=False):
+        self.mapped_calls.append((lid_jid, phone_jid, defer_ui))
+        self._lid_to_phone[lid_jid] = phone_jid
+
+    def resolve_lid_jids_via_api(self, jids):
+        # The real one ends with an unconditional refresh of its own; that is
+        # exactly why it must not be what this test relies on.
+        self.resolved_lid_batches.append(list(jids))
+
+    def get_contact_profile(self, jid):
+        self.profile_lookups.append(jid)
+        return {"response": {"name": "Alguém"}}
+
+    def _learn_sender_names_bulk(self, records):
+        pass
+
+    def _needs_sender_resolution(self, jid):
+        return False
+
+    def _normalize_jid(self, jid):
+        return jid
+
+    def _schedule_set_chats(self):
+        self.refreshes += 1
+
+    def _schedule_refresh_active_messages(self):
+        self.message_refreshes += 1
+
+
+def _make(chats):
+    stub = _Stub(chats)
+    stub.scan_all_cached_messages_for_mentions = types.MethodType(
+        MainWindow.__dict__["scan_all_cached_messages_for_mentions"], stub)
+    return stub
+
+
+@pytest.fixture(autouse=True)
+def _inline(monkeypatch):
+    """The scan runs on its own thread and sleeps 3 s before starting."""
+    monkeypatch.setattr(main.time, "sleep", lambda *_a: None)
+    monkeypatch.setattr(main.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+    monkeypatch.setattr(
+        main.threading, "Thread",
+        lambda target=None, **kw: types.SimpleNamespace(start=lambda: target and target()))
+
+
+class TestAScanThatOnlyLearnsMappings:
+    """No @lid needs the API, no mention needs a name — the case `mapped`
+    exists for, and the one the misplaced gate could not reach."""
+
+    def test_it_refreshes_the_chat_list(self):
+        stub = _make({LID: _chat_with_alt()})
+        stub.scan_all_cached_messages_for_mentions()
+        assert stub._lid_to_phone[LID] == PHONE, "the mapping itself must be learned"
+        assert stub.refreshes == 1, (
+            "the per-mapping refreshes were deferred, so this one is the only "
+            "thing standing between a learned name and a list still showing @lid")
+
+    def test_it_refreshes_the_open_conversation_too(self):
+        stub = _make({LID: _chat_with_alt()})
+        stub.scan_all_cached_messages_for_mentions()
+        assert stub.message_refreshes == 1
+
+    def test_nothing_was_resolved_through_the_api(self):
+        """Pins the premise: this scan never reaches
+        resolve_lid_jids_via_api(), whose own unconditional refresh would
+        otherwise mask the bug."""
+        stub = _make({LID: _chat_with_alt()})
+        stub.scan_all_cached_messages_for_mentions()
+        assert stub.resolved_lid_batches == []
+        assert stub.profile_lookups == []
+
+    def test_the_mappings_are_learned_with_the_ui_deferred(self):
+        stub = _make({LID: _chat_with_alt()})
+        stub.scan_all_cached_messages_for_mentions()
+        assert stub.mapped_calls == [(LID, PHONE, True)]
+
+
+class TestAScanWithNothingToLearn:
+    def test_it_does_not_refresh(self):
+        """The gate still gates: an idle scan must not schedule a rebuild of a
+        935-chat list for nothing."""
+        stub = _make({PHONE: {"remoteJid": PHONE,
+                              "messages": {"messages": {"records": []}}}})
+        stub.scan_all_cached_messages_for_mentions()
+        assert stub.refreshes == 0
+        assert stub.message_refreshes == 0
+
+    def test_a_mapping_already_known_is_not_relearned(self):
+        stub = _make({LID: _chat_with_alt()})
+        stub._lid_to_phone[LID] = PHONE
+        stub.scan_all_cached_messages_for_mentions()
+        assert stub.mapped_calls == []
+        assert stub.refreshes == 0
+
+
+class TestTheEmptyAccount:
+    def test_no_chats_at_all_is_not_an_error(self):
+        stub = _make({})
+        stub.scan_all_cached_messages_for_mentions()
+        assert stub.refreshes == 0


### PR DESCRIPTION
… âncora parada

Revisão dos commits 18944e4 e 5848374. Os três são independentes entre si; vão juntos porque tocam o mesmo arquivo.

1. _exhausted_chats persistido escrevia conversas como perdidas para sempre

5848374 passou a persistir _exhausted_chats, e com isso removeu o limite que tornava tolerável uma marcação prematura que já existia. O docstring de request_older_messages() descrevia o risco e o delimitava a "this session"; não delimita mais.

A marcação acontece quando a página volta vazia e o pedido ao celular já foi feito. Só que o celular responde com um chunk de history-sync minutos depois, e o backfill revisita a conversa ~30 s após o pedido (_BACKFILL_FIRST_DELAY): a segunda página vazia — a que escreve a conversa como perdida — chega uma ordem de grandeza antes da resposta que ela está julgando.

Como fetch_older_messages() faz early-return no topo para conversa exausta, e esse early-return é compartilhado com a rolagem manual do usuário, o resultado era rolar para cima e não receber nada, em toda sessão futura. Não havia nenhum caminho de remoção no código (só .add), e o F5 preserva system_metadata, então nem o gesto natural do usuário corrigia.

- _older_requested_chats vira dict {jid: timestamp} e passa a ser persistido. É o que permite distinguir "página vazia" de "página vazia que já sobreviveu à janela de resposta" — nada dentro de uma sessão estabelece isso.
- _OLDER_REQUEST_GRACE (15 min) separa as duas. A marcação em memória continua imediata, para a fila do backfill profundo drenar no mesmo ritmo de antes; só a gravação durável espera. Na prática a barra é vencida no lançamento seguinte: custa uma caminhada extra de uma conta já completa.
- _forget_history_exhaustion(), chamado pelo F5. "Histórico esgotado" é conclusão sobre o WhatsApp Web, não estado do usuário, e as mensagens que ela bloqueia acabaram de ser apagadas pelo próprio resync. É também a única saída de uma conclusão errada, e "sincronizar tudo" é onde o usuário procuraria. Extraído de _resync_all_worker() porque aquele método é todo desmontagem de UI e não roda sem wx.App.
- Docstring de request_older_messages() e a linha de log que ainda dizia "in-memory" corrigidos.

2. O refresh de fim do scan de menções estava inalcançável

18944e4 adicionou o contador `mapped` para cobrir o caso "aprendeu mapeamentos mas nenhum contato mudou", e pôs a guarda dentro de `if phones_to_resolve:`. Os dois são alimentados por passagens sem relação: `mapped` conta pares @lid <-> telefone achados em key.remoteJidAlt ao caminhar as mensagens, phones_to_resolve guarda JIDs mencionados que ainda precisam de nome.

Um scan que aprende mapeamentos, não precisa de lookup de @lid (então o refresh incondicional de resolve_lid_jids_via_api() não dispara) e não acha menção sem nome não fazia refresh nenhum — e com os refreshes por mapeamento deferidos pelo mesmo commit, a lista seguia mostrando @lid cru até algo sem relação reconstruí-la.

updated_contacts sobe para antes do `if`, sem o que a desindentação trocaria o bug silencioso por um NameError no exato caminho que a correção quer cobrir.

3. Página cheia era contada como progresso mesmo sem avançar a âncora

deep_backfill_chat() somava len(page) em `stored`, e _backfill_empty_chats() renova todo o orçamento quando deep_stored > 0. Uma página inteiramente duplicada grava zero linhas (chave primária) e mesmo assim somava 200.

Não é hipotético. /get-messages resolve o id da âncora dentro da página, e quando não acha, deviceController.ts reancora de propósito em `originalOldestId` — a mensagem mais antiga que a página tem carregada — em vez de responder vazio. Nossa âncora vem do SQLite, e esta caminhada existe para acumular em disco histórico que a página não mantém mais em memória: quanto mais uma conversa é caminhada, mais provável fica o fallback. Ele responde a faixa entre o que já gravamos e o que a página tem, o banco descarta tudo, a âncora não anda, e a mesma janela volta — cinco vezes por visita, todo passe, renovando o orçamento de 4 horas sem gravar uma mensagem.

_anchor_identity() compara (timestamp, key.id) antes e depois de gravar — identidade e não ordem porque get_messages_asc desempata segundo igual pelo message_id. Âncora parada encerra a visita e não conta em `stored`. A conversa não é marcada como exausta nesse caminho: nada foi aprendido sobre haver mais histórico, só que aquela resposta foi inútil.

Isso protege o cliente de uma resposta errada; não conserta a resposta errada. Se aparecer relato de "sincronizando para sempre" sem o histórico crescer, o diagnóstico é grep "Anchor not found after walkback" no log.log — o controlador já loga a decisão e o console da página já é espelhado para lá.

Testes: 2589 passando. Cada defesa conferida por sabotagem em separado — a janela de carência (2 testes caem), o aninhamento do refresh (2), a fiação do F5 (1), a guarda de avanço da âncora (2). A fiação do F5 é lida da fonte por AST porque testar o helper isolado não a alcança, que é como duas defesas passaram sem cobertura nos commits que esta revisão examinou.