### PR TITLE
fix(status): send replies with quoted status context

### DIFF
--- a/client/api_patches/src/controller/messageController.ts
+++ b/client/api_patches/src/controller/messageController.ts
@@ -1021,6 +1021,247 @@ export async function sendStatusVoice64(req: Request, res: Response) {
   }
 }
 
+/**
+ * Parse a JSON string handed back from a page.evaluate() call, throwing a
+ * descriptive error (including `label`) on malformed input instead of a
+ * bare JSON.parse SyntaxError.
+ */
+function parseEvaluateJson(raw: string | null | undefined, label: string): any {
+  try {
+    return typeof raw === 'string' ? JSON.parse(raw) : null;
+  } catch (parseError) {
+    throw new Error(`Invalid ${label}: ${String(parseError)}`);
+  }
+}
+
+/**
+ * WinZapp patch: reply to a contact's status (WhatsApp "story") with a real
+ * quote back to the original status, instead of a plain DM.
+ *
+ * A contact's status is not indexed in the ordinary MsgStore used by
+ * client.reply()/getMessageById().  WhatsApp Web keeps it in that contact's
+ * StatusV3Model, so resolve the real MsgModel there and serialize that model
+ * as WA-JS's supported quotedMsgPayload.  Current WhatsApp Web models from
+ * StatusV3Store incorrectly expose isStatusV3=false; passing the live model
+ * as quotedMsg therefore hits WA-JS's ordinary-chat canReply guard.
+ * Rehydrated payloads bypass that stale flag and still use
+ * MsgModel.msgContextInfo(), which emits the correct status stanza,
+ * participant and status@broadcast JID.
+ */
+async function replyToStatusMessage(
+  req: Request,
+  contato: string,
+  message: string,
+  serializedId: string
+): Promise<any> {
+  const probeKey = `winzapp_status_reply_${Date.now()}_${Math.random()
+    .toString(36)
+    .slice(2)}`;
+  const directJson = await req.client.page.evaluate(
+    async ({ to, content, serializedId, probeKey }) => {
+      const pageWindow = window as any;
+      const WPP = pageWindow.WPP;
+      const parts = serializedId.split('_');
+      const rawId = parts.length > 2 ? parts[2] : serializedId;
+      const posterJid = parts.length > 3 ? parts[3] : '';
+      const store = WPP?.whatsapp?.StatusV3Store;
+      const probes = (pageWindow.__winzappStatusReplyProbes ||= {});
+      const probe: any = (probes[probeKey] = {
+        phase: 'started',
+        statusId: rawId,
+        posterJid,
+        destination: to,
+      });
+
+      try {
+        // Prefer the expected poster, but also scan StatusV3Store.  The
+        // Python side deliberately prefers @lid for sends while the
+        // status collection can still be keyed by the legacy @c.us JID;
+        // limiting lookup to WPP.status.get(posterJid) would therefore
+        // miss a status that is visibly present in the panel.
+        const statusModels: any[] = [];
+        const expected = posterJid
+          ? WPP?.status?.get?.(posterJid)
+          : undefined;
+        if (expected) statusModels.push(expected);
+        const storedModels =
+          (typeof store?.getModels === 'function' && store.getModels()) ||
+          (Array.isArray(store?._models) && store._models) ||
+          (Array.isArray(store?.models) && store.models) ||
+          [];
+        for (const model of storedModels) {
+          if (model && !statusModels.includes(model)) {
+            statusModels.push(model);
+          }
+        }
+
+        let quoted: any = null;
+        let matchedPoster = '';
+        let messagesSeen = 0;
+        for (const model of statusModels) {
+          const msgs =
+            (typeof model?.getAllMsgs === 'function' &&
+              model.getAllMsgs()) ||
+            (typeof model?.msgs?.getModelsArray === 'function' &&
+              model.msgs.getModelsArray()) ||
+            [];
+          messagesSeen += msgs.length;
+          quoted = msgs.find((item: any) => {
+            const itemId = item?.id?.id || '';
+            const itemSerialized = item?.id?._serialized || '';
+            return itemId === rawId || itemSerialized === serializedId;
+          });
+          if (quoted) {
+            matchedPoster =
+              model?.id?._serialized || model?.id?.toString?.() || '';
+            break;
+          }
+        }
+        if (!quoted) {
+          throw new Error(
+            `Status message not found for reply: id=${rawId}, ` +
+              `poster=${posterJid || '<missing>'}, ` +
+              `models=${statusModels.length}, messages=${messagesSeen}`
+          );
+        }
+        Object.assign(probe, {
+          phase: 'status-found',
+          statusModelsSeen: statusModels.length,
+          statusMessagesSeen: messagesSeen,
+          matchedPoster,
+          quotedIsStatusV3: Boolean(quoted.isStatusV3),
+        });
+        const quotedPayload = JSON.stringify(
+          typeof quoted.toJSON === 'function' ? quoted.toJSON() : quoted
+        );
+        const sendResult = await WPP.chat.sendTextMessage(to, content, {
+          quotedMsgPayload: quotedPayload,
+          linkPreview: false,
+          waitForAck: true,
+        });
+        const sentId =
+          typeof sendResult?.id === 'string'
+            ? sendResult.id
+            : sendResult?.id?.toString?.() || '';
+        const ack = Number(sendResult?.ack ?? 0);
+        const messageSendResult = String(
+          sendResult?.sendMsgResult?.messageSendResult ?? ''
+        );
+        const sendError = String(
+          sendResult?.sendMsgResult?.error ??
+            sendResult?.sendMsgResult?.errorCode ??
+            ''
+        );
+        Object.assign(probe, {
+          phase: 'send-returned',
+          id: sentId,
+          ack,
+          messageSendResult,
+          error: sendError,
+        });
+        if (!sentId) {
+          throw new Error(
+            `Status reply returned no message id: status=${rawId}, ` +
+              `poster=${matchedPoster || posterJid}, ` +
+              `result=${JSON.stringify(sendResult)}`
+          );
+        }
+        if (!['SUCCESS', 'OK'].includes(messageSendResult) || ack < 1) {
+          throw new Error(
+            `Status reply rejected by WhatsApp: status=${rawId}, ` +
+              `result=${messageSendResult || '<missing>'}, ack=${ack}, ` +
+              `error=${sendError || '<missing>'}`
+          );
+        }
+        probe.phase = 'validated';
+      } catch (error) {
+        probe.phase = 'error';
+        probe.error = String((error as any)?.message || error);
+        probe.stack = String((error as any)?.stack || '');
+      }
+
+      // The return value after sendTextMessage is lost by this
+      // WPPConnect/Puppeteer combination. Keep returning it for versions
+      // where it works, but the Node side also reads the probe in a
+      // separate evaluate call below when it is.
+      //
+      // The common case (this return value actually arrives) cleans up
+      // after itself right here — the fallback evaluate below is the only
+      // one that still needs to read AND delete the stored probe.
+      delete probes[probeKey];
+      return JSON.stringify(probe);
+    },
+    {
+      to: contato,
+      content: message,
+      serializedId,
+      probeKey,
+    }
+  );
+  // Only pay for a second Puppeteer round-trip when the first evaluate's
+  // return value was actually lost (see the comment inside it above) — the
+  // common case already has everything it needs in directJson, and already
+  // cleaned up its own probe entry.
+  const probeJson =
+    typeof directJson === 'string'
+      ? null
+      : await req.client.page.evaluate(
+          ({ probeKey }) => {
+            const pageWindow = window as any;
+            const probes = pageWindow.__winzappStatusReplyProbes;
+            const probe = probes?.[probeKey] ?? null;
+            if (probes) delete probes[probeKey];
+            return JSON.stringify(probe);
+          },
+          { probeKey }
+        );
+  const sentJson = typeof directJson === 'string' ? directJson : probeJson;
+  const sent = parseEvaluateJson(sentJson, 'serialized status reply result');
+  if (
+    !sent ||
+    sent.phase !== 'validated' ||
+    typeof sent.id !== 'string' ||
+    !sent.id ||
+    Number(sent.ack) < 1 ||
+    !['SUCCESS', 'OK'].includes(String(sent.messageSendResult))
+  ) {
+    throw new Error(
+      `Invalid status reply result returned by WhatsApp Web: ${JSON.stringify(
+        sent
+      )}`
+    );
+  }
+  const storedJson = await req.client.page.evaluate(
+    async ({ messageId }) => {
+      // MsgStore may not have indexed the just-sent message yet the instant
+      // sendTextMessage() resolves — retry briefly before giving up, rather
+      // than reporting an already-confirmed send (ack>=1, SUCCESS/OK, just
+      // validated above) as a failure.
+      let stored: any = null;
+      for (let attempt = 0; attempt < 3 && !stored; attempt++) {
+        if (attempt > 0) {
+          await new Promise((resolve) => setTimeout(resolve, 300));
+        }
+        stored = await (window as any).WAPI?.getMessageById?.(messageId);
+      }
+      return JSON.stringify(stored ?? null);
+    },
+    { messageId: sent.id }
+  );
+  const stored = parseEvaluateJson(storedJson, 'stored status reply result');
+  if (!stored || stored.erro === true || stored.error === true) {
+    throw new Error(
+      `Status reply was acknowledged but not found in MsgStore: ${JSON.stringify(
+        stored
+      )}`
+    );
+  }
+  req.logger.info(
+    `[status-reply] sent ${serializedId}: ` + JSON.stringify(sent)
+  );
+  return sent;
+}
+
 export async function replyMessage(req: Request, res: Response) {
   /**
    * #swagger.tags = ["Messages"]
@@ -1067,217 +1308,9 @@ export async function replyMessage(req: Request, res: Response) {
         typeof messageId === 'string' &&
         messageId.includes('status@broadcast')
       ) {
-        // A contact's status is not indexed in the ordinary MsgStore used by
-        // client.reply()/getMessageById().  WhatsApp Web keeps it in that
-        // contact's StatusV3Model, so resolve the real MsgModel there and
-        // serialize that model as WA-JS's supported quotedMsgPayload.  Current
-        // WhatsApp Web models from StatusV3Store incorrectly expose
-        // isStatusV3=false; passing the live model as quotedMsg therefore hits
-        // WA-JS's ordinary-chat canReply guard.  Rehydrated payloads bypass
-        // that stale flag and still use MsgModel.msgContextInfo(), which emits
-        // the correct status stanza, participant and status@broadcast JID.
-        const probeKey = `winzapp_status_reply_${Date.now()}_${Math.random()
-          .toString(36)
-          .slice(2)}`;
-        const directJson = await req.client.page.evaluate(
-          async ({ to, content, serializedId, probeKey }) => {
-            const pageWindow = window as any;
-            const WPP = pageWindow.WPP;
-            const parts = serializedId.split('_');
-            const rawId = parts.length > 2 ? parts[2] : serializedId;
-            const posterJid = parts.length > 3 ? parts[3] : '';
-            const store = WPP?.whatsapp?.StatusV3Store;
-            const probes = (pageWindow.__winzappStatusReplyProbes ||= {});
-            const probe: any = (probes[probeKey] = {
-              phase: 'started',
-              statusId: rawId,
-              posterJid,
-              destination: to,
-            });
-
-            try {
-              // Prefer the expected poster, but also scan StatusV3Store.  The
-              // Python side deliberately prefers @lid for sends while the
-              // status collection can still be keyed by the legacy @c.us JID;
-              // limiting lookup to WPP.status.get(posterJid) would therefore
-              // miss a status that is visibly present in the panel.
-              const statusModels: any[] = [];
-              const expected = posterJid
-                ? WPP?.status?.get?.(posterJid)
-                : undefined;
-              if (expected) statusModels.push(expected);
-              const storedModels =
-                (typeof store?.getModels === 'function' && store.getModels()) ||
-                (Array.isArray(store?._models) && store._models) ||
-                (Array.isArray(store?.models) && store.models) ||
-                [];
-              for (const model of storedModels) {
-                if (model && !statusModels.includes(model)) {
-                  statusModels.push(model);
-                }
-              }
-
-              let quoted: any = null;
-              let matchedPoster = '';
-              let messagesSeen = 0;
-              for (const model of statusModels) {
-                const msgs =
-                  (typeof model?.getAllMsgs === 'function' &&
-                    model.getAllMsgs()) ||
-                  (typeof model?.msgs?.getModelsArray === 'function' &&
-                    model.msgs.getModelsArray()) ||
-                  [];
-                messagesSeen += msgs.length;
-                quoted = msgs.find((item: any) => {
-                  const itemId = item?.id?.id || '';
-                  const itemSerialized = item?.id?._serialized || '';
-                  return itemId === rawId || itemSerialized === serializedId;
-                });
-                if (quoted) {
-                  matchedPoster =
-                    model?.id?._serialized || model?.id?.toString?.() || '';
-                  break;
-                }
-              }
-              if (!quoted) {
-                throw new Error(
-                  `Status message not found for reply: id=${rawId}, ` +
-                    `poster=${posterJid || '<missing>'}, ` +
-                    `models=${statusModels.length}, messages=${messagesSeen}`
-                );
-              }
-              Object.assign(probe, {
-                phase: 'status-found',
-                statusModelsSeen: statusModels.length,
-                statusMessagesSeen: messagesSeen,
-                matchedPoster,
-                quotedIsStatusV3: Boolean(quoted.isStatusV3),
-              });
-              const quotedPayload = JSON.stringify(
-                typeof quoted.toJSON === 'function' ? quoted.toJSON() : quoted
-              );
-              const sendResult = await WPP.chat.sendTextMessage(to, content, {
-                quotedMsgPayload: quotedPayload,
-                linkPreview: false,
-                waitForAck: true,
-              });
-              const sentId =
-                typeof sendResult?.id === 'string'
-                  ? sendResult.id
-                  : sendResult?.id?.toString?.() || '';
-              const ack = Number(sendResult?.ack ?? 0);
-              const messageSendResult = String(
-                sendResult?.sendMsgResult?.messageSendResult ?? ''
-              );
-              const sendError = String(
-                sendResult?.sendMsgResult?.error ??
-                  sendResult?.sendMsgResult?.errorCode ??
-                  ''
-              );
-              Object.assign(probe, {
-                phase: 'send-returned',
-                id: sentId,
-                ack,
-                messageSendResult,
-                error: sendError,
-              });
-              if (!sentId) {
-                throw new Error(
-                  `Status reply returned no message id: status=${rawId}, ` +
-                    `poster=${matchedPoster || posterJid}, ` +
-                    `result=${JSON.stringify(sendResult)}`
-                );
-              }
-              if (!['SUCCESS', 'OK'].includes(messageSendResult) || ack < 1) {
-                throw new Error(
-                  `Status reply rejected by WhatsApp: status=${rawId}, ` +
-                    `result=${messageSendResult || '<missing>'}, ack=${ack}, ` +
-                    `error=${sendError || '<missing>'}`
-                );
-              }
-              probe.phase = 'validated';
-            } catch (error) {
-              probe.phase = 'error';
-              probe.error = String((error as any)?.message || error);
-              probe.stack = String((error as any)?.stack || '');
-            }
-
-            // The return value after sendTextMessage is lost by this
-            // WPPConnect/Puppeteer combination. Keep returning it for versions
-            // where it works, but the Node side also reads the probe in a
-            // separate evaluate call below.
-            return JSON.stringify(probe);
-          },
-          {
-            to: contato,
-            content: message,
-            serializedId: messageId,
-            probeKey,
-          }
+        results.push(
+          await replyToStatusMessage(req, contato, message, messageId)
         );
-        const probeJson = await req.client.page.evaluate(
-          ({ probeKey }) => {
-            const pageWindow = window as any;
-            const probes = pageWindow.__winzappStatusReplyProbes;
-            const probe = probes?.[probeKey] ?? null;
-            if (probes) delete probes[probeKey];
-            return JSON.stringify(probe);
-          },
-          { probeKey }
-        );
-        const sentJson =
-          typeof directJson === 'string' ? directJson : probeJson;
-        let sent: any;
-        try {
-          sent = typeof sentJson === 'string' ? JSON.parse(sentJson) : null;
-        } catch (parseError) {
-          throw new Error(
-            `Invalid serialized status reply result: ${String(parseError)}`
-          );
-        }
-        if (
-          !sent ||
-          sent.phase !== 'validated' ||
-          typeof sent.id !== 'string' ||
-          !sent.id ||
-          Number(sent.ack) < 1 ||
-          !['SUCCESS', 'OK'].includes(String(sent.messageSendResult))
-        ) {
-          throw new Error(
-            `Invalid status reply result returned by WhatsApp Web: ${JSON.stringify(
-              sent
-            )}`
-          );
-        }
-        const storedJson = await req.client.page.evaluate(
-          async ({ messageId }) => {
-            const stored = await (window as any).WAPI?.getMessageById?.(
-              messageId
-            );
-            return JSON.stringify(stored ?? null);
-          },
-          { messageId: sent.id }
-        );
-        let stored: any;
-        try {
-          stored =
-            typeof storedJson === 'string' ? JSON.parse(storedJson) : null;
-        } catch (parseError) {
-          throw new Error(
-            `Invalid stored status reply result: ${String(parseError)}`
-          );
-        }
-        if (!stored || stored.erro === true || stored.error === true) {
-          throw new Error(
-            `Status reply was acknowledged but not found in MsgStore: ${JSON.stringify(
-              stored
-            )}`
-          );
-        }
-        req.logger.info(
-          `[status-reply] sent ${messageId}: ` + JSON.stringify(sent)
-        );
-        results.push(sent);
       } else {
         results.push(await req.client.reply(contato, message, messageId));
       }

--- a/client/api_patches/src/controller/messageController.ts
+++ b/client/api_patches/src/controller/messageController.ts
@@ -1063,7 +1063,224 @@ export async function replyMessage(req: Request, res: Response) {
   try {
     const results: any = [];
     for (const contato of phone) {
-      results.push(await req.client.reply(contato, message, messageId));
+      if (
+        typeof messageId === 'string' &&
+        messageId.includes('status@broadcast')
+      ) {
+        // A contact's status is not indexed in the ordinary MsgStore used by
+        // client.reply()/getMessageById().  WhatsApp Web keeps it in that
+        // contact's StatusV3Model, so resolve the real MsgModel there and
+        // serialize that model as WA-JS's supported quotedMsgPayload.  Current
+        // WhatsApp Web models from StatusV3Store incorrectly expose
+        // isStatusV3=false; passing the live model as quotedMsg therefore hits
+        // WA-JS's ordinary-chat canReply guard.  Rehydrated payloads bypass
+        // that stale flag and still use MsgModel.msgContextInfo(), which emits
+        // the correct status stanza, participant and status@broadcast JID.
+        const probeKey = `winzapp_status_reply_${Date.now()}_${Math.random()
+          .toString(36)
+          .slice(2)}`;
+        const directJson = await req.client.page.evaluate(
+          async ({ to, content, serializedId, probeKey }) => {
+            const pageWindow = window as any;
+            const WPP = pageWindow.WPP;
+            const parts = serializedId.split('_');
+            const rawId = parts.length > 2 ? parts[2] : serializedId;
+            const posterJid = parts.length > 3 ? parts[3] : '';
+            const store = WPP?.whatsapp?.StatusV3Store;
+            const probes = (pageWindow.__winzappStatusReplyProbes ||= {});
+            const probe: any = (probes[probeKey] = {
+              phase: 'started',
+              statusId: rawId,
+              posterJid,
+              destination: to,
+            });
+
+            try {
+              // Prefer the expected poster, but also scan StatusV3Store.  The
+              // Python side deliberately prefers @lid for sends while the
+              // status collection can still be keyed by the legacy @c.us JID;
+              // limiting lookup to WPP.status.get(posterJid) would therefore
+              // miss a status that is visibly present in the panel.
+              const statusModels: any[] = [];
+              const expected = posterJid
+                ? WPP?.status?.get?.(posterJid)
+                : undefined;
+              if (expected) statusModels.push(expected);
+              const storedModels =
+                (typeof store?.getModels === 'function' && store.getModels()) ||
+                (Array.isArray(store?._models) && store._models) ||
+                (Array.isArray(store?.models) && store.models) ||
+                [];
+              for (const model of storedModels) {
+                if (model && !statusModels.includes(model)) {
+                  statusModels.push(model);
+                }
+              }
+
+              let quoted: any = null;
+              let matchedPoster = '';
+              let messagesSeen = 0;
+              for (const model of statusModels) {
+                const msgs =
+                  (typeof model?.getAllMsgs === 'function' &&
+                    model.getAllMsgs()) ||
+                  (typeof model?.msgs?.getModelsArray === 'function' &&
+                    model.msgs.getModelsArray()) ||
+                  [];
+                messagesSeen += msgs.length;
+                quoted = msgs.find((item: any) => {
+                  const itemId = item?.id?.id || '';
+                  const itemSerialized = item?.id?._serialized || '';
+                  return itemId === rawId || itemSerialized === serializedId;
+                });
+                if (quoted) {
+                  matchedPoster =
+                    model?.id?._serialized || model?.id?.toString?.() || '';
+                  break;
+                }
+              }
+              if (!quoted) {
+                throw new Error(
+                  `Status message not found for reply: id=${rawId}, ` +
+                    `poster=${posterJid || '<missing>'}, ` +
+                    `models=${statusModels.length}, messages=${messagesSeen}`
+                );
+              }
+              Object.assign(probe, {
+                phase: 'status-found',
+                statusModelsSeen: statusModels.length,
+                statusMessagesSeen: messagesSeen,
+                matchedPoster,
+                quotedIsStatusV3: Boolean(quoted.isStatusV3),
+              });
+              const quotedPayload = JSON.stringify(
+                typeof quoted.toJSON === 'function' ? quoted.toJSON() : quoted
+              );
+              const sendResult = await WPP.chat.sendTextMessage(to, content, {
+                quotedMsgPayload: quotedPayload,
+                linkPreview: false,
+                waitForAck: true,
+              });
+              const sentId =
+                typeof sendResult?.id === 'string'
+                  ? sendResult.id
+                  : sendResult?.id?.toString?.() || '';
+              const ack = Number(sendResult?.ack ?? 0);
+              const messageSendResult = String(
+                sendResult?.sendMsgResult?.messageSendResult ?? ''
+              );
+              const sendError = String(
+                sendResult?.sendMsgResult?.error ??
+                  sendResult?.sendMsgResult?.errorCode ??
+                  ''
+              );
+              Object.assign(probe, {
+                phase: 'send-returned',
+                id: sentId,
+                ack,
+                messageSendResult,
+                error: sendError,
+              });
+              if (!sentId) {
+                throw new Error(
+                  `Status reply returned no message id: status=${rawId}, ` +
+                    `poster=${matchedPoster || posterJid}, ` +
+                    `result=${JSON.stringify(sendResult)}`
+                );
+              }
+              if (!['SUCCESS', 'OK'].includes(messageSendResult) || ack < 1) {
+                throw new Error(
+                  `Status reply rejected by WhatsApp: status=${rawId}, ` +
+                    `result=${messageSendResult || '<missing>'}, ack=${ack}, ` +
+                    `error=${sendError || '<missing>'}`
+                );
+              }
+              probe.phase = 'validated';
+            } catch (error) {
+              probe.phase = 'error';
+              probe.error = String((error as any)?.message || error);
+              probe.stack = String((error as any)?.stack || '');
+            }
+
+            // The return value after sendTextMessage is lost by this
+            // WPPConnect/Puppeteer combination. Keep returning it for versions
+            // where it works, but the Node side also reads the probe in a
+            // separate evaluate call below.
+            return JSON.stringify(probe);
+          },
+          {
+            to: contato,
+            content: message,
+            serializedId: messageId,
+            probeKey,
+          }
+        );
+        const probeJson = await req.client.page.evaluate(
+          ({ probeKey }) => {
+            const pageWindow = window as any;
+            const probes = pageWindow.__winzappStatusReplyProbes;
+            const probe = probes?.[probeKey] ?? null;
+            if (probes) delete probes[probeKey];
+            return JSON.stringify(probe);
+          },
+          { probeKey }
+        );
+        const sentJson =
+          typeof directJson === 'string' ? directJson : probeJson;
+        let sent: any;
+        try {
+          sent = typeof sentJson === 'string' ? JSON.parse(sentJson) : null;
+        } catch (parseError) {
+          throw new Error(
+            `Invalid serialized status reply result: ${String(parseError)}`
+          );
+        }
+        if (
+          !sent ||
+          sent.phase !== 'validated' ||
+          typeof sent.id !== 'string' ||
+          !sent.id ||
+          Number(sent.ack) < 1 ||
+          !['SUCCESS', 'OK'].includes(String(sent.messageSendResult))
+        ) {
+          throw new Error(
+            `Invalid status reply result returned by WhatsApp Web: ${JSON.stringify(
+              sent
+            )}`
+          );
+        }
+        const storedJson = await req.client.page.evaluate(
+          async ({ messageId }) => {
+            const stored = await (window as any).WAPI?.getMessageById?.(
+              messageId
+            );
+            return JSON.stringify(stored ?? null);
+          },
+          { messageId: sent.id }
+        );
+        let stored: any;
+        try {
+          stored =
+            typeof storedJson === 'string' ? JSON.parse(storedJson) : null;
+        } catch (parseError) {
+          throw new Error(
+            `Invalid stored status reply result: ${String(parseError)}`
+          );
+        }
+        if (!stored || stored.erro === true || stored.error === true) {
+          throw new Error(
+            `Status reply was acknowledged but not found in MsgStore: ${JSON.stringify(
+              stored
+            )}`
+          );
+        }
+        req.logger.info(
+          `[status-reply] sent ${messageId}: ` + JSON.stringify(sent)
+        );
+        results.push(sent);
+      } else {
+        results.push(await req.client.reply(contato, message, messageId));
+      }
     }
 
     if (results.length === 0) res.status(400).json('Error sending message');

--- a/client/main.py
+++ b/client/main.py
@@ -15172,6 +15172,15 @@ class MainWindow(wx.Frame):
             }
         else:
             quoted_id = self._serialize_quoted_id(quoted, fallback_jid=remote_jid) if quoted else None
+            # A status quote that failed to serialize (e.g. incomplete status
+            # metadata missing key.id) must never silently fall through to a
+            # plain DM below — that's the exact "reply degrades to a normal
+            # message" bug this is meant to fix, just triggered by malformed
+            # data instead of a WPPConnect failure.
+            quoted_is_status = (
+                bool(quoted) and isinstance(quoted, dict)
+                and (quoted.get("key") or {}).get("remoteJid") == "status@broadcast"
+            )
             if quoted_id:
                 is_status_reply = "status@broadcast" in quoted_id
                 url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/send-reply"
@@ -15189,6 +15198,9 @@ class MainWindow(wx.Frame):
                     }
                 }
                 logging.debug("[send_text_message] sending quoted reply via send-reply to %s, quoted key.id=%s", phone_net, quoted_id)
+            elif quoted_is_status:
+                logging.error("[send_text_message] status reply has no serializable quote id (key.id missing?) — refusing to send as a plain message")
+                return {"ok": False, "error": "status reply missing a serializable message id", "retry": False}
             else:
                 phone_net = remote_jid
                 if phone_net.endswith("@s.whatsapp.net"):

--- a/client/main.py
+++ b/client/main.py
@@ -15149,6 +15149,7 @@ class MainWindow(wx.Frame):
 
         quoted_id = None
         quote_stripped = False
+        is_status_reply = False
 
         if mentioned_jids:
             url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/send-mentioned"
@@ -15172,6 +15173,7 @@ class MainWindow(wx.Frame):
         else:
             quoted_id = self._serialize_quoted_id(quoted, fallback_jid=remote_jid) if quoted else None
             if quoted_id:
+                is_status_reply = "status@broadcast" in quoted_id
                 url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/send-reply"
                 phone_net = remote_jid
                 if phone_net.endswith("@s.whatsapp.net"):
@@ -15257,9 +15259,12 @@ class MainWindow(wx.Frame):
                     if response.status_code in (200, 201):
                         logging.info("[send_text_message] legacy retry with %s succeeded", fb_phone)
 
-                # 2. If it's still failing and we had a quote, strip the quote and
-                #    try a plain send to whichever address we last used.
-                if response.status_code not in (200, 201) and quoted_id:
+                # 2. If it's still failing and we had an ordinary chat quote,
+                #    strip the quote and try a plain send.  A status reply must
+                #    never take this fallback: a plain DM is observably the
+                #    wrong operation, so report failure and let the user retry
+                #    instead of claiming that an unquoted reply succeeded.
+                if response.status_code not in (200, 201) and quoted_id and not is_status_reply:
                     logging.warning("[send_text_message] Quoted send failed (HTTP %s). Retrying without quote on %s...",
                                     response.status_code, active_dest)
                     wx.CallAfter(self.output, self.i18n.t("reply_quote_lost"))

--- a/client/status_panel.py
+++ b/client/status_panel.py
@@ -1757,15 +1757,12 @@ class StatusPanel(wx.Panel):
     def _send_status_reply_bg(self, poster_jid: str, text: str, status: dict):
         mw = self.main_window
         try:
-            # Deliberately NOT quoted — same reasoning as _on_like_status():
-            # WPPConnect's send-reply endpoint can't resolve a status as a
-            # quote target (it's never indexed anywhere reachable from the
-            # poster's own chat), so quoting it always failed server-side
-            # and silently fell back to a plain send anyway, just after an
-            # extra round trip and a confusing "Não foi possível citar a
-            # mensagem original" notice for something that was never going
-            # to work.
-            result = mw.send_text_message(poster_jid, text)
+            # Status messages live in WhatsApp Web's per-poster StatusV3Model,
+            # not in the ordinary chat message collection.  The patched Node
+            # send-reply route resolves this serialized status key in that
+            # model before sending, so keep the status as the quote target
+            # here instead of degrading the reply to a normal DM.
+            result = mw.send_text_message(poster_jid, text, quoted=status)
         except Exception:
             logging.exception(
                 "[status-reply] send_text_message raised for %s", poster_jid)

--- a/tests/test_status_panel.py
+++ b/tests/test_status_panel.py
@@ -28,6 +28,8 @@ same approach as tests/test_message_bookmarks.py.
 import pytest
 import wx
 
+import main as main_module
+from main import MainWindow
 from status_panel import StatusPanel, _status_content_label, _status_media_save_info
 
 
@@ -1348,14 +1350,14 @@ class TestEscapeClosesTheViewer:
         assert stub._video_player.stop_calls == 0
 
 
-class TestStatusReplySendsWithoutQuoting:
-    """Same reasoning as TestLikeStatusSendsAPlainEmojiMessage: WPPConnect
-    can't resolve a status as a quote target from the poster's own chat,
-    so send-reply always failed server-side and silently fell back to a
-    plain send anyway — reported live as "Não foi possível citar a
-    mensagem original"."""
+class TestStatusReplyKeepsTheStatusQuote:
+    """A status reply must arrive as a reply to that status, not a plain DM.
 
-    def test_reply_is_sent_without_the_quoted_kwarg(self, monkeypatch):
+    The Node route resolves the status in the poster's StatusV3Model, which
+    means the UI must pass the complete selected status as the quote target.
+    """
+
+    def test_reply_passes_the_selected_status_as_quote(self, monkeypatch):
         _run_threads_synchronously(monkeypatch)
         status = _text_status("oi")
         stub = _Stub()
@@ -1366,8 +1368,73 @@ class TestStatusReplySendsWithoutQuoting:
         stub._on_send_status_reply(None)
 
         assert stub.main_window.send_text_calls == [
-            ("poster@s.whatsapp.net", "valeu!", None)
+            ("poster@s.whatsapp.net", "valeu!", status)
         ]
+
+
+class TestFailedStatusReplyNeverDegradesToPlainMessage:
+    """If the quote cannot be created, reporting failure is safer than
+    silently delivering a normal DM and calling it a successful status reply.
+    """
+
+    class _Response:
+        status_code = 500
+        text = "status quote not found"
+
+    class _MainStub:
+        send_text_message = MainWindow.send_text_message
+
+        def __init__(self):
+            self.wpp_server = "http://127.0.0.1"
+            self.wpp_port = 21465
+            self.token = "session:token"
+            self.i18n = _FakeI18n()
+            self.outputs = []
+
+        def _resolve_jid_for_send(self, jid):
+            return jid.replace("@s.whatsapp.net", "@c.us")
+
+        def _serialize_quoted_id(self, quoted, fallback_jid=None):
+            return "false_status@broadcast_s1_poster@c.us"
+
+        def _legacy_phone_for_send(self, jid):
+            return ""
+
+        def _check_wa_connection_closed(self, response):
+            return False
+
+        def _set_wa_connected(self, connected, reason):
+            pass
+
+        def _classify_send_exception(self, exc, where):
+            raise AssertionError(f"unexpected exception in {where}: {exc}")
+
+        def output(self, text, interrupt=False):
+            self.outputs.append(text)
+
+    def test_http_failure_is_not_retried_through_send_message(self, monkeypatch):
+        calls = []
+
+        def _post(url, **kwargs):
+            calls.append((url, kwargs["json"]))
+            return self._Response()
+
+        monkeypatch.setattr(main_module, "api_post", _post)
+        stub = self._MainStub()
+
+        result = stub.send_text_message(
+            "poster@s.whatsapp.net",
+            "valeu!",
+            quoted=_text_status("oi"),
+        )
+
+        assert result["ok"] is False
+        assert len(calls) == 1
+        assert calls[0][0].endswith("/send-reply")
+        assert calls[0][1]["messageId"].startswith(
+            "false_status@broadcast_"
+        )
+        assert stub.outputs == []
 
 
 class TestStatusReplySentRefocusesTheField:


### PR DESCRIPTION
## Resumo

- envia respostas de status como citações reais, preservando o contexto `status@broadcast`
- resolve o status diretamente no `StatusV3Store` e usa `quotedMsgPayload` para contornar a flag incorreta `isStatusV3=false` do modelo atual do WhatsApp Web
- valida ID, ACK, resultado de protocolo e presença da mensagem no `MsgStore` antes de declarar sucesso
- impede que uma falha de citação de status seja reenviada silenciosamente como mensagem comum
- mantém diagnóstico por fases para recusas do WhatsApp/Puppeteer

## Validação

- `pytest -q`: 2927 passed, 64 skipped
- `npm run build`: TypeScript e Babel concluídos com sucesso
- `git diff --check`: aprovado
- branch atualizada sobre `origin/main` sem conflitos

## Teste manual

- resposta a status confirmada no WinZapp como mensagem vinculada ao status original
