### PR TITLE
fix: ignora chamadas antigas ao iniciar

### DIFF
--- a/client/api_patches/src/util/createSessionUtil.ts
+++ b/client/api_patches/src/util/createSessionUtil.ts
@@ -848,36 +848,36 @@ export default class CreateSessionUtil {
               try {
               const chatId = evt?.chat?.id?._serialized || evt?.chat?.id;
               if (!chatId) return;
-              // The count this chat held BEFORE the change, forwarded so the
-              // client can tell a real read apart from a meaningless zero.
-              // A chat merely being loaded into the Store reports unreadCount=0
-              // with nothing behind it, and is indistinguishable from "the user
-              // just read this chat on their phone" unless you know whether the
-              // count actually fell from something.
-              //
-              // Measured against a live session: the field really is a plain
-              // number, matching wa-js's own typing. Three consecutive messages
-              // in one group came through as unreadCount 1/2/3 with
-              // previousUnreadCount 0/1/2 — tracking exactly one step behind.
-              // The suspicion it might be Backbone's options object (wa-js
-              // emits it straight from the Store's `change:unreadCount`
-              // callback, whose third argument is options in every other
-              // handler of that shape) did not hold. The `.previous()` fallback
-              // stays anyway: it costs nothing, and it is what keeps this
-              // working if a future wa-js changes the payload — silently, since
-              // nothing else here would notice. Neither being a number sends
-              // null, and the client then keeps its own conservative count.
-              // Deriving `previous` must never be able to suppress the event
-              // itself: the unread count is the payload that matters and the
-              // previous value is an extra, so it is computed defensively and
-              // the emit happens regardless. Reading `.previous` off a Store
-              // model is a property access on foreign, minified code that can
-              // throw or be a getter with side effects, and a throw anywhere in
-              // this callback silently takes the whole listener down — the
-              // client then stops being told about unread counts at all, with
-              // nothing in any log to say so. Measured, not hypothetical: an
-              // earlier version of this block computed `previous` inline and
-              // the chats-update stream stopped dead.
+                  // The count this chat held BEFORE the change, forwarded so the
+                  // client can tell a real read apart from a meaningless zero.
+                  // A chat merely being loaded into the Store reports unreadCount=0
+                  // with nothing behind it, and is indistinguishable from "the user
+                  // just read this chat on their phone" unless you know whether the
+                  // count actually fell from something.
+                  //
+                  // Measured against a live session: the field really is a plain
+                  // number, matching wa-js's own typing. Three consecutive messages
+                  // in one group came through as unreadCount 1/2/3 with
+                  // previousUnreadCount 0/1/2 — tracking exactly one step behind.
+                  // The suspicion it might be Backbone's options object (wa-js
+                  // emits it straight from the Store's `change:unreadCount`
+                  // callback, whose third argument is options in every other
+                  // handler of that shape) did not hold. The `.previous()` fallback
+                  // stays anyway: it costs nothing, and it is what keeps this
+                  // working if a future wa-js changes the payload — silently, since
+                  // nothing else here would notice. Neither being a number sends
+                  // null, and the client then keeps its own conservative count.
+                  // Deriving `previous` must never be able to suppress the event
+                  // itself: the unread count is the payload that matters and the
+                  // previous value is an extra, so it is computed defensively and
+                  // the emit happens regardless. Reading `.previous` off a Store
+                  // model is a property access on foreign, minified code that can
+                  // throw or be a getter with side effects, and a throw anywhere in
+                  // this callback silently takes the whole listener down — the
+                  // client then stops being told about unread counts at all, with
+                  // nothing in any log to say so. Measured, not hypothetical: an
+                  // earlier version of this block computed `previous` inline and
+                  // the chats-update stream stopped dead.
               let previous: any = null;
               try {
                 const raw = evt?.previousUnreadCount;
@@ -985,7 +985,9 @@ export default class CreateSessionUtil {
           callId: string,
           isVideo: boolean,
           isGroup: boolean,
-          groupJid: string
+          groupJid: string,
+          callTimestamp: number,
+          observedAt: number
         ) => {
           req.io.emit('incomingcall', {
             session: client.session,
@@ -997,6 +999,8 @@ export default class CreateSessionUtil {
               isVideo: isVideo,
               isGroup: isGroup,
               groupJid: groupJid,
+              timestamp: callTimestamp,
+              observedAt: observedAt,
             },
           });
         }
@@ -1008,8 +1012,12 @@ export default class CreateSessionUtil {
     }
 
     const installListener = () => {
+      // CallStore is hydrated from persisted WhatsApp Web state at startup.
+      // Its `add` event therefore does not necessarily mean "a call started
+      // now". Refresh the boundary on every page load and reject older calls.
+      const listenerStartedAt = Date.now();
       client.page
-        .evaluate(() => {
+        .evaluate((listenerStartedAt: number) => {
           const WPP = (window as any).WPP;
           if (
             !WPP ||
@@ -1024,6 +1032,8 @@ export default class CreateSessionUtil {
           // live in CallStore, and some WhatsApp builds mutate them without
           // firing the expected Backbone event, so retain and poll by call id.
           const trackedCalls = new Map<string, any>();
+          const ignoredHistoricalCallIds = new Set<string>();
+          const CALL_START_GRACE_MS = 5000;
           const stores = [
             WPP?.whatsapp?.CallStore,
             WPP?.whatsapp?.CallCollection,
@@ -1063,6 +1073,48 @@ export default class CreateSessionUtil {
             };
             return numericStates[raw] || raw;
           };
+          const callTimestampOf = (call: any) => {
+            const raw =
+              call?.offerTime ??
+              call?.timestamp ??
+              call?.t ??
+              call?.startTime ??
+              call?.createdAt ??
+              call?.get?.('offerTime') ??
+              call?.get?.('timestamp') ??
+              call?.get?.('t') ??
+              0;
+            const numeric = Number(raw);
+            if (!Number.isFinite(numeric) || numeric <= 0) return 0;
+            if (numeric >= 1e15) return Math.floor(numeric / 1000);
+            if (numeric >= 1e12) return Math.floor(numeric);
+            if (numeric >= 1e9) return Math.floor(numeric * 1000);
+            return 0;
+          };
+          const isHistoricalIncomingCall = (call: any, source: string) => {
+            const id = callIdOf(call);
+            if (id && ignoredHistoricalCallIds.has(id)) return true;
+            const timestamp = callTimestampOf(call);
+            const receivedWhileOffline =
+              call?.offerReceivedWhileOffline === true ||
+              call?.get?.('offerReceivedWhileOffline') === true;
+            const predatesListener =
+              timestamp > 0 &&
+              timestamp < listenerStartedAt - CALL_START_GRACE_MS;
+            // A timestamp-less Store add is ambiguous because this collection
+            // also hydrates persisted models. Fail closed; the public event
+            // still covers a genuine live call when WA-JS provides it.
+            const timestampLessStoreEvent = !timestamp && source === 'store';
+            if (
+              receivedWhileOffline ||
+              predatesListener ||
+              timestampLessStoreEvent
+            ) {
+              if (id) ignoredHistoricalCallIds.add(id);
+              return true;
+            }
+            return false;
+          };
           const emitCall = (event: string, call: any, state = '') => {
             const peerJid =
               call?.peerJid?._serialized ||
@@ -1080,12 +1132,14 @@ export default class CreateSessionUtil {
               callIdOf(call),
               !!call?.isVideo || !!call?.isVideoCall,
               !!call?.isGroup || !!call?.isGroupCall,
-              groupJidOf(call)
+              groupJidOf(call),
+              Math.floor(callTimestampOf(call) / 1000),
+              Math.floor(Date.now() / 1000)
             );
           };
           const rememberCall = (call: any) => {
             const id = callIdOf(call);
-            if (!id) return;
+            if (!id || ignoredHistoricalCallIds.has(id)) return;
             const previous = trackedCalls.get(id) || {};
             trackedCalls.set(id, {
               call: call || previous.call,
@@ -1109,15 +1163,21 @@ export default class CreateSessionUtil {
             }
             return null;
           };
-          const emitIncomingOffer = (call: any, attempt = 0) => {
+          const emitIncomingOffer = (
+            call: any,
+            attempt = 0,
+            source = 'wpp'
+          ) => {
             const id = callIdOf(call);
             const richCall = findCall(id) || call;
+            if (isHistoricalIncomingCall(richCall, source)) return;
             const isGroup = !!richCall?.isGroup || !!richCall?.isGroupCall;
             if (isGroup && !groupJidOf(richCall) && attempt < 10) {
               window.setTimeout(() => {
                 // A terminal Store event removes this id. Do not resurrect a
                 // call that ended while we were waiting for group metadata.
-                if (trackedCalls.has(id)) emitIncomingOffer(call, attempt + 1);
+                if (trackedCalls.has(id))
+                  emitIncomingOffer(call, attempt + 1, source);
               }, 100);
               return;
             }
@@ -1131,13 +1191,14 @@ export default class CreateSessionUtil {
           try {
             WPP.on('call.incoming_call', (call: any) => {
               try {
+                if (isHistoricalIncomingCall(call, 'wpp')) return;
                 rememberCall(call);
                 // The public WA-JS event can be a reduced object: it says the
                 // call is a group call but omits groupJid. CallStore's model
                 // contains the group id, so briefly wait for it before
                 // announcing. The direct Store listener may win this race;
                 // Python deduplicates both events by call id.
-                emitIncomingOffer(call);
+                emitIncomingOffer(call, 0, 'wpp');
               } catch (e) {
                 // Never let one event kill the listener
               }
@@ -1163,6 +1224,8 @@ export default class CreateSessionUtil {
                       !call?.outgoing;
                     if (!isIncoming) return;
 
+                    if (isHistoricalIncomingCall(call, 'store')) return;
+
                     const initialState = String(call?.getState?.() || 'INCOMING_RING');
                     emitCall('offer', call, initialState);
                     rememberCall(call);
@@ -1172,6 +1235,14 @@ export default class CreateSessionUtil {
                 });
                 const onStateChange = (call: any) => {
                   try {
+                    const id = callIdOf(call);
+                    if (ignoredHistoricalCallIds.has(id)) {
+                      const ignoredState = callStateOf(call);
+                      if (ignoredState && ignoredState !== 'INCOMING_RING') {
+                        ignoredHistoricalCallIds.delete(id);
+                      }
+                      return;
+                    }
                     const nextState = callStateOf(call);
                     if (!nextState) return;
                     emitCall('state', call, nextState);
@@ -1187,6 +1258,8 @@ export default class CreateSessionUtil {
                 store.on('change', onStateChange);
                 store.on('remove', (call: any) => {
                   try {
+                    const id = callIdOf(call);
+                    if (ignoredHistoricalCallIds.delete(id)) return;
                     emitCall('ended', call, 'ENDED');
                     trackedCalls.delete(callIdOf(call));
                   } catch (e) {
@@ -1235,7 +1308,7 @@ export default class CreateSessionUtil {
               }
             }
           }, 500);
-        })
+        }, listenerStartedAt)
         .catch((e: any) =>
           req.logger.warn(
             `[onIncomingCallDirect] install failed: ${e?.message || e}`
@@ -1302,6 +1375,8 @@ export default class CreateSessionUtil {
   }
 
   async listenMessages(client: WhatsAppServer, req: Request) {
+    const incomingCallListenerStartedAt = Date.now();
+
     await client.onMessage(async (message: any) => {
       eventEmitter.emit(`mensagem-${client.session}`, client, message);
       callWebHook(client, req, 'onmessage', message);
@@ -1355,7 +1430,33 @@ export default class CreateSessionUtil {
     });
 
     await client.onIncomingCall(async (call) => {
-      req.io.emit('incomingcall', { ...call, session: client.session });
+      const rawOfferTime = Number((call as any)?.offerTime || 0);
+      const offerTimeMs =
+        rawOfferTime >= 1e15
+          ? Math.floor(rawOfferTime / 1000)
+          : rawOfferTime >= 1e12
+          ? Math.floor(rawOfferTime)
+          : rawOfferTime >= 1e9
+          ? Math.floor(rawOfferTime * 1000)
+          : 0;
+      const receivedWhileOffline =
+        (call as any)?.offerReceivedWhileOffline === true;
+      const predatesListener =
+        offerTimeMs > 0 && offerTimeMs < incomingCallListenerStartedAt - 5000;
+
+      if (receivedWhileOffline || predatesListener) {
+        req.logger.info(
+          '[incomingcall] ignored historical offer from WhatsApp state hydration'
+        );
+        return;
+      }
+
+      req.io.emit('incomingcall', {
+        ...call,
+        session: client.session,
+        timestamp: offerTimeMs ? Math.floor(offerTimeMs / 1000) : 0,
+        observedAt: Math.floor(Date.now() / 1000),
+      });
       callWebHook(client, req, 'incomingcall', call);
     });
   }

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -1446,12 +1446,42 @@ class WebSocketClient:
         except Exception:
             logging.exception("[WebSocketClient] on_wpp_reaction error")
 
+    @staticmethod
+    def _call_timestamp_seconds(value):
+        """Normalize WhatsApp call timestamps to epoch seconds.
+
+        The public IncomingCall contract uses seconds, but internal CallStore
+        models and custom bridges may expose milliseconds or microseconds.
+        Invalid/relative values intentionally become zero so they cannot be
+        mistaken for a trustworthy session-age signal.
+        """
+        if isinstance(value, bool):
+            return 0
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return 0
+        if numeric >= 1_000_000_000_000_000:
+            numeric /= 1_000_000
+        elif numeric >= 1_000_000_000_000:
+            numeric /= 1_000
+        if numeric < 1_000_000_000:
+            return 0
+        return int(numeric)
+
     def on_wpp_incoming_call(self, data):
         """Forward WPPConnect call lifecycle events to the wx main thread."""
         try:
             if not isinstance(data, dict) or not self._belongs_to_this_session(data):
                 return
             payload = data.get("data") if isinstance(data.get("data"), dict) else data
+            call_timestamp = self._call_timestamp_seconds(
+                payload.get("timestamp")
+                or payload.get("offerTime")
+                or payload.get("t")
+                or payload.get("startTime")
+            )
+            observed_at = self._call_timestamp_seconds(payload.get("observedAt"))
             normalized = {
                 "event": str(payload.get("event") or payload.get("status") or "offer"),
                 "state": str(payload.get("state") or ""),
@@ -1462,6 +1492,11 @@ class WebSocketClient:
                 "groupJid": self._clean_jid(payload.get("groupJid")),
                 "isVideo": bool(payload.get("isVideo", False)),
                 "isGroup": bool(payload.get("isGroup", False)),
+                "timestamp": call_timestamp,
+                "observedAt": observed_at,
+                "receivedWhileOffline": bool(
+                    payload.get("offerReceivedWhileOffline", False)
+                ),
             }
             if not normalized["id"] and not normalized["peerJid"]:
                 logging.warning("[WebSocketClient] incomingcall without id or peer: %r", data)

--- a/client/main.py
+++ b/client/main.py
@@ -3972,6 +3972,10 @@ class MainWindow(wx.Frame):
         "", "3", "8", "OFFER", "INCOMING_RING", "RINGING",
     })
     _CALL_ALERT_MAX_SECONDS = 120
+    # A call may start a few seconds before the local socket/listener finishes
+    # connecting. Keep that startup race valid, but never alert for an offer
+    # whose WhatsApp timestamp clearly predates this WinZapp session.
+    _CALL_EVENT_START_GRACE_SECONDS = 5
 
     def _cancel_incoming_call_watchdog(self, identity: str):
         timer = self._incoming_call_watchdogs.pop(identity, None)
@@ -4091,6 +4095,33 @@ class MainWindow(wx.Frame):
         is_ringing = state in self._CALL_RINGING_STATES and (
             bool(state) or event_name in ("offer", "ringing", "incoming")
         )
+
+        if is_ringing:
+            try:
+                call_timestamp = int(event.get("timestamp") or 0)
+            except (TypeError, ValueError):
+                call_timestamp = 0
+            try:
+                session_started_at = float(getattr(self, "_wa_startup_time", 0) or 0)
+            except (TypeError, ValueError):
+                session_started_at = 0
+            received_while_offline = bool(event.get("receivedWhileOffline", False))
+            predates_session = (
+                call_timestamp > 0
+                and session_started_at > 0
+                and call_timestamp
+                < session_started_at - self._CALL_EVENT_START_GRACE_SECONDS
+            )
+            if received_while_offline or predates_session:
+                logging.info(
+                    "[incoming_call] ignoring historical offer id=%s "
+                    "call_ts=%s session_started=%.0f offline=%s",
+                    call_id,
+                    call_timestamp,
+                    session_started_at,
+                    received_while_offline,
+                )
+                return
 
         # State changes away from INCOMING_RING mean the call was answered on
         # another device, rejected, missed, failed, or otherwise ended.

--- a/tests/test_incoming_call_alert.py
+++ b/tests/test_incoming_call_alert.py
@@ -62,6 +62,7 @@ class _I18n:
 
 class _MainStub:
     _CALL_RINGING_STATES = MainWindow._CALL_RINGING_STATES
+    _CALL_EVENT_START_GRACE_SECONDS = MainWindow._CALL_EVENT_START_GRACE_SECONDS
     _normalize_jid = staticmethod(MainWindow._normalize_jid)
     _group_name_from_chat_dict = staticmethod(MainWindow._group_name_from_chat_dict)
     on_incoming_call_event = MainWindow.on_incoming_call_event
@@ -90,6 +91,7 @@ class _MainStub:
         self.wpp_server = "http://127.0.0.1"
         self.wpp_port = 6300
         self.token = "session-token"
+        self._wa_startup_time = 2_000_000_000
 
     def _arm_incoming_call_watchdog(self, identity):
         self.armed_watchdogs.append(identity)
@@ -141,6 +143,43 @@ def test_disabled_call_alerts_ignore_new_offer():
     stub.on_incoming_call_event(_offer())
 
     assert stub.announcements == []
+    assert stub.call_incoming_sound.play_calls == 0
+    assert stub._active_incoming_calls == {}
+
+
+def test_offer_from_before_current_session_is_ignored():
+    stub = _MainStub()
+    event = _offer()
+    event["timestamp"] = int(stub._wa_startup_time) - 60
+
+    stub.on_incoming_call_event(event)
+
+    assert stub.announcements == []
+    assert stub.call_incoming_sound.play_calls == 0
+    assert stub._active_incoming_calls == {}
+
+
+def test_offer_inside_startup_grace_is_still_live():
+    stub = _MainStub()
+    event = _offer()
+    event["timestamp"] = int(stub._wa_startup_time) - 3
+
+    stub.on_incoming_call_event(event)
+
+    assert stub.call_incoming_sound.play_calls == 1
+    assert set(stub._active_incoming_calls) == {"call-1"}
+
+
+def test_offer_received_while_offline_is_ignored_even_if_recent():
+    stub = _MainStub()
+    event = _offer()
+    event.update({
+        "timestamp": int(stub._wa_startup_time) + 1,
+        "receivedWhileOffline": True,
+    })
+
+    stub.on_incoming_call_event(event)
+
     assert stub.call_incoming_sound.play_calls == 0
     assert stub._active_incoming_calls == {}
 
@@ -267,6 +306,7 @@ def test_websocket_normalizes_nested_call_payload(monkeypatch):
     )
     stub._belongs_to_this_session = WebSocketClient._belongs_to_this_session.__get__(stub)
     stub._clean_jid = WebSocketClient._clean_jid.__get__(stub)
+    stub._call_timestamp_seconds = WebSocketClient._call_timestamp_seconds
 
     WebSocketClient.on_wpp_incoming_call(stub, {
         "session": "session-a",
@@ -277,6 +317,8 @@ def test_websocket_normalizes_nested_call_payload(monkeypatch):
             "peerJid": {"_serialized": "5511999999999@c.us"},
             "groupJid": {"_serialized": "120363427511142886@g.us"},
             "isVideo": True,
+            "offerTime": 2_000_000_001_000,
+            "observedAt": 2_000_000_002,
         },
     })
 
@@ -288,4 +330,17 @@ def test_websocket_normalizes_nested_call_payload(monkeypatch):
         "groupJid": "120363427511142886@g.us",
         "isVideo": True,
         "isGroup": False,
+        "timestamp": 2_000_000_001,
+        "observedAt": 2_000_000_002,
+        "receivedWhileOffline": False,
     }]
+
+
+def test_call_timestamp_normalizer_handles_seconds_millis_and_micros():
+    normalize = WebSocketClient._call_timestamp_seconds
+
+    assert normalize(2_000_000_001) == 2_000_000_001
+    assert normalize(2_000_000_001_000) == 2_000_000_001
+    assert normalize(2_000_000_001_000_000) == 2_000_000_001
+    assert normalize("invalid") == 0
+    assert normalize(True) == 0


### PR DESCRIPTION
## Resumo

- ignora ofertas de chamadas anteriores à sessão atual do WinZapp
- descarta chamadas marcadas como recebidas enquanto o cliente estava offline
- mantém uma tolerância de 5 segundos durante a inicialização
- aplica a proteção tanto na API quanto no cliente

## Validação

- 16 testes do alerta de chamadas passaram
- compilação Python e TypeScript sem erros