### PR TITLE
fix: Correções de mensagens, atualizador e ajustes de acessibilidade na lista

### DIFF
--- a/client/core/database.py
+++ b/client/core/database.py
@@ -30,6 +30,8 @@ from typing import Any
 import aiosqlite
 from cryptography.fernet import Fernet
 
+from core.utils import video_seconds
+
 log = logging.getLogger(__name__)
 
 # ── Schema ────────────────────────────────────────────────────────────────────
@@ -697,18 +699,74 @@ class DatabaseManager:
         return (mid, remote_jid, from_me, participant, mtype, msg_enc, ts,
                 _delivery_status(msg))
 
+    async def _with_known_video_duration(self, conn, remote_jid: str, msg: dict) -> dict:
+        """*msg*, with a video duration already on record restored when the
+        incoming copy states none.
+
+        Some videos are handed over by WhatsApp Web with duration 0 forever —
+        the sending client left the field out of the message, and no field on
+        the payload carries the real length. WinZapp measures those from the
+        file itself once it has been downloaded or played, and that
+        measurement lives only in the stored record: the server never learns
+        it. So every resync, which overwrites the row with the server's copy,
+        used to erase it — the length showed up after playing the video and
+        was gone again on the next restart.
+
+        The rule lives here, at the single point every write passes through,
+        rather than in each of the several sync paths that batch-insert
+        messages, so no future one can forget it. A message's video is
+        immutable (WhatsApp has no way to change the media of a sent
+        message), so a duration measured once stays valid for that id. A copy
+        that DOES state a duration always wins — that is the sender's own
+        answer finally arriving — and anything that is not a video without a
+        duration returns untouched without hitting the database at all.
+        """
+        video = (msg.get("message") or {}).get("videoMessage")
+        if not isinstance(video, dict) or video_seconds(video) is not None:
+            return msg
+        message_id = (msg.get("key") or {}).get("id") or ""
+        if not message_id:
+            return msg
+        cursor = await conn.execute(
+            "SELECT message_json FROM messages WHERE remote_jid=? AND message_id=?",
+            (remote_jid, message_id),
+        )
+        row = await cursor.fetchone()
+        if not row:
+            return msg
+        stored = self._decrypt_json(row["message_json"]) or {}
+        known = video_seconds((stored.get("message") or {}).get("videoMessage"))
+        if known is None:
+            return msg
+        log.info(
+            "[messages] %s: keeping the measured %ds duration; the incoming copy states none",
+            message_id, known,
+        )
+        merged = dict(msg)
+        merged["message"] = dict(msg.get("message") or {})
+        merged["message"]["videoMessage"] = {**video, "seconds": known}
+        return merged
+
     async def insert_message(self, remote_jid: str, msg: dict) -> None:
-        """Insert a single message record."""
-        values = self._build_message_values(remote_jid, msg)
-        if values is None:
-            log.warning(
-                "[insert_message] dropping message with empty key.id for %s "
-                "(would collide with any other id-less message in this chat)",
-                remote_jid,
-            )
-            return
+        """Insert a single message record.
+
+        The whole read-then-write sits inside one lock hold: the read is
+        _with_known_video_duration()'s lookup of a duration this row may
+        already carry, and releasing the lock between the two would let
+        another write land in the gap — the very race that helper exists to
+        close.
+        """
         async with self._write_lock:
             conn = await self._ensure_conn()
+            msg = await self._with_known_video_duration(conn, remote_jid, msg)
+            values = self._build_message_values(remote_jid, msg)
+            if values is None:
+                log.warning(
+                    "[insert_message] dropping message with empty key.id for %s "
+                    "(would collide with any other id-less message in this chat)",
+                    remote_jid,
+                )
+                return
             await conn.execute(
                 """INSERT OR REPLACE INTO messages
                    (message_id, remote_jid, from_me, participant,
@@ -730,6 +788,7 @@ class DatabaseManager:
             try:
                 await conn.execute("BEGIN")
                 for msg in msgs:
+                    msg = await self._with_known_video_duration(conn, remote_jid, msg)
                     values = self._build_message_values(remote_jid, msg)
                     if values is None:
                         # See _build_message_values() — an empty id-less

--- a/client/core/database.py
+++ b/client/core/database.py
@@ -30,7 +30,7 @@ from typing import Any
 import aiosqlite
 from cryptography.fernet import Fernet
 
-from core.utils import video_seconds
+from core.utils import MEASURED_SECONDS_KEY
 
 log = logging.getLogger(__name__)
 
@@ -700,8 +700,8 @@ class DatabaseManager:
                 _delivery_status(msg))
 
     async def _with_known_video_duration(self, conn, remote_jid: str, msg: dict) -> dict:
-        """*msg*, with a video duration already on record restored when the
-        incoming copy states none.
+        """*msg*, with a video duration WinZapp measured earlier restored when
+        the incoming copy carries none.
 
         Some videos are handed over by WhatsApp Web with duration 0 forever —
         the sending client left the field out of the message, and no field on
@@ -722,7 +722,7 @@ class DatabaseManager:
         duration returns untouched without hitting the database at all.
         """
         video = (msg.get("message") or {}).get("videoMessage")
-        if not isinstance(video, dict) or video_seconds(video) is not None:
+        if not isinstance(video, dict) or MEASURED_SECONDS_KEY in video:
             return msg
         message_id = (msg.get("key") or {}).get("id") or ""
         if not message_id:
@@ -735,16 +735,17 @@ class DatabaseManager:
         if not row:
             return msg
         stored = self._decrypt_json(row["message_json"]) or {}
-        known = video_seconds((stored.get("message") or {}).get("videoMessage"))
-        if known is None:
+        stored_video = (stored.get("message") or {}).get("videoMessage")
+        if not isinstance(stored_video, dict) or MEASURED_SECONDS_KEY not in stored_video:
             return msg
+        known = stored_video[MEASURED_SECONDS_KEY]
         log.info(
-            "[messages] %s: keeping the measured %ds duration; the incoming copy states none",
+            "[messages] %s: keeping the measured %ss duration; the incoming copy carries none",
             message_id, known,
         )
         merged = dict(msg)
         merged["message"] = dict(msg.get("message") or {})
-        merged["message"]["videoMessage"] = {**video, "seconds": known}
+        merged["message"]["videoMessage"] = {**video, MEASURED_SECONDS_KEY: known}
         return merged
 
     async def insert_message(self, remote_jid: str, msg: dict) -> None:

--- a/client/core/utils.py
+++ b/client/core/utils.py
@@ -13,35 +13,59 @@ from cryptography.fernet import Fernet
 SEARCH_NORMALIZATION_MODES = ("off", "nfd", "nfkd")
 
 
+#: Where a duration WinZapp measured from the media file itself is kept, apart
+#: from the "seconds" the message arrived with. Two reasons for its own key:
+#: a resync overwrites "seconds" with the server's copy and must not touch
+#: this, and only a measured value can legitimately be 0 (see video_seconds).
+MEASURED_SECONDS_KEY = "_measured_seconds"
+
+
 def video_seconds(video: dict):
-    """A video's stated length in whole seconds, or None when it doesn't
-    actually state one.
+    """A video's length in whole seconds, or None when it isn't known.
 
-    Zero counts as "not stated" HERE, unlike audio. WhatsApp Web hands over
-    duration 0 whenever the sending client left the field out of the message
-    (confirmed against /get-messages for such a video: `duration` is the
-    string "0" and no other field on the payload or its mediaData carries the
-    real length). No video lasts no time, so rendering that as "duração: 0
-    segundos" states a length that is certainly wrong — reported as exactly
-    that on a video that plays for minutes. A voice note under a second, by
-    contrast, genuinely reports 0 and WhatsApp itself shows "0:00" for it,
-    which is why the audio path keeps treating 0 as a real answer.
+    Two sources, in order:
 
-    The value may arrive as an int or as a string, depending on which layer
+    1. ``_measured_seconds`` — what WinZapp read off the media file itself
+       (see ui/conversations.probe_media_duration). This is the only place a
+       0 is believed: the file said so, and a clip under a second really does
+       round to 0 there. WhatsApp shows "0:00" for such a thing, so we do too.
+
+    2. ``seconds`` — what the message arrived with, and only when above zero.
+       WhatsApp Web hands over duration 0 whenever the sending client left the
+       field out of the message (confirmed against /get-messages for such a
+       video: `duration` is the string "0", and no other field on the payload
+       or its mediaData carries the real length). No video lasts no time, so
+       announcing "duração: 0 segundos" from that states a length that is
+       certainly wrong — reported as exactly that on a video that plays for
+       minutes.
+
+    So a stated 0 means "not stated", a measured 0 means "really that short",
+    and the two are no longer the same answer. Audio never needed the
+    distinction: a voice note under a second genuinely reports its own 0, and
+    that path keeps treating it as a real value.
+
+    Either value may arrive as an int or as a string depending on which layer
     normalized it (WebSocketClient._media_seconds() casts, a record restored
     straight from a REST sync may not) — "0" is truthy, so this cannot be a
     plain falsiness check at the call site.
     """
     if not isinstance(video, dict):
         return None
-    raw = video.get("seconds")
-    if raw is None or raw == "":
+    measured = _whole_seconds(video.get(MEASURED_SECONDS_KEY))
+    if measured is not None and measured >= 0:
+        return measured
+    stated = _whole_seconds(video.get("seconds"))
+    return stated if stated is not None and stated > 0 else None
+
+
+def _whole_seconds(raw):
+    """*raw* as a whole number of seconds, or None if it isn't a number."""
+    if raw is None or raw == "" or isinstance(raw, bool):
         return None
     try:
-        secs = int(float(raw))
+        return int(float(raw))
     except (TypeError, ValueError):
         return None
-    return secs if secs > 0 else None
 
 
 def carry_over_video_durations(new_msgs, old_msgs) -> int:
@@ -59,17 +83,21 @@ def carry_over_video_durations(new_msgs, old_msgs) -> int:
 
     A message's video is immutable — WhatsApp has no "edit the media of a sent
     message" — so a duration measured once stays valid for that message id
-    forever. A new copy that DOES state a duration always wins, since that is
-    the sender's own answer finally arriving.
+    forever.
+    Only the measured value travels: "seconds" is the server's own field and
+    the incoming copy's is authoritative for it, whatever it says.
     """
     known = {}
     for m in old_msgs or ():
         if not isinstance(m, dict):
             continue
         mid = (m.get("key") or {}).get("id")
-        secs = video_seconds(((m.get("message") or {}).get("videoMessage")))
-        if mid and secs is not None:
-            known[mid] = secs
+        video = (m.get("message") or {}).get("videoMessage")
+        if not isinstance(video, dict):
+            continue
+        measured = _whole_seconds(video.get(MEASURED_SECONDS_KEY))
+        if mid and measured is not None and measured >= 0:
+            known[mid] = measured
     if not known:
         return 0
     carried = 0
@@ -77,11 +105,13 @@ def carry_over_video_durations(new_msgs, old_msgs) -> int:
         if not isinstance(m, dict):
             continue
         video = (m.get("message") or {}).get("videoMessage")
-        if not isinstance(video, dict) or video_seconds(video) is not None:
+        if not isinstance(video, dict):
             continue
-        secs = known.get((m.get("key") or {}).get("id"))
-        if secs is not None:
-            video["seconds"] = secs
+        if _whole_seconds(video.get(MEASURED_SECONDS_KEY)) is not None:
+            continue
+        measured = known.get((m.get("key") or {}).get("id"))
+        if measured is not None:
+            video[MEASURED_SECONDS_KEY] = measured
             carried += 1
     return carried
 

--- a/client/core/utils.py
+++ b/client/core/utils.py
@@ -13,6 +13,79 @@ from cryptography.fernet import Fernet
 SEARCH_NORMALIZATION_MODES = ("off", "nfd", "nfkd")
 
 
+def video_seconds(video: dict):
+    """A video's stated length in whole seconds, or None when it doesn't
+    actually state one.
+
+    Zero counts as "not stated" HERE, unlike audio. WhatsApp Web hands over
+    duration 0 whenever the sending client left the field out of the message
+    (confirmed against /get-messages for such a video: `duration` is the
+    string "0" and no other field on the payload or its mediaData carries the
+    real length). No video lasts no time, so rendering that as "duração: 0
+    segundos" states a length that is certainly wrong — reported as exactly
+    that on a video that plays for minutes. A voice note under a second, by
+    contrast, genuinely reports 0 and WhatsApp itself shows "0:00" for it,
+    which is why the audio path keeps treating 0 as a real answer.
+
+    The value may arrive as an int or as a string, depending on which layer
+    normalized it (WebSocketClient._media_seconds() casts, a record restored
+    straight from a REST sync may not) — "0" is truthy, so this cannot be a
+    plain falsiness check at the call site.
+    """
+    if not isinstance(video, dict):
+        return None
+    raw = video.get("seconds")
+    if raw is None or raw == "":
+        return None
+    try:
+        secs = int(float(raw))
+    except (TypeError, ValueError):
+        return None
+    return secs if secs > 0 else None
+
+
+def carry_over_video_durations(new_msgs, old_msgs) -> int:
+    """Copy a measured video duration from *old_msgs* onto the matching
+    message in *new_msgs* whenever the new copy states none. Returns how many
+    were carried over.
+
+    A resync replaces the in-memory records of a chat with the server's copy,
+    and the server never learns a duration WinZapp measured from the file
+    itself (see ui/conversations.probe_media_duration) — so without this the
+    length vanished from the list the moment any sync ran, and only came back
+    after the video was played again. The database side of the same rule lives
+    in DatabaseManager._with_known_video_duration(); this one keeps what is on
+    screen right now in step with it.
+
+    A message's video is immutable — WhatsApp has no "edit the media of a sent
+    message" — so a duration measured once stays valid for that message id
+    forever. A new copy that DOES state a duration always wins, since that is
+    the sender's own answer finally arriving.
+    """
+    known = {}
+    for m in old_msgs or ():
+        if not isinstance(m, dict):
+            continue
+        mid = (m.get("key") or {}).get("id")
+        secs = video_seconds(((m.get("message") or {}).get("videoMessage")))
+        if mid and secs is not None:
+            known[mid] = secs
+    if not known:
+        return 0
+    carried = 0
+    for m in new_msgs or ():
+        if not isinstance(m, dict):
+            continue
+        video = (m.get("message") or {}).get("videoMessage")
+        if not isinstance(video, dict) or video_seconds(video) is not None:
+            continue
+        secs = known.get((m.get("key") or {}).get("id"))
+        if secs is not None:
+            video["seconds"] = secs
+            carried += 1
+    return carried
+
+
 def search_normalization_mode(value) -> str:
     """Canonicalize whatever settings.json holds into one of the three modes.
 

--- a/client/data/settings_default.json
+++ b/client/data/settings_default.json
@@ -73,6 +73,7 @@
     "storage": {
         "auto_download_media": true,
         "media_max_days": 30,
-        "media_max_mb": 100
+        "media_max_mb": 100,
+        "probe_video_duration_on_download": false
     }
 }

--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -721,6 +721,7 @@
     "auto_download_media_label": "Automatically download media when syncing",
     "media_max_days_label": "Download media from up to (days): 0 = unlimited",
     "media_max_mb_label": "Download media up to a maximum of (MB): 0 = unlimited",
+    "probe_video_duration_on_download_label": "Find the length of videos that state none as soon as they download (instead of only on playback)",
     "invalid_media_max_days": "The media download day limit must be a whole number (0 or greater).",
     "invalid_media_max_mb": "The media download size limit must be a whole number (0 or greater).",
     "sound_events_list_label": "Sound events",

--- a/client/languages/es-ES.json
+++ b/client/languages/es-ES.json
@@ -721,6 +721,7 @@
     "auto_download_media_label": "Descargar medios automáticamente al sincronizar",
     "media_max_days_label": "Descargar medios de hasta (días): 0 = ilimitado",
     "media_max_mb_label": "Descargar medios de hasta un máximo de (MB): 0 = ilimitado",
+    "probe_video_duration_on_download_label": "Averiguar la duración de los vídeos que no la indican al descargarlos (en lugar de solo al reproducirlos)",
     "invalid_media_max_days": "El límite de días para descargar medios debe ser un número entero (0 o mayor).",
     "invalid_media_max_mb": "El límite de tamaño para descargar medios debe ser un número entero (0 o mayor).",
     "sound_events_list_label": "Eventos de sonido",

--- a/client/languages/pl.json
+++ b/client/languages/pl.json
@@ -721,6 +721,7 @@
     "auto_download_media_label": "Automatycznie pobieraj multimedia podczas synchronizacji",
     "media_max_days_label": "Pobieraj multimedia sprzed maksymalnie (dni): 0 = bez ograniczeń",
     "media_max_mb_label": "Pobieraj multimedia o rozmiarze maksymalnie (MB): 0 = bez ograniczeń",
+    "probe_video_duration_on_download_label": "Ustal długość filmów, które jej nie podają, zaraz po pobraniu (zamiast dopiero przy odtwarzaniu)",
     "invalid_media_max_days": "Limit dni pobierania multimediów musi być liczbą całkowitą (0 lub większą).",
     "invalid_media_max_mb": "Limit rozmiaru pobieranych multimediów musi być liczbą całkowitą (0 lub większą).",
     "sound_events_list_label": "Zdarzenia dźwiękowe",

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -721,6 +721,7 @@
     "auto_download_media_label": "Baixar mídias automaticamente ao sincronizar",
     "media_max_days_label": "Baixar mídias de até (dias): 0 = ilimitado",
     "media_max_mb_label": "Baixar mídias de até no máximo (MB): 0 = ilimitado",
+    "probe_video_duration_on_download_label": "Descobrir a duração de vídeos sem duração informada logo ao baixá-los (em vez de só ao reproduzir)",
     "invalid_media_max_days": "O limite de dias para baixar mídias deve ser um número inteiro (0 ou maior).",
     "invalid_media_max_mb": "O limite de tamanho para baixar mídias deve ser um número inteiro (0 ou maior).",
     "sound_events_list_label": "Eventos de som",

--- a/client/languages/pt-PT.json
+++ b/client/languages/pt-PT.json
@@ -721,6 +721,7 @@
     "auto_download_media_label": "Descarregar ficheiros multimédia automaticamente ao sincronizar",
     "media_max_days_label": "Descarregar ficheiros multimédia de até (dias): 0 = ilimitado",
     "media_max_mb_label": "Descarregar ficheiros multimédia de até no máximo (MB): 0 = ilimitado",
+    "probe_video_duration_on_download_label": "Descobrir a duração de vídeos sem duração indicada logo ao transferi-los (em vez de só ao reproduzir)",
     "invalid_media_max_days": "O limite de dias para descarregar ficheiros multimédia deve ser um número inteiro (0 ou maior).",
     "invalid_media_max_mb": "O limite de tamanho para descarregar ficheiros multimédia deve ser um número inteiro (0 ou maior).",
     "sound_events_list_label": "Eventos de som",

--- a/client/main.py
+++ b/client/main.py
@@ -26,6 +26,7 @@ import shutil
 import socket as _socket
 
 import subprocess
+import tempfile
 import threading
 import textwrap
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -62,7 +63,9 @@ if sys.platform == "win32":
 from core.notification_manager import NotificationManager
 from ui.dialogs.connect import Connect
 from ui.navigation import NavigationPanel
-from ui.conversations import ConversationsPanel, ArchivedConversationsPanel
+from ui.conversations import (
+    ConversationsPanel, ArchivedConversationsPanel, probe_media_duration,
+)
 from status_panel import StatusPanel
 from version import __version__
 from window_title import format_window_title
@@ -15091,7 +15094,80 @@ class MainWindow(wx.Frame):
         encrypted = encrypt(content, self.key)
         with open(media_path, "wb") as f:
             f.write(encrypted)
+        self._maybe_probe_video_duration(msg, content)
         return True
+
+    def _maybe_probe_video_duration(self, msg: dict, content: bytes):
+        """Measure a just-downloaded video that never stated its duration, if
+        Settings > Armazenamento says to.
+
+        A video whose sender omitted the duration reads as a bare "vídeo"
+        until it is played, at which point _learn_video_duration() fills the
+        gap for free (the file is decoded for playback anyway). This option
+        trades that wait for one media decode per downloaded video: worth it
+        for someone who wants the length in the list without opening
+        anything, wasted work for someone who doesn't — hence off by default.
+
+        The measurement runs on its own thread. handle_media_message() is
+        called from the UI thread too (the play path downloads on demand
+        before starting), and a BASS decode of a 25 MB video is not something
+        to do inline there. `content` is the bytes already in hand, so the
+        just-written file is never read back and decrypted a second time.
+        """
+        if not self.settings.get("storage", {}).get(
+            "probe_video_duration_on_download", False
+        ):
+            return
+        video = (msg.get("message") or {}).get("videoMessage")
+        if not isinstance(video, dict) or video_seconds(video) is not None:
+            return
+
+        def _bg():
+            tmp_path = ""
+            try:
+                with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+                    tmp.write(content)
+                    tmp_path = tmp.name
+                secs = probe_media_duration(tmp_path)
+            except Exception:
+                logging.exception("[_maybe_probe_video_duration] probe failed")
+                return
+            finally:
+                if tmp_path:
+                    try:
+                        os.remove(tmp_path)
+                    except OSError:
+                        pass
+            if secs and secs > 0:
+                wx.CallAfter(self._apply_probed_video_duration, msg, secs)
+
+        threading.Thread(target=_bg, daemon=True).start()
+
+    def _apply_probed_video_duration(self, msg: dict, seconds: int):
+        """Store a probed video length on the record and show it (UI thread)."""
+        video = (msg.get("message") or {}).get("videoMessage")
+        if not isinstance(video, dict) or video_seconds(video) is not None:
+            # Playback got there first (_learn_video_duration) — its answer
+            # came from the same file, so there is nothing to correct.
+            return
+        video["seconds"] = seconds
+        msg_id = msg.get("key", {}).get("id", "")
+        jid = self._normalize_jid(msg.get("key", {}).get("remoteJid", ""))
+        logging.info("[_apply_probed_video_duration] %s: file says %ds", msg_id, seconds)
+        if jid and getattr(self, "db", None) is not None:
+            def _bg_persist():
+                try:
+                    self.db.insert_message(jid, msg)
+                except Exception as exc:
+                    logging.warning("[_apply_probed_video_duration] persist failed for %s: %s",
+                                    msg_id, exc)
+            self._msg_bg_executor.submit(_bg_persist)
+            self._schedule_save(dirty_jid=jid)
+        cp = getattr(self, "conversations_panel", None)
+        if cp is not None and cp.conversation and cp.conversation.get("remoteJid") == jid:
+            # Repaint only — a rebuild here would move the user's focus for a
+            # row that just gained a duration clause.
+            cp._repaint_message_rows([msg_id])
 
     def _check_wa_connection_closed(self, response) -> bool:
         """Detect a response that means "WhatsApp is not connected".

--- a/client/main.py
+++ b/client/main.py
@@ -48,7 +48,7 @@ from core.i18n import I18n
 from core.sync_contracts import observe_payload
 from core.websocket_client import WebSocketClient
 from core.api_client import api_get, api_post
-from core.utils import reaction_targets_status, encrypt, decrypt, encrypt_json, decrypt_json, generate_and_save_key, retrieve_key, format_number, is_phone_like, looks_like_binary_blob, prune_message_record, prune_chats_messages, effective_unread_count, mute_response_accepted, normalize_for_search, search_normalization_mode, parse_bool_flag as _parse_bool_flag, DEFAULT_SETTINGS, append_selected_marker, is_message_forwarded, plan_row_updates
+from core.utils import reaction_targets_status, encrypt, decrypt, encrypt_json, decrypt_json, generate_and_save_key, retrieve_key, format_number, is_phone_like, looks_like_binary_blob, prune_message_record, prune_chats_messages, effective_unread_count, mute_response_accepted, normalize_for_search, search_normalization_mode, parse_bool_flag as _parse_bool_flag, DEFAULT_SETTINGS, append_selected_marker, is_message_forwarded, plan_row_updates, carry_over_video_durations, video_seconds
 from core.locale_format import get_date_format, get_time_format, get_datetime_format
 from core.quiet_hours import is_quiet_hours_active
 from core.database_bridge import DatabaseBridge
@@ -14538,6 +14538,16 @@ class MainWindow(wx.Frame):
             )
 
         if local_records:
+            # A duration WinZapp measured from the file itself is not
+            # something the server knows, so the API copy of that same video
+            # arrives stating none — carry it across before the API copy
+            # replaces the record, or the length disappears from the list on
+            # every sync. The database keeps the same rule on its own side
+            # (DatabaseManager._with_known_video_duration).
+            carried = carry_over_video_durations(all_messages, local_records)
+            if carried:
+                logging.info("[sync_chat_messages] %s: kept %d measured video duration(s)",
+                             remote_jid, carried)
             api_ids = {r.get("key", {}).get("id") for r in all_messages}
             extra   = [r for r in local_records
                        if r.get("key", {}).get("id") and

--- a/client/main.py
+++ b/client/main.py
@@ -1291,6 +1291,13 @@ class MainWindow(wx.Frame):
         self._msg_bg_executor = ThreadPoolExecutor(
             max_workers=4, thread_name_prefix="msg-bg"
         )
+        # jid -> Future of the most recent message insert submitted for an
+        # @lid chat, so _merge_lid_into_phone() can wait for it before moving
+        # that chat's rows to the phone JID (see its own comment). Only @lid
+        # chats are tracked: they are the only ones a merge can rename, and
+        # tracking every chat would keep a dict of completed futures around
+        # for nothing.
+        self._pending_lid_inserts: dict = {}
         # Cache of resolved background-notification Sound objects
         self._notification_sound_cache: dict = {}
         # Run WPP status checks and WebSocket connection in a background thread to prevent UI freezing
@@ -4301,15 +4308,51 @@ class MainWindow(wx.Frame):
             lid_chat["remoteJid"] = phone_jid
             self.chats[phone_jid] = lid_chat
         self.chats.pop(lid_jid, None)
-        
-        def _bg_delete_chat():
-            try:
-                self.db.delete_chat(lid_jid)
-            except Exception as e:
-                logging.error(f"[merge_lid] Failed to delete merged LID chat {lid_jid}: {e}")
-        threading.Thread(target=_bg_delete_chat, daemon=True).start()
 
-        
+        # The in-memory merge above is only half the job: navigate_to_conversation()
+        # reloads a conversation's messages straight from the database by its
+        # JID, and get_messages()'s _jid_variants() knows @c.us <-> @s.whatsapp.net
+        # but nothing about @lid. So any message already filed under lid_jid has
+        # to be MOVED to phone_jid, not dropped — this used to call
+        # db.delete_chat(lid_jid), which deletes that chat's message rows
+        # outright. A first message from a contact whose @lid wasn't cached yet
+        # (on_new_message stores it under the raw @lid until /contact/pn-lid
+        # answers) was therefore deleted from the database moments after
+        # arriving: the chat-list preview still showed it, because the merged
+        # in-memory records are what the preview reads, and opening the
+        # conversation replaced those records with an empty DB read. Reported
+        # as a message from a long-quiet contact that appeared in the list and
+        # was gone by the time the conversation opened.
+        #
+        # merge_or_rename_chat() is the same operation deduplicate_chats()
+        # already uses for the sync path: it moves every row it safely can and
+        # only deletes an old_jid row once an equivalent survives under new_jid.
+        pending_insert = self._pending_lid_inserts.pop(lid_jid, None)
+
+        def _bg_merge_chat(fut=pending_insert):
+            # A just-arrived message for this @lid may still be queued for the
+            # messages table (on_new_message hands the insert to a pool
+            # thread). Renaming the chat before that insert lands would file it
+            # under a JID nothing queries again, so wait for it first. Waiting
+            # on a dedicated thread rather than inside _msg_bg_executor: a
+            # bounded pool whose workers block on other tasks from the same
+            # pool can deadlock.
+            if fut is not None:
+                try:
+                    fut.result(timeout=30)
+                except Exception as e:
+                    logging.warning(
+                        "[merge_lid] insert still pending for %s after waiting: %s",
+                        lid_jid, e,
+                    )
+            try:
+                self.db.merge_or_rename_chat(lid_jid, phone_jid)
+                logging.info("[merge_lid] moved %s -> %s in the database", lid_jid, phone_jid)
+            except Exception as e:
+                logging.error(f"[merge_lid] Failed to merge LID chat {lid_jid} into {phone_jid}: {e}")
+        threading.Thread(target=_bg_merge_chat, daemon=True).start()
+
+
         # Redirect active conversation if it was the merged LID chat, or refresh if it is the destination phone chat
         if hasattr(self, "conversations_panel") and self.conversations_panel.conversation:
             active_jid = self.conversations_panel.conversation.get("remoteJid", "")
@@ -4863,7 +4906,16 @@ class MainWindow(wx.Frame):
                 self.db.insert_message(remote_jid, msg)
             except Exception as e:
                 logging.error(f"[on_new_message] Failed to insert message to DB: {e}")
-        self._msg_bg_executor.submit(_bg_insert_msg)
+        _insert_fut = self._msg_bg_executor.submit(_bg_insert_msg)
+        if remote_jid.endswith("@lid"):
+            # This message is being filed under a JID that a later merge will
+            # rename (the @lid is only resolved to a phone JID once
+            # /contact/pn-lid answers). _merge_lid_into_phone() waits on this
+            # future so it never moves the chat out from under an insert that
+            # hasn't landed yet — that leaves the message under a JID nothing
+            # queries again, which is exactly how a first message from a
+            # contact could vanish on opening the conversation.
+            self._pending_lid_inserts[remote_jid] = _insert_fut
 
         # ── Update unread count (only for messages we received) ───────────────
         # System events never count as unread — see is_countable_message().

--- a/client/main.py
+++ b/client/main.py
@@ -49,7 +49,7 @@ from core.i18n import I18n
 from core.sync_contracts import observe_payload
 from core.websocket_client import WebSocketClient
 from core.api_client import api_get, api_post
-from core.utils import reaction_targets_status, encrypt, decrypt, encrypt_json, decrypt_json, generate_and_save_key, retrieve_key, format_number, is_phone_like, looks_like_binary_blob, prune_message_record, prune_chats_messages, effective_unread_count, mute_response_accepted, normalize_for_search, search_normalization_mode, parse_bool_flag as _parse_bool_flag, DEFAULT_SETTINGS, append_selected_marker, is_message_forwarded, plan_row_updates, carry_over_video_durations, video_seconds
+from core.utils import reaction_targets_status, encrypt, decrypt, encrypt_json, decrypt_json, generate_and_save_key, retrieve_key, format_number, is_phone_like, looks_like_binary_blob, prune_message_record, prune_chats_messages, effective_unread_count, mute_response_accepted, normalize_for_search, search_normalization_mode, parse_bool_flag as _parse_bool_flag, DEFAULT_SETTINGS, append_selected_marker, is_message_forwarded, plan_row_updates, carry_over_video_durations, video_seconds, MEASURED_SECONDS_KEY
 from core.locale_format import get_date_format, get_time_format, get_datetime_format
 from core.quiet_hours import is_quiet_hours_active
 from core.database_bridge import DatabaseBridge
@@ -15138,7 +15138,9 @@ class MainWindow(wx.Frame):
                         os.remove(tmp_path)
                     except OSError:
                         pass
-            if secs and secs > 0:
+            # secs == 0 is a real answer (a clip under a second), only None
+            # means the file could not be read — see video_seconds().
+            if secs is not None and secs >= 0:
                 wx.CallAfter(self._apply_probed_video_duration, msg, secs)
 
         threading.Thread(target=_bg, daemon=True).start()
@@ -15150,7 +15152,7 @@ class MainWindow(wx.Frame):
             # Playback got there first (_learn_video_duration) — its answer
             # came from the same file, so there is nothing to correct.
             return
-        video["seconds"] = seconds
+        video[MEASURED_SECONDS_KEY] = seconds
         msg_id = msg.get("key", {}).get("id", "")
         jid = self._normalize_jid(msg.get("key", {}).get("remoteJid", ""))
         logging.info("[_apply_probed_video_duration] %s: file says %ds", msg_id, seconds)

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -47,7 +47,7 @@ from ui.accessible import (
     CompatListBoxMessagesCtrl,
 )
 from ui.dialogs.emoji_picker import choose_and_insert_emoji
-from core.utils import reaction_targets_status, format_number, decrypt_bytes, is_phone_like, encrypt, effective_unread_count, first_unread_index, paginated_window, db_fetch_limit, looks_like_binary_blob, get_downloads_folder, normalize_for_search, normalize_line_separators, parse_bool_flag as _parse_bool_flag, append_selected_marker, is_message_forwarded
+from core.utils import reaction_targets_status, format_number, decrypt_bytes, is_phone_like, encrypt, effective_unread_count, first_unread_index, paginated_window, db_fetch_limit, looks_like_binary_blob, get_downloads_folder, normalize_for_search, normalize_line_separators, parse_bool_flag as _parse_bool_flag, append_selected_marker, is_message_forwarded, video_seconds
 from core.locale_format import get_date_format, get_time_format, get_datetime_format
 from core.video_player import VideoPlayer
 from app_paths import data_path
@@ -95,6 +95,71 @@ def message_caption(msg) -> str:
         if isinstance(media, dict):
             return (media.get("caption") or "").strip()
     return ""
+
+
+def probe_media_duration(path: str):
+    """Best-effort length in whole seconds of a media file, or None if unknown.
+
+    Supports .mp3, .ogg, .wav, .m4a, .flac, .opus, .aac etc. — and .mp4, since
+    BASS opens the container directly through the bass_aac plugin the app
+    already loads at startup (that is how core/video_player.py plays a video's
+    audio track), which is what lets a video with no stated duration be
+    measured from the file. Uses sound_lib / BASS when available, or stdlib
+    wave and header fallback parsers.
+
+    A module-level function rather than only a ConversationsPanel method
+    because MainWindow probes downloaded video from the media-download path,
+    where there is no panel in reach.
+    """
+    if not path or not os.path.isfile(path):
+        return None
+
+    # 1. Try BASS / sound_lib stream length (supports all audio formats: mp3, ogg, wav, m4a, flac, opus, aac)
+    try:
+        from sound_lib import stream
+        s = stream.FileStream(file=path)
+        length_bytes = s.get_length()
+        length_secs = s.bytes_to_seconds(length_bytes)
+        s.free()
+        if length_secs and 0 < length_secs < 86400:
+            return int(length_secs)
+    except Exception:
+        pass
+
+    # 2. Try stdlib wave module for .wav files
+    if path.lower().endswith(".wav"):
+        try:
+            import wave
+            with wave.open(path, "rb") as wf:
+                frames = wf.getnframes()
+                rate   = wf.getframerate()
+                if rate > 0:
+                    sec = int(frames / rate)
+                    if 0 < sec < 86400:
+                        return sec
+        except Exception:
+            pass
+
+    # 3. Fallback lightweight header parser for MP3 / OGG
+    try:
+        ext = os.path.splitext(path)[1].lower()
+        if ext == ".mp3":
+            size = os.path.getsize(path)
+            if size > 0:
+                # Estimate based on standard 128kbps (16000 bytes/sec)
+                sec = max(1, int(size / 16000))
+                if 0 < sec < 86400:
+                    return sec
+        elif ext in (".ogg", ".opus"):
+            size = os.path.getsize(path)
+            if size > 0:
+                sec = max(1, int(size / 6000))
+                if 0 < sec < 86400:
+                    return sec
+    except Exception:
+        pass
+
+    return None
 
 
 def _fmt_last_seen(ts, i18n) -> str:
@@ -5395,6 +5460,9 @@ class ConversationsPanel(wx.Panel):
                 tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
                 tmp.write(content)
                 tmp.close()
+                # Now that the file is on disk, it can answer what the message
+                # itself never stated (see video_seconds()).
+                self._learn_video_duration(msg, tmp.name)
                 speed = self._audio_speed_steps[self._audio_speed_index]
                 self._current_video_msg_id = msg_id
                 wx.CallAfter(self._start_video_playback, tmp.name, speed, msg_id)
@@ -5409,6 +5477,41 @@ class ConversationsPanel(wx.Panel):
                 )
 
         threading.Thread(target=_run, daemon=True).start()
+
+    def _learn_video_duration(self, msg: dict, path: str):
+        """Fill in a video's length from the decoded file when the message
+        never stated one, then persist it and repaint that row.
+
+        A video whose sender left the duration out of the message renders as
+        a bare "vídeo" (see video_seconds()) — accurate, but the length is
+        knowable the moment the file is on disk, and playing it is exactly
+        when that happens. BASS opens an .mp4 directly (the same bass_aac
+        path core/video_player.py plays it through), so _probe_audio_duration()
+        already works here and no extra process is needed.
+
+        Runs on the playback worker thread: the DB write goes through
+        _persist_message_local_flag()'s own thread, and the repaint is bounced
+        to the UI thread. Repaint rather than repopulate — a full rebuild
+        would move the user's focus in the middle of starting playback, and
+        a row that fails to repaint just keeps reading "vídeo" until the
+        conversation is reopened.
+        """
+        video = (msg.get("message") or {}).get("videoMessage")
+        if not isinstance(video, dict) or video_seconds(video) is not None:
+            return
+        secs = self._probe_audio_duration(path)
+        if not secs or secs <= 0:
+            return
+        video["seconds"] = secs
+        logging.info(
+            "[_learn_video_duration] %s: message stated no duration, file says %ds",
+            msg.get("key", {}).get("id", ""), secs,
+        )
+        jid = self.conversation.get("remoteJid", "") if self.conversation else ""
+        if jid:
+            self._persist_message_local_flag(jid, msg)
+            self.main_window._schedule_save(dirty_jid=jid)
+        wx.CallAfter(self._repaint_message_rows, [msg.get("key", {}).get("id", "")])
 
     def _start_video_playback(self, path: str, speed: float, msg_id: str):
         """Runs on the UI thread (via wx.CallAfter from _run() above). Starts
@@ -6587,60 +6690,8 @@ class ConversationsPanel(wx.Panel):
             return ""
 
     def _probe_audio_duration(self, path: str):
-        """Best-effort audio length in whole seconds for any audio format, or None if unknown.
-
-        Supports .mp3, .ogg, .wav, .m4a, .flac, .opus, .aac etc. Uses sound_lib / BASS
-        when available, or stdlib wave and header fallback parsers.
-        """
-        if not path or not os.path.isfile(path):
-            return None
-
-        # 1. Try BASS / sound_lib stream length (supports all audio formats: mp3, ogg, wav, m4a, flac, opus, aac)
-        try:
-            from sound_lib import stream
-            s = stream.FileStream(file=path)
-            length_bytes = s.get_length()
-            length_secs = s.bytes_to_seconds(length_bytes)
-            s.free()
-            if length_secs and 0 < length_secs < 86400:
-                return int(length_secs)
-        except Exception:
-            pass
-
-        # 2. Try stdlib wave module for .wav files
-        if path.lower().endswith(".wav"):
-            try:
-                import wave
-                with wave.open(path, "rb") as wf:
-                    frames = wf.getnframes()
-                    rate   = wf.getframerate()
-                    if rate > 0:
-                        sec = int(frames / rate)
-                        if 0 < sec < 86400:
-                            return sec
-            except Exception:
-                pass
-
-        # 3. Fallback lightweight header parser for MP3 / OGG
-        try:
-            ext = os.path.splitext(path)[1].lower()
-            if ext == ".mp3":
-                size = os.path.getsize(path)
-                if size > 0:
-                    # Estimate based on standard 128kbps (16000 bytes/sec)
-                    sec = max(1, int(size / 16000))
-                    if 0 < sec < 86400:
-                        return sec
-            elif ext in (".ogg", ".opus"):
-                size = os.path.getsize(path)
-                if size > 0:
-                    sec = max(1, int(size / 6000))
-                    if 0 < sec < 86400:
-                        return sec
-        except Exception:
-            pass
-
-        return None
+        """Method form of probe_media_duration() — see that function."""
+        return probe_media_duration(path)
 
     def _format_duration(self, seconds):
         """Human-readable length, or "" when it isn't known.
@@ -6854,9 +6905,10 @@ class ConversationsPanel(wx.Panel):
             if video.get("gifPlayback"):
                 # Animated GIF — treat identically to sticker
                 return i18n.t("sticker")
-            dur = self._format_duration(video.get("seconds"))
+            dur = self._format_duration(video_seconds(video))
             # Same as the audio branch: an unknown length omits the clause
             # instead of reading "duração: " with nothing after the colon.
+            # For video, "unknown" includes a stated 0 — see video_seconds().
             base = f"{i18n.t('video')}, {i18n.t('duration')}: {dur}" if dur else i18n.t("video")
             caption = (video.get("caption") or "").strip()
             return f"{base}, {caption}" if caption else base

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -1680,90 +1680,116 @@ class ConversationsPanel(wx.Panel):
 
         # ── Edit mode: update existing message ──────────────────────────────
         if self._editing_message_id is not None:
-            msg_id = self._editing_message_id
-
-            # An edit goes through exactly the same @mention pipeline as a new
-            # send. It used to skip it entirely: the raw "@DisplayName" text was
-            # posted verbatim (so WhatsApp highlighted nothing — the mention was
-            # only cosmetic) and the local record was rewritten as a plain
-            # `conversation`, discarding any contextInfo it had. That is why
-            # adding a mention with Alt+E never produced the hyperlinks that
-            # lead to the mentioned person's chat, and why editing a message
-            # that already had mentions silently dropped them.
-            api_text, edit_mentions = self._build_mention_payload(text)
-
-            # Call WPPConnect API to update the message
-            self.main_window.edit_message(
-                remote_jid, msg_id, api_text, mentioned_jids=edit_mentions
-            )
-
-            # Re-locate the message by ID rather than trusting the row index
-            # captured when edit mode was entered: a background sync can call
-            # populate_messages() at any point while the user is typing,
-            # which fully rebuilds _sorted_messages — the old index could by
-            # then point at an unrelated row, silently overwriting a
-            # different message's local content/cache with the edited text
-            # (the server-side edit_message() call above is unaffected, since
-            # it addresses the message by ID, not by index — only the local
-            # display was at risk).
-            idx = next(
-                (i for i, m in enumerate(self._sorted_messages)
-                 if isinstance(m, dict) and m.get("key", {}).get("id") == msg_id),
-                -1,
-            )
-
-            # Update local state
-            if 0 <= idx < len(self._sorted_messages):
-                edited = self._sorted_messages[idx]
-                if edit_mentions:
-                    # Same shape the send path builds for a mentioning message,
-                    # so _get_message_content() rewrites @phone → @DisplayName
-                    # and _extract_mentions() finds the JIDs for the hyperlinks.
-                    edited["message"] = {"extendedTextMessage": {"text": api_text}}
-                    edited["messageType"] = "extendedTextMessage"
-                    ctx = edited.setdefault("contextInfo", {})
-                    ctx["mentionedJid"] = edit_mentions
-                else:
-                    edited["message"] = {"conversation": text}
-                    edited["messageType"] = "conversation"
-                    # An edit that removed every mention must clear the old list
-                    # too, or the stale hyperlinks stay on screen forever.
-                    ctx = edited.get("contextInfo")
-                    if isinstance(ctx, dict):
-                        ctx.pop("mentionedJid", None)
-                        ctx.pop("mentionedJidList", None)
-                edited["_edited"] = True
-                self.messages_list.SetItemText(
-                    idx, self._render_message_line(edited)
-                )
-                # _sorted_messages[idx] is the same dict object held in
-                # main_window.chats[remote_jid]'s records (populate_messages()
-                # builds it from there without copying) — persist it so the
-                # "Editada" marker and new text survive a restart.
-                self.main_window._schedule_save(dirty_jid=remote_jid)
-                # Refresh the conversations list too — _last_msg_preview()
-                # reads straight from these records, but nothing tells the
-                # list widget to redraw the row on its own. Without this the
-                # preview kept showing the pre-edit text until the
-                # conversation was closed (which rebuilds the list from
-                # scratch for an unrelated reason) — see the remote-edit
-                # path (_apply_possible_edit(), main.py), which already
-                # does this and never had the bug.
-                self.main_window._schedule_set_chats()
-                # Rebuild the links/mentions panels if the edited row is the one
-                # currently focused — they are only refreshed on a focus change,
-                # so without this the panels below the list keep describing the
-                # message as it was before the edit.
-                if self.messages_list.GetFocusedItem() == idx:
-                    self._update_links_panel(
-                        self._extract_links(self._render_message_line(edited))
-                    )
-                    self._update_mentions_panel(self._extract_mentions(edited))
-
-            self._on_cancel_edit()
+            self._apply_message_edit(text, remote_jid)
             return
 
         # ── Normal send ──────────────────────────────────────────────────────
+        self._send_new_text_message(text, remote_jid)
+
+    def _apply_message_edit(self, text: str, remote_jid: str):
+        """Apply an edit to a message already sent: update it locally now and
+        tell WhatsApp about it on a worker thread.
+
+        Split out of on_send_message() so it can be tested without a live wx
+        panel, and so the server call is visibly off the UI thread.
+        """
+        msg_id = self._editing_message_id
+
+        # An edit goes through exactly the same @mention pipeline as a new
+        # send. It used to skip it entirely: the raw "@DisplayName" text was
+        # posted verbatim (so WhatsApp highlighted nothing — the mention was
+        # only cosmetic) and the local record was rewritten as a plain
+        # `conversation`, discarding any contextInfo it had. That is why
+        # adding a mention with Alt+E never produced the hyperlinks that
+        # lead to the mentioned person's chat, and why editing a message
+        # that already had mentions silently dropped them.
+        api_text, edit_mentions = self._build_mention_payload(text)
+
+        # Call WPPConnect to update the message — on a worker thread.
+        # edit-message drives Puppeteer/WhatsApp Web and routinely takes a
+        # second or two to come back (its own timeout is 15s); running it
+        # inline here froze the whole window for that long on every edit,
+        # the one server-backed message action still doing that. Everything
+        # below is the local, optimistic update — the same shape
+        # _on_menu_pin_message() uses.
+        threading.Thread(
+            target=self.main_window.edit_message,
+            args=(remote_jid, msg_id, api_text),
+            kwargs={"mentioned_jids": edit_mentions},
+            daemon=True,
+        ).start()
+
+        # Re-locate the message by ID rather than trusting the row index
+        # captured when edit mode was entered: a background sync can call
+        # populate_messages() at any point while the user is typing,
+        # which fully rebuilds _sorted_messages — the old index could by
+        # then point at an unrelated row, silently overwriting a
+        # different message's local content/cache with the edited text
+        # (the server-side edit_message() call above is unaffected, since
+        # it addresses the message by ID, not by index — only the local
+        # display was at risk).
+        idx = next(
+            (i for i, m in enumerate(self._sorted_messages)
+             if isinstance(m, dict) and m.get("key", {}).get("id") == msg_id),
+            -1,
+        )
+
+        # Update local state
+        if 0 <= idx < len(self._sorted_messages):
+            edited = self._sorted_messages[idx]
+            if edit_mentions:
+                # Same shape the send path builds for a mentioning message,
+                # so _get_message_content() rewrites @phone → @DisplayName
+                # and _extract_mentions() finds the JIDs for the hyperlinks.
+                edited["message"] = {"extendedTextMessage": {"text": api_text}}
+                edited["messageType"] = "extendedTextMessage"
+                ctx = edited.setdefault("contextInfo", {})
+                ctx["mentionedJid"] = edit_mentions
+            else:
+                edited["message"] = {"conversation": text}
+                edited["messageType"] = "conversation"
+                # An edit that removed every mention must clear the old list
+                # too, or the stale hyperlinks stay on screen forever.
+                ctx = edited.get("contextInfo")
+                if isinstance(ctx, dict):
+                    ctx.pop("mentionedJid", None)
+                    ctx.pop("mentionedJidList", None)
+            edited["_edited"] = True
+            self.messages_list.SetItemText(
+                idx, self._render_message_line(edited)
+            )
+            # _sorted_messages[idx] is the same dict object held in
+            # main_window.chats[remote_jid]'s records (populate_messages()
+            # builds it from there without copying) — persist it so the
+            # "Editada" marker and new text survive a restart.
+            self.main_window._schedule_save(dirty_jid=remote_jid)
+            # Refresh the conversations list too — _last_msg_preview()
+            # reads straight from these records, but nothing tells the
+            # list widget to redraw the row on its own. Without this the
+            # preview kept showing the pre-edit text until the
+            # conversation was closed (which rebuilds the list from
+            # scratch for an unrelated reason) — see the remote-edit
+            # path (_apply_possible_edit(), main.py), which already
+            # does this and never had the bug.
+            self.main_window._schedule_set_chats()
+            # Rebuild the links/mentions panels if the edited row is the one
+            # currently focused — they are only refreshed on a focus change,
+            # so without this the panels below the list keep describing the
+            # message as it was before the edit.
+            if self.messages_list.GetFocusedItem() == idx:
+                self._update_links_panel(
+                    self._extract_links(self._render_message_line(edited))
+                )
+                self._update_mentions_panel(self._extract_mentions(edited))
+
+        self._on_cancel_edit()
+
+    def _send_new_text_message(self, text: str, remote_jid: str):
+        """Queue a brand-new text message and show it as pending right away.
+
+        The other half of on_send_message(), split out alongside
+        _apply_message_edit() so neither branch hides inside the other.
+        """
         # Build a virtual message dict that renders identically to real messages.
         local_id = str(uuid.uuid4())
         api_text, _mentioned = self._build_mention_payload(text)

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -4869,11 +4869,27 @@ class ConversationsPanel(wx.Panel):
         change — SetItemText only, no list rebuild/focus disruption."""
         if not msg_ids:
             return
-        ids = set(msg_ids)
+        self._set_message_row_texts(set(msg_ids))
+
+    def _set_message_row_texts(self, ids: set) -> set:
+        """Re-render every rendered row whose message id is in *ids*, and
+        return the ids that were actually found on screen.
+
+        The bare mechanism, shared by _refresh_message_rows_by_ids() (selection
+        markers, which never care whether a row is missing) and
+        _repaint_message_rows() (local flag changes, which fall back to a full
+        rebuild when one is).
+        """
+        found = set()
         total = len(self._sorted_messages)
         for i, m in enumerate(self._sorted_messages):
-            if not self._is_separator(m) and m.get("key", {}).get("id") in ids:
+            if self._is_separator(m):
+                continue
+            mid = m.get("key", {}).get("id", "")
+            if mid in ids:
                 self.messages_list.SetItemText(i, self._render_message_line(m, index=i, total=total))
+                found.add(mid)
+        return found
 
     def _on_messages_list_key_down(self, event):
         """Ctrl+Space toggles the focused row's membership in
@@ -6088,7 +6104,11 @@ class ConversationsPanel(wx.Panel):
             self._stop_playback_for_removed_messages({msg_id})
         if msg_id and self._focused_msg_id() == msg_id:
             self._hide_all_media_controls()
-        self.refresh_active_conversation_messages()
+        # Only the revoked message's own row changes text (it keeps its row —
+        # a revoke protocolMessage is still displayable), so re-rendering every
+        # row of the conversation for it was disproportionate.
+        if not self._repaint_message_rows([msg_id]):
+            self.refresh_active_conversation_messages()
 
     def on_audio_timer(self, event):
         if self._current_video_msg_id is not None:
@@ -8979,7 +8999,7 @@ class ConversationsPanel(wx.Panel):
         if jid:
             self.main_window._schedule_save()
             self._persist_message_local_flag(jid, msg)
-            self.populate_messages(preserve_focus=True)
+            self._repaint_or_repopulate([msg.get("key", {}).get("id", "")])
 
     def _on_menu_pin_message(self, msg: dict):
         """Pin/unpin a message via WhatsApp's own message-pin feature.
@@ -8998,7 +9018,7 @@ class ConversationsPanel(wx.Panel):
         msg["pinInChat"] = pin
         self.main_window._schedule_save()
         self._persist_message_local_flag(jid, msg)
-        self.populate_messages(preserve_focus=True)
+        self._repaint_or_repopulate([msg.get("key", {}).get("id", "")])
 
         msg_key = dict(msg.get("key", {}))
 
@@ -9016,7 +9036,7 @@ class ConversationsPanel(wx.Panel):
         if jid:
             self._persist_message_local_flag(jid, msg)
         self.main_window._schedule_save()
-        self.populate_messages(preserve_focus=True)
+        self._repaint_or_repopulate([msg.get("key", {}).get("id", "")])
         i18n = self.main_window.i18n
         wx.MessageBox(
             i18n.t("pin_message_failed" if attempted_pin else "unpin_message_failed"),
@@ -11380,6 +11400,104 @@ class ConversationsPanel(wx.Panel):
             tuple(sig),
         )
 
+    @staticmethod
+    def _signature_changed_ids(old, new):
+        """Which message ids differ between two _messages_signature() snapshots.
+
+        Returns None when the difference isn't expressible as "these rows
+        changed": a different conversation, a moved unread separator, or an id
+        that is empty/repeated in either snapshot (which makes the per-id
+        comparison below ambiguous). Those change which row sits where, so no
+        per-row repaint can stand in for a rebuild.
+        """
+        if not (isinstance(old, tuple) and isinstance(new, tuple)):
+            return None
+        if len(old) != 4 or len(new) != 4 or old[:3] != new[:3]:
+            return None
+        old_rows = {r[0]: r for r in old[3]}
+        new_rows = {r[0]: r for r in new[3]}
+        if len(old_rows) != len(old[3]) or len(new_rows) != len(new[3]):
+            return None
+        if "" in old_rows or "" in new_rows:
+            return None
+        return {
+            mid for mid in set(old_rows) | set(new_rows)
+            if old_rows.get(mid) != new_rows.get(mid)
+        }
+
+    def _adopt_signature_after_repaint(self, msg_ids: set) -> None:
+        """Move refresh_messages_if_changed()'s fingerprint forward after rows
+        were repainted in place.
+
+        populate_messages() snapshots the fingerprint on its way out, so a
+        local change used to land in the cache as a side effect of rebuilding.
+        Repainting instead leaves the cache describing the state *before* the
+        change, and the next background refresh would find a mismatch and
+        rebuild the whole list — moving the user's focus for something already
+        correct on screen. Adopting the new fingerprint unconditionally would
+        be worse: anything else that changed in `records` since the last
+        rebuild would be swallowed and never rendered. So it's adopted only
+        when the rows that differ are the ones just repainted.
+        """
+        try:
+            new_sig = self._messages_signature()
+        except Exception:
+            logging.exception("[_adopt_signature_after_repaint] signature failed")
+            self._messages_signature_cache = None
+            return
+        changed = self._signature_changed_ids(
+            getattr(self, "_messages_signature_cache", None), new_sig
+        )
+        if changed is not None and changed <= set(msg_ids):
+            self._messages_signature_cache = new_sig
+
+    def _repaint_message_rows(self, msg_ids) -> bool:
+        """Repaint the rows of *msg_ids* in place instead of rebuilding the
+        list. Returns whether every requested row was found and repainted;
+        callers fall back to a full rebuild when it returns False.
+
+        Starring, pinning and a remote "delete for everyone" each change the
+        text of rows already on screen and nothing else: the list is sorted by
+        timestamp, which none of them touch, so no row moves, appears or
+        disappears (a revoked message keeps its row — see
+        _is_displayable_message()). populate_messages() nevertheless re-sorts
+        and de-duplicates every record in the conversation, rebuilds the
+        reaction map, recomputes the unread separator and the pagination
+        window, then DeleteAllItems() + Append()s every row — and hands the
+        screen reader a whole new list in the process (CLAUDE.md's
+        Freeze()/Thaw() note). Starring a selection of messages in a long
+        conversation is the visible case. Same idea as main.py's
+        refresh_chat_row_text() for the conversations list.
+        """
+        ids = {i for i in (msg_ids or ()) if i}
+        if not ids or not self._sorted_messages:
+            return False
+        # Backing list out of step with the control means a targeted
+        # SetItemText would write the right text into the wrong row.
+        if self.messages_list.GetItemCount() != len(self._sorted_messages):
+            logging.info("[_repaint_message_rows] list out of step with rows — full path")
+            return False
+        try:
+            found = self._set_message_row_texts(ids)
+        except Exception:
+            logging.exception("[_repaint_message_rows] failed — full path")
+            return False
+        if found != ids:
+            # Something asked for isn't rendered: paginated out of the current
+            # window, or replaced by a resync while a server call was in
+            # flight. The rebuild is the only thing that can show it.
+            logging.info("[_repaint_message_rows] %d of %d rows not rendered — full path",
+                         len(ids - found), len(ids))
+            return False
+        self._adopt_signature_after_repaint(ids)
+        return True
+
+    def _repaint_or_repopulate(self, msg_ids) -> None:
+        """Repaint just the rows of *msg_ids*, rebuilding the list only if
+        that isn't possible. The shape every local flag change uses."""
+        if not self._repaint_message_rows(msg_ids):
+            self.populate_messages(preserve_focus=True)
+
     def refresh_messages_if_changed(self):
         """Repopulate the messages list only when its content actually changed.
 
@@ -11828,7 +11946,9 @@ class ConversationsPanel(wx.Panel):
         if jid:
             self._persist_message_local_flags(jid, to_star)
         self.main_window._schedule_save()
-        self.populate_messages(preserve_focus=True)
+        # The whole selection, not just to_star: clearing selected_messages
+        # above dropped the " selecionado" marker from every row in it.
+        self._repaint_or_repopulate(ids)
         self.main_window.output(i18n.t("success_star_bulk"), interrupt=True)
 
     def _on_mass_pin_messages(self, event):
@@ -11863,7 +11983,7 @@ class ConversationsPanel(wx.Panel):
             m["pinInChat"] = True
         self._persist_message_local_flags(jid, to_pin)
         self.main_window._schedule_save()
-        self.populate_messages(preserve_focus=True)
+        self._repaint_or_repopulate(ids)   # see _on_mass_star_messages on `ids`
         self.main_window.output(i18n.t("success_pin_bulk"), interrupt=True)
 
         # Keys are copied now: the message dicts can be replaced underneath us
@@ -11895,7 +12015,7 @@ class ConversationsPanel(wx.Panel):
             m["pinInChat"] = False
         self._persist_message_local_flags(jid, failed)
         self.main_window._schedule_save()
-        self.populate_messages(preserve_focus=True)
+        self._repaint_or_repopulate([m.get("key", {}).get("id", "") for m in failed])
         i18n = self.main_window.i18n
         wx.MessageBox(
             f"{i18n.t('pin_message_failed')} ({len(failed)}/{total})",

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -652,6 +652,17 @@ class ConversationsPanel(wx.Panel):
         self.message_field.Bind(wx.EVT_TEXT_PASTE, self._on_text_field_paste)
         conv_sizer.Add(self.message_field, 0, wx.EXPAND | wx.ALL, 5)
 
+        # Criado (e adicionado ao sizer) antes do botão de emojis de propósito:
+        # quando há uma citação ativa, remover a citação é a ação mais imediata,
+        # então ela deve ser lida primeiro pelo leitor de tela. A ordem de
+        # tabulação segue a ordem de criação dos controles, não só a do sizer.
+        self._remove_quote_btn = wx.Button(
+            self.conversation_panel, label=i18n.t("remove_quote")
+        )
+        self._remove_quote_btn.Bind(wx.EVT_BUTTON, self._on_cancel_reply)
+        conv_sizer.Add(self._remove_quote_btn, 0, wx.LEFT | wx.BOTTOM, 5)
+        self._remove_quote_btn.Hide()
+
         self._emoji_btn = wx.Button(
             self.conversation_panel, label=i18n.t("emoji_button")
         )
@@ -665,13 +676,6 @@ class ConversationsPanel(wx.Panel):
         self._cancel_edit_btn.Bind(wx.EVT_BUTTON, self._on_cancel_edit)
         conv_sizer.Add(self._cancel_edit_btn, 0, wx.LEFT | wx.BOTTOM, 5)
         self._cancel_edit_btn.Hide()
-
-        self._remove_quote_btn = wx.Button(
-            self.conversation_panel, label=i18n.t("remove_quote")
-        )
-        self._remove_quote_btn.Bind(wx.EVT_BUTTON, self._on_cancel_reply)
-        conv_sizer.Add(self._remove_quote_btn, 0, wx.LEFT | wx.BOTTOM, 5)
-        self._remove_quote_btn.Hide()
 
         # ── Pending mention pills (one label + remove button per @mention) ──
         self._pending_mentions_panel = wx.Panel(self.conversation_panel)

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -47,7 +47,7 @@ from ui.accessible import (
     CompatListBoxMessagesCtrl,
 )
 from ui.dialogs.emoji_picker import choose_and_insert_emoji
-from core.utils import reaction_targets_status, format_number, decrypt_bytes, is_phone_like, encrypt, effective_unread_count, first_unread_index, paginated_window, db_fetch_limit, looks_like_binary_blob, get_downloads_folder, normalize_for_search, normalize_line_separators, parse_bool_flag as _parse_bool_flag, append_selected_marker, is_message_forwarded, video_seconds
+from core.utils import reaction_targets_status, format_number, decrypt_bytes, is_phone_like, encrypt, effective_unread_count, first_unread_index, paginated_window, db_fetch_limit, looks_like_binary_blob, get_downloads_folder, normalize_for_search, normalize_line_separators, parse_bool_flag as _parse_bool_flag, append_selected_marker, is_message_forwarded, video_seconds, MEASURED_SECONDS_KEY
 from core.locale_format import get_date_format, get_time_format, get_datetime_format
 from core.video_player import VideoPlayer
 from app_paths import data_path
@@ -115,6 +115,11 @@ def probe_media_duration(path: str):
         return None
 
     # 1. Try BASS / sound_lib stream length (supports all audio formats: mp3, ogg, wav, m4a, flac, opus, aac)
+    #    A file that reads as shorter than a second returns 0, not None: the
+    #    caller has to tell "measured, and it really is that short" apart from
+    #    "could not measure" — see core.utils.video_seconds(). A length of
+    #    exactly 0.0 is the second case (nothing decodable), so it falls
+    #    through to the parsers below.
     try:
         from sound_lib import stream
         s = stream.FileStream(file=path)
@@ -133,9 +138,9 @@ def probe_media_duration(path: str):
             with wave.open(path, "rb") as wf:
                 frames = wf.getnframes()
                 rate   = wf.getframerate()
-                if rate > 0:
+                if frames > 0 and rate > 0:
                     sec = int(frames / rate)
-                    if 0 < sec < 86400:
+                    if sec < 86400:
                         return sec
         except Exception:
             pass
@@ -5500,9 +5505,12 @@ class ConversationsPanel(wx.Panel):
         if not isinstance(video, dict) or video_seconds(video) is not None:
             return
         secs = self._probe_audio_duration(path)
-        if not secs or secs <= 0:
+        # 0 is a real answer here, unlike the 0 the message itself states: the
+        # file was read and it really is under a second. Only None means the
+        # probe could not tell (see video_seconds()).
+        if secs is None or secs < 0:
             return
-        video["seconds"] = secs
+        video[MEASURED_SECONDS_KEY] = secs
         logging.info(
             "[_learn_video_duration] %s: message stated no duration, file says %ds",
             msg.get("key", {}).get("id", ""), secs,

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -1164,6 +1164,52 @@ class ConversationsPanel(wx.Panel):
             return i18n.t("group_admins_only")
         return f"{i18n.t('type_message_group') if is_group else i18n.t('type_message')} {name}"
 
+    def _apply_composer_permissions(self, jid: str, conversation: dict):
+        """Enable/disable the composer controls according to what *jid* allows.
+
+        Three cases: a channel (nothing can be posted at all), a group with
+        "only admins can send messages" on where the user isn't an admin, and
+        everything else.  Kept out of navigate_to_conversation() so it can be
+        tested without a live wx panel — the emoji button used to be the one
+        control this switch forgot, staying clickable in a group the user
+        cannot post in and inserting text into a read-only field.
+        """
+        is_channel = jid.endswith("@newsletter")
+        admins_only_group = (
+            jid.endswith("@g.us")
+            and self.main_window._is_group_send_restricted(conversation)
+        )
+        if is_channel:
+            self.message_field.Enable()
+            self.message_field.SetEditable(True)
+            self.message_field.Disable()
+            self.send_message_btn.Disable()
+            self.record_voice_message_btn.Disable()
+            self._add_attachment_btn.Disable()
+            self._emoji_btn.Disable()
+        elif admins_only_group:
+            # Keep the field enabled/focusable (unlike the channel case
+            # above) so it stays reachable via Tab/the Alt+D accelerator and
+            # NVDA can announce its read-only state — only actual editing is
+            # blocked. Sending/attaching/recording would just be rejected by
+            # WhatsApp Web anyway, so those stay disabled like the channel case.
+            # Disable() here instead of SetEditable(False) drops the field out
+            # of the tab order entirely, which leaves a screen-reader user in
+            # a group they cannot post in with nothing announcing why.
+            self.message_field.Enable()
+            self.message_field.SetEditable(False)
+            self.send_message_btn.Disable()
+            self.record_voice_message_btn.Disable()
+            self._add_attachment_btn.Disable()
+            self._emoji_btn.Disable()
+        else:
+            self.message_field.Enable()
+            self.message_field.SetEditable(True)
+            self.send_message_btn.Enable()
+            self.record_voice_message_btn.Enable()
+            self._add_attachment_btn.Enable()
+            self._emoji_btn.Enable()
+
     def update_conversation_name(self, jid: str, new_name: str):
         """Apply a group rename to the conversation currently on screen.
 
@@ -1282,35 +1328,7 @@ class ConversationsPanel(wx.Panel):
             self._conversation_note_text(self.conversation_name, is_group)
         )
 
-        is_channel        = jid.endswith("@newsletter")
-        admins_only_group = is_group and self.main_window._is_group_send_restricted(conversation)
-        if is_channel:
-            self.message_field.Enable()
-            self.message_field.SetEditable(True)
-            self.message_field.Disable()
-            self.send_message_btn.Disable()
-            self.record_voice_message_btn.Disable()
-            self._add_attachment_btn.Disable()
-        elif admins_only_group:
-            # Keep the field enabled/focusable (unlike the channel case
-            # above) so it stays reachable via Tab/the Alt+D accelerator and
-            # NVDA can announce its read-only state — only actual editing is
-            # blocked. Sending/attaching/recording would just be rejected by
-            # WhatsApp Web anyway, so those stay disabled like the channel case.
-            # Disable() here instead of SetEditable(False) drops the field out
-            # of the tab order entirely, which leaves a screen-reader user in
-            # a group they cannot post in with nothing announcing why.
-            self.message_field.Enable()
-            self.message_field.SetEditable(False)
-            self.send_message_btn.Disable()
-            self.record_voice_message_btn.Disable()
-            self._add_attachment_btn.Disable()
-        else:
-            self.message_field.Enable()
-            self.message_field.SetEditable(True)
-            self.send_message_btn.Enable()
-            self.record_voice_message_btn.Enable()
-            self._add_attachment_btn.Enable()
+        self._apply_composer_permissions(jid, conversation)
         self.message_label.SetLabel(
             self._message_label_text(jid, conversation, self.conversation_name)
         )

--- a/client/ui/dialogs/settings_dialog.py
+++ b/client/ui/dialogs/settings_dialog.py
@@ -753,6 +753,15 @@ class SettingsDialog(wx.Dialog):
         self._media_max_mb_field = wx.TextCtrl(self._storage_page, style=wx.TE_DONTWRAP)
         storage_sizer.Add(self._media_max_mb_field, 0, wx.EXPAND | wx.ALL, 8)
 
+        # Off by default: it costs one media decode per downloaded video, and
+        # a video that never states its duration simply reads as "vídeo" until
+        # it is played, which already fills the gap for free (see
+        # ConversationsPanel._learn_video_duration).
+        self._probe_video_duration_check = wx.CheckBox(
+            self._storage_page, label=i18n.t("probe_video_duration_on_download_label")
+        )
+        storage_sizer.Add(self._probe_video_duration_check, 0, wx.ALL, 8)
+
         self._storage_page.SetSizer(storage_sizer)
         self._notebook.AddPage(self._storage_page, i18n.t("tab_storage"))
 
@@ -1049,6 +1058,9 @@ class SettingsDialog(wx.Dialog):
         self._auto_download_media_check.SetValue(storage.get("auto_download_media", True))
         self._media_max_days_field.SetValue(str(storage.get("media_max_days", 30)))
         self._media_max_mb_field.SetValue(str(storage.get("media_max_mb", 100)))
+        self._probe_video_duration_check.SetValue(
+            storage.get("probe_video_duration_on_download", False)
+        )
 
     def _set_alert_combo(self, combo, choice_key: str):
         try:
@@ -1925,6 +1937,7 @@ class SettingsDialog(wx.Dialog):
             "auto_download_media": self._auto_download_media_check.GetValue(),
             "media_max_days": int(self._media_max_days_field.GetValue().strip()),
             "media_max_mb": int(self._media_max_mb_field.GetValue().strip()),
+            "probe_video_duration_on_download": self._probe_video_duration_check.GetValue(),
         })
 
         # Persist and propagate

--- a/client/updater.py
+++ b/client/updater.py
@@ -341,6 +341,133 @@ def _wrap_changelog_text(text: str, width: int = 100) -> str:
 
 # ── Install helpers ───────────────────────────────────────────────────────────
 
+def _oem_encoding() -> str:
+    """The code page cmd.exe decodes a .bat file with.
+
+    Not the one Python writes text in by default, and not UTF-8: a console
+    reads a batch script in the OEM code page (CP852 on a Polish Windows,
+    CP850 on a Portuguese one, ...). GetOEMCP() is what actually answers
+    that; cp850 is a last-resort guess if the call is unavailable.
+    """
+    try:
+        return f"cp{ctypes.windll.kernel32.GetOEMCP()}"
+    except Exception:
+        return "cp850"
+
+
+def _console_safe_path(path: str) -> str:
+    """*path* in a form a batch script can carry safely — its 8.3 short form
+    when the long one has characters outside ASCII.
+
+    A path like ``C:\\Users\\Paweł\\AppData\\Local\\WinZapp`` written into a
+    .bat as UTF-8 reaches cmd.exe as mojibake, because cmd decodes the file in
+    the OEM code page (see _oem_encoding()). Every command that path appears
+    in then addresses a directory that does not exist — which is exactly how
+    an update could copy nothing, write no failure marker (the marker path
+    contains the same character), and never relaunch the app (so does the
+    exe path), leaving no trace of why. Reported from a Windows account whose
+    name contains "ł" (issue #83).
+
+    GetShortPathNameW returns the 8.3 alias, which is pure ASCII, so the
+    script becomes code-page-independent. It needs the path to exist and 8.3
+    generation to be enabled on the volume; when either isn't true it returns
+    the long path unchanged and the caller falls back to writing the script
+    in the OEM code page instead.
+    """
+    if not path or path.isascii() or sys.platform != "win32":
+        return path
+    try:
+        buf = ctypes.create_unicode_buffer(32768)
+        length = ctypes.windll.kernel32.GetShortPathNameW(path, buf, len(buf))
+        if length and buf.value and buf.value.isascii():
+            return buf.value
+        logging.info(
+            "Auto-updater: no ASCII 8.3 name for %r (8.3 generation disabled?) "
+            "— falling back to the OEM code page for the script.", path,
+        )
+    except Exception:
+        logging.exception("Auto-updater: GetShortPathNameW failed for %r", path)
+    return path
+
+
+def _build_installer_script(source_dir: str, install_dir: str, exe_path: str,
+                            log_path: str, marker_path: str, pid: int,
+                            api_port: int) -> str:
+    """The batch script text. Pure — every path is already console-safe.
+
+    Kept apart from _run_batch_installer() so what the script says can be
+    asserted without launching anything.
+    """
+    return (
+        "@echo off\n"
+        f'> "{log_path}" echo [WinZapp] update started %DATE% %TIME%\n'
+        # The active code page goes into the log first: when a path does come
+        # out wrong, this is the single fact that explains it, and the old
+        # script left no record of anything at all.
+        f'>> "{log_path}" chcp\n'
+        f'>> "{log_path}" echo source: {source_dir}\n'
+        f'>> "{log_path}" echo target: {install_dir}\n'
+        ":WAIT\n"
+        f'tasklist /FI "PID eq {pid}" 2>NUL | find "{pid}" >NUL\n'
+        "if not errorlevel 1 (\n"
+        "    timeout /t 1 /nobreak >NUL\n"
+        "    goto WAIT\n"
+        ")\n"
+        # Give child processes a moment to exit, then kill stragglers holding file locks.
+        "timeout /t 2 /nobreak >NUL\n"
+        f"for /f \"tokens=5\" %%a in ('netstat -aon ^| findstr :{api_port} ^| findstr LISTENING') do taskkill /F /PID %%a >NUL 2>&1\n"
+        "for /f \"tokens=5\" %%a in ('netstat -aon ^| findstr :5433 ^| findstr LISTENING') do taskkill /F /PID %%a >NUL 2>&1\n"
+        "timeout /t 1 /nobreak >NUL\n"
+        # xcopy's exit code was previously never checked, so a failed copy
+        # (locked file, disk full, permissions) silently relaunched whatever
+        # was already in install_dir — the user saw the app come back and
+        # assumed the update worked. errorlevel 4+ means xcopy itself failed
+        # (as opposed to 0/1, which just mean "nothing to copy"/"success");
+        # leave a marker file WinZapp checks on next startup so the user is
+        # told instead of silently running a stale/partial install.
+        f'xcopy /E /Y /I /H "{source_dir}\\*" "{install_dir}\\" >> "{log_path}" 2>&1\n'
+        "if errorlevel 4 (\n"
+        f'    >> "{log_path}" echo xcopy FAILED\n'
+        f'    echo update failed > "{marker_path}"\n'
+        f'    if exist "{exe_path}" start "" "{exe_path}"\n'
+        # Deliberately not deleted on failure: the script and its log are the
+        # only evidence of what went wrong, and erasing them is what made the
+        # original report impossible to diagnose from the user's machine.
+        "    exit /b 1\n"
+        ")\n"
+        f'>> "{log_path}" echo xcopy OK\n'
+        f'if exist "{exe_path}" start "" "{exe_path}"\n'
+        'del "%~f0"\n'
+    )
+
+
+def _write_installer_script(bat_path: str, script: str) -> bool:
+    """Write *script* so cmd.exe reads it back correctly. Returns success.
+
+    ASCII (the normal case, and what _console_safe_path() aims for) is written
+    as-is. Anything left over is written in the code page cmd will decode it
+    with — never UTF-8, which is what made a non-ASCII install path unusable.
+    A script that cannot be represented at all is refused rather than written
+    corrupt: the caller then reports a failed update instead of closing the
+    app for an installer that would quietly do nothing.
+    """
+    encoding = "ascii" if script.isascii() else _oem_encoding()
+    try:
+        with open(bat_path, "w", encoding=encoding, errors="strict", newline="\r\n") as f:
+            f.write(script)
+    except (UnicodeEncodeError, LookupError) as exc:
+        logging.error(
+            "Auto-updater: installer script cannot be written in %s (%s) — "
+            "the install path has characters cmd.exe cannot read back. "
+            "Aborting instead of running a script with broken paths.",
+            encoding, exc,
+        )
+        return False
+    logging.info("Auto-updater: Wrote batch installer script to %s (encoding=%s)",
+                 bat_path, encoding)
+    return True
+
+
 def _needs_admin() -> bool:
     """Return True if the install directory is not writable by the current user."""
     install_dir = _outer_exe_dir()
@@ -377,39 +504,29 @@ def _run_batch_installer(extracted_dir: str, install_dir: str, exe_name: str, pi
     bat_fd, bat_path = tempfile.mkstemp(suffix=".bat", prefix="winzapp_upd_")
     os.close(bat_fd)
 
-    exe_path = os.path.join(install_dir, exe_name)
+    # Every path the script carries is made console-safe: a non-ASCII install
+    # path (a Windows account named "Paweł", issue #83) reached cmd.exe as
+    # mojibake and every command in the script then addressed a directory that
+    # does not exist. Only the DIRECTORIES are converted — GetShortPathNameW
+    # answers for paths that exist, and the exe/marker/log are files the
+    # script is about to create — so the ASCII file names are joined onto the
+    # already-safe directory afterwards. The log lives next to the install so
+    # it survives the update either way; the previous script left no record at
+    # all, which is why this failed silently.
+    safe_source  = _console_safe_path(source_dir)
+    safe_install = _console_safe_path(install_dir)
 
-    bat = (
-        "@echo off\n"
-        ":WAIT\n"
-        f'tasklist /FI "PID eq {pid}" 2>NUL | find "{pid}" >NUL\n'
-        "if not errorlevel 1 (\n"
-        "    timeout /t 1 /nobreak >NUL\n"
-        "    goto WAIT\n"
-        ")\n"
-        # Give child processes a moment to exit, then kill stragglers holding file locks.
-        "timeout /t 2 /nobreak >NUL\n"
-        f"for /f \"tokens=5\" %%a in ('netstat -aon ^| findstr :{api_port} ^| findstr LISTENING') do taskkill /F /PID %%a >NUL 2>&1\n"
-        "for /f \"tokens=5\" %%a in ('netstat -aon ^| findstr :5433 ^| findstr LISTENING') do taskkill /F /PID %%a >NUL 2>&1\n"
-        "timeout /t 1 /nobreak >NUL\n"
-        # xcopy's exit code was previously never checked, so a failed copy
-        # (locked file, disk full, permissions) silently relaunched whatever
-        # was already in install_dir — the user saw the app come back and
-        # assumed the update worked. errorlevel 4+ means xcopy itself failed
-        # (as opposed to 0/1, which just mean "nothing to copy"/"success");
-        # leave a marker file WinZapp checks on next startup so the user is
-        # told instead of silently running a stale/partial install.
-        f'xcopy /E /Y /I /H "{source_dir}\\*" "{install_dir}\\"\n'
-        "if errorlevel 4 (\n"
-        f'    echo update failed > "{install_dir}\\update_failed.marker"\n'
-        ")\n"
-        f'if exist "{exe_path}" start "" "{exe_path}"\n'
-        'del "%~f0"\n'
+    script = _build_installer_script(
+        safe_source,
+        safe_install,
+        os.path.join(safe_install, exe_name),
+        os.path.join(safe_install, "update_install.log"),
+        os.path.join(safe_install, "update_failed.marker"),
+        pid,
+        api_port,
     )
-
-    with open(bat_path, "w", encoding="utf-8") as f:
-        f.write(bat)
-    logging.info("Auto-updater: Wrote batch installer script to %s", bat_path)
+    if not _write_installer_script(bat_path, script):
+        return False
 
     if sys.platform == "win32":
         needs_admin = _needs_admin()

--- a/tests/test_composer_permissions.py
+++ b/tests/test_composer_permissions.py
@@ -1,0 +1,110 @@
+"""Tests for ConversationsPanel._apply_composer_permissions().
+
+Opening a channel, or a group with "only admins can send messages" on while
+the user is not an admin, disables the composer's send/record/attach buttons.
+The emoji button was left out of that switch: it stayed clickable in a group
+the user cannot post in, opening the picker and inserting text into a field
+that had just been made read-only.
+
+ConversationsPanel is a wx.Panel and cannot be instantiated without a running
+wx.App, so the method under test is bound to a small stub carrying only the
+widgets it touches — same approach as tests/test_conversation_name_update.py.
+"""
+
+import pytest
+
+from ui.conversations import ConversationsPanel
+
+
+class _FakeButton:
+    def __init__(self):
+        self.enabled = None
+
+    def Enable(self):
+        self.enabled = True
+
+    def Disable(self):
+        self.enabled = False
+
+
+class _FakeTextField(_FakeButton):
+    def __init__(self):
+        super().__init__()
+        self.editable = None
+
+    def SetEditable(self, value):
+        self.editable = value
+
+
+class _FakeMainWindow:
+    def __init__(self, restricted=()):
+        self._restricted = set(restricted)
+
+    def _is_group_send_restricted(self, chat):
+        return chat.get("remoteJid", "") in self._restricted
+
+
+class _Panel:
+    _apply_composer_permissions = ConversationsPanel._apply_composer_permissions
+
+    def __init__(self, restricted=()):
+        self.main_window = _FakeMainWindow(restricted)
+        self.message_field = _FakeTextField()
+        self.send_message_btn = _FakeButton()
+        self.record_voice_message_btn = _FakeButton()
+        self._add_attachment_btn = _FakeButton()
+        self._emoji_btn = _FakeButton()
+
+
+_GROUP = "123456-group@g.us"
+
+
+class TestRestrictedGroup:
+    def test_emoji_button_is_disabled_with_the_other_send_controls(self):
+        panel = _Panel(restricted=[_GROUP])
+        panel._apply_composer_permissions(_GROUP, {"remoteJid": _GROUP})
+        assert panel._emoji_btn.enabled is False
+        assert panel.send_message_btn.enabled is False
+        assert panel.record_voice_message_btn.enabled is False
+        assert panel._add_attachment_btn.enabled is False
+
+    def test_message_field_stays_focusable_but_read_only(self):
+        panel = _Panel(restricted=[_GROUP])
+        panel._apply_composer_permissions(_GROUP, {"remoteJid": _GROUP})
+        assert panel.message_field.enabled is True
+        assert panel.message_field.editable is False
+
+
+class TestChannel:
+    def test_emoji_button_is_disabled(self):
+        panel = _Panel()
+        jid = "123456@newsletter"
+        panel._apply_composer_permissions(jid, {"remoteJid": jid})
+        assert panel._emoji_btn.enabled is False
+        assert panel.message_field.enabled is False
+
+
+class TestWritableConversations:
+    def test_unrestricted_group_keeps_every_control_enabled(self):
+        panel = _Panel()
+        panel._apply_composer_permissions(_GROUP, {"remoteJid": _GROUP})
+        assert panel._emoji_btn.enabled is True
+        assert panel.send_message_btn.enabled is True
+        assert panel.message_field.editable is True
+
+    def test_private_chat_keeps_every_control_enabled(self):
+        panel = _Panel(restricted=[_GROUP])
+        jid = "5511988888888@s.whatsapp.net"
+        panel._apply_composer_permissions(jid, {"remoteJid": jid})
+        assert panel._emoji_btn.enabled is True
+        assert panel.send_message_btn.enabled is True
+        assert panel.message_field.editable is True
+
+    def test_reopening_a_writable_chat_reenables_after_a_restricted_one(self):
+        # The switch has to re-enable, not just skip disabling: the panel is
+        # reused across conversations, so a disabled emoji button would stick.
+        panel = _Panel(restricted=[_GROUP])
+        panel._apply_composer_permissions(_GROUP, {"remoteJid": _GROUP})
+        jid = "5511988888888@s.whatsapp.net"
+        panel._apply_composer_permissions(jid, {"remoteJid": jid})
+        assert panel._emoji_btn.enabled is True

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -437,6 +437,26 @@ class TestMergeOrRenameChat:
         old_msgs = await in_memory_db.get_messages("old@lid")
         assert old_msgs == []
 
+    async def test_a_message_left_under_an_lid_is_invisible_from_the_phone_jid(
+        self, in_memory_db
+    ):
+        """Why the merge is mandatory rather than cosmetic: _jid_variants()
+        bridges @c.us <-> @s.whatsapp.net and nothing else, so a message still
+        filed under the contact's @lid cannot be read back through the phone
+        JID — which is the only one navigate_to_conversation() ever asks for
+        once the chats have been merged in memory."""
+        await in_memory_db.insert_message("old@lid", {
+            "key": {"remoteJid": "old@lid", "id": "m1"},
+            "messageTimestamp": 1,
+        })
+
+        assert await in_memory_db.get_messages("new@s.whatsapp.net") == []
+
+        await in_memory_db.merge_or_rename_chat("old@lid", "new@s.whatsapp.net")
+
+        msgs = await in_memory_db.get_messages("new@s.whatsapp.net")
+        assert [m["key"]["id"] for m in msgs] == ["m1"]
+
     async def test_merge_deletes_old_chat_row_when_new_exists(self, in_memory_db):
         await in_memory_db.upsert_chat("old@lid", {"remoteJid": "old@lid"})
         await in_memory_db.upsert_chat("new@w", {"remoteJid": "new@w", "pushName": "Kept"})

--- a/tests/test_edit_message_off_ui_thread.py
+++ b/tests/test_edit_message_off_ui_thread.py
@@ -1,0 +1,209 @@
+"""Regression test: editing a message froze the UI for a second or two.
+
+ConversationsPanel's edit path called MainWindow.edit_message() inline, on the
+wx main thread. That method POSTs to WPPConnect's /edit-message, which drives
+Puppeteer/WhatsApp Web and routinely takes a second or two to answer (its own
+timeout is 15s) — so the whole window stopped responding for the length of the
+request every single time a sent message was edited. It was the last
+server-backed message action still doing that: sending goes through
+MessageQueue's worker, pinning and deleting each start their own thread.
+
+The fix runs the server call on a worker and applies the local update
+immediately, the same optimistic shape _on_menu_pin_message() uses.
+
+ConversationsPanel is a wx.Panel and cannot be instantiated without a running
+wx.App, so _apply_message_edit() is bound to a small stub — same approach as
+tests/test_message_bookmarks.py.
+"""
+
+import pytest
+
+from ui.conversations import ConversationsPanel
+
+
+class _FakeList:
+    def __init__(self, focused=-1):
+        self._focused = focused
+        self.texts = {}
+
+    def SetItemText(self, idx, text):
+        self.texts[idx] = text
+
+    def GetFocusedItem(self):
+        return self._focused
+
+
+class _FakeMainWindow:
+    def __init__(self):
+        self.edit_calls = []
+        self.saves = []
+        self.set_chats_calls = 0
+
+    def edit_message(self, remote_jid, message_id, new_text, mentioned_jids=None):
+        self.edit_calls.append((remote_jid, message_id, new_text, mentioned_jids))
+
+    def _schedule_save(self, dirty_jid=None):
+        self.saves.append(dirty_jid)
+
+    def _schedule_set_chats(self):
+        self.set_chats_calls += 1
+
+
+class _Panel:
+    _apply_message_edit = ConversationsPanel._apply_message_edit
+
+    def __init__(self, messages=(), editing_id="m1", mentions=None, focused=-1):
+        self.main_window = _FakeMainWindow()
+        self._sorted_messages = list(messages)
+        self.messages_list = _FakeList(focused=focused)
+        self._editing_message_id = editing_id
+        self._mentions = mentions
+        self.cancel_calls = 0
+        self.links_panels = []
+        self.mentions_panels = []
+
+    def _build_mention_payload(self, text):
+        return (text, self._mentions)
+
+    def _render_message_line(self, msg, index=None, total=None):
+        body = msg.get("message", {})
+        return body.get("conversation") or body.get("extendedTextMessage", {}).get("text", "")
+
+    def _on_cancel_edit(self):
+        self.cancel_calls += 1
+
+    def _extract_links(self, line):
+        return []
+
+    def _extract_mentions(self, msg):
+        return []
+
+    def _update_links_panel(self, links):
+        self.links_panels.append(links)
+
+    def _update_mentions_panel(self, mentions):
+        self.mentions_panels.append(mentions)
+
+
+class _CapturedThread:
+    """threading.Thread stand-in that records the call instead of running it,
+    so a test can tell the work was handed to a worker at all."""
+
+    created = []
+
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+        self.daemon_flag = daemon
+        _CapturedThread.created.append(self)
+
+    def start(self):
+        pass
+
+    def run_it(self):
+        self._target(*self._args, **self._kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _captured_threads(monkeypatch):
+    _CapturedThread.created = []
+    monkeypatch.setattr("ui.conversations.threading.Thread", _CapturedThread)
+    yield
+    _CapturedThread.created = []
+
+
+def _msg(mid="m1", text="antes"):
+    return {
+        "key": {"id": mid, "fromMe": True},
+        "messageType": "conversation",
+        "message": {"conversation": text},
+    }
+
+
+class TestServerCallIsOffTheUiThread:
+    def test_the_edit_request_is_handed_to_a_worker(self):
+        panel = _Panel([_msg()])
+
+        panel._apply_message_edit("depois", "grupo@g.us")
+
+        assert panel.main_window.edit_calls == [], (
+            "edit_message() must not run inline — it blocks the UI thread for "
+            "as long as WhatsApp Web takes to answer"
+        )
+        assert len(_CapturedThread.created) == 1
+        assert _CapturedThread.created[0].daemon_flag is True
+
+    def test_the_worker_sends_exactly_what_the_edit_asked_for(self):
+        panel = _Panel([_msg()], mentions=["5511999999999@s.whatsapp.net"])
+
+        panel._apply_message_edit("depois", "grupo@g.us")
+        _CapturedThread.created[0].run_it()
+
+        assert panel.main_window.edit_calls == [
+            ("grupo@g.us", "m1", "depois", ["5511999999999@s.whatsapp.net"])
+        ]
+
+    def test_the_row_is_updated_without_waiting_for_the_server(self):
+        panel = _Panel([_msg()])
+
+        panel._apply_message_edit("depois", "grupo@g.us")
+
+        # Nothing ran the worker, yet the local state is already applied.
+        assert panel._sorted_messages[0]["message"] == {"conversation": "depois"}
+        assert panel._sorted_messages[0]["_edited"] is True
+        assert panel.messages_list.texts == {0: "depois"}
+        assert panel.main_window.saves == ["grupo@g.us"]
+        assert panel.main_window.set_chats_calls == 1
+        assert panel.cancel_calls == 1
+
+
+class TestLocalUpdate:
+    def test_the_message_is_located_by_id_not_by_row_index(self):
+        """A background sync can rebuild _sorted_messages while the user is
+        typing, so the index captured when edit mode was entered may by then
+        point at an unrelated row."""
+        panel = _Panel([_msg("other", "outra"), _msg("m1", "antes")])
+
+        panel._apply_message_edit("depois", "grupo@g.us")
+
+        assert panel._sorted_messages[0]["message"] == {"conversation": "outra"}
+        assert panel._sorted_messages[1]["message"] == {"conversation": "depois"}
+
+    def test_an_edit_that_adds_mentions_keeps_the_extended_shape(self):
+        panel = _Panel([_msg()], mentions=["5511999999999@s.whatsapp.net"])
+
+        panel._apply_message_edit("oi @5511999999999", "grupo@g.us")
+
+        edited = panel._sorted_messages[0]
+        assert edited["messageType"] == "extendedTextMessage"
+        assert edited["contextInfo"]["mentionedJid"] == ["5511999999999@s.whatsapp.net"]
+
+    def test_an_edit_that_removes_every_mention_clears_the_stale_list(self):
+        msg = _msg()
+        msg["contextInfo"] = {"mentionedJid": ["5511999999999@s.whatsapp.net"]}
+        panel = _Panel([msg], mentions=None)
+
+        panel._apply_message_edit("sem mencao", "grupo@g.us")
+
+        assert "mentionedJid" not in panel._sorted_messages[0]["contextInfo"]
+
+    def test_a_message_no_longer_in_the_list_still_leaves_edit_mode(self):
+        """The server call already went out addressed by id; the local half
+        just has nothing to update. Staying stuck in edit mode would be worse."""
+        panel = _Panel([_msg("other")])
+
+        panel._apply_message_edit("depois", "grupo@g.us")
+
+        assert len(_CapturedThread.created) == 1
+        assert panel.main_window.saves == []
+        assert panel.cancel_calls == 1
+
+    def test_the_side_panels_refresh_only_for_the_focused_row(self):
+        panel = _Panel([_msg()], focused=0)
+        panel._apply_message_edit("depois", "grupo@g.us")
+        assert panel.links_panels and panel.mentions_panels
+
+        other = _Panel([_msg()], focused=5)
+        other._apply_message_edit("depois", "grupo@g.us")
+        assert other.links_panels == [] and other.mentions_panels == []

--- a/tests/test_edit_message_refreshes_chat_list.py
+++ b/tests/test_edit_message_refreshes_chat_list.py
@@ -1,8 +1,9 @@
 """Test for GitHub issue #12: editing the most recent message in a chat
 didn't update its preview in the conversations list.
 
-Root cause: ConversationsPanel.on_send_message()'s edit-mode branch
-(conversations.py) mutates the message dict in place and persists it via
+Root cause: ConversationsPanel's edit-mode branch (_apply_message_edit(),
+split out of on_send_message()) mutates the message dict in place and
+persists it via
 main_window._schedule_save(), but never told the conversations LIST widget
 to redraw — _last_msg_preview() (main.py) reads straight from the mutated
 record so the data was correct, nothing just repainted the row. Only
@@ -12,10 +13,11 @@ picked up the change. The companion path for a REMOTE edit
 main_window._schedule_set_chats() and never had this bug — this fixes the
 local-edit path to match.
 
-on_send_message() is a large method deep in wx widget interactions
-(message_field, mention pills, etc.) that isn't practical to drive end to
-end without a running wx.App, so this pins the fix structurally via source
-inspection — same approach as tests/test_archived_context_menu.py.
+The edit path sits deep in wx widget interactions (message_field, mention
+pills, etc.) that aren't practical to drive end to end without a running
+wx.App, so this pins the fix structurally via source inspection — same
+approach as tests/test_archived_context_menu.py. The behaviour it can be
+driven for lives in tests/test_edit_message_off_ui_thread.py.
 """
 
 import inspect
@@ -25,12 +27,7 @@ from ui.conversations import ConversationsPanel
 
 
 def test_edit_mode_branch_refreshes_the_conversations_list():
-    src = inspect.getsource(ConversationsPanel.on_send_message)
-
-    # Isolate the edit-mode branch (from "Edit mode:" down to "Normal send").
-    start = src.index("Edit mode: update existing message")
-    end = src.index("Normal send")
-    edit_branch = src[start:end]
+    edit_branch = inspect.getsource(ConversationsPanel._apply_message_edit)
 
     assert "self.main_window._schedule_save(dirty_jid=remote_jid)" in edit_branch
     assert "self.main_window._schedule_set_chats()" in edit_branch, (

--- a/tests/test_empty_placeholder_cleared.py
+++ b/tests/test_empty_placeholder_cleared.py
@@ -124,7 +124,9 @@ class TestSeparatorIndexFollows:
 class TestAppendPathsCallIt:
     @pytest.mark.parametrize("method_name", [
         "on_incoming_message",
-        "on_send_message",
+        # on_send_message()'s own append path, split out of it alongside
+        # _apply_message_edit().
+        "_send_new_text_message",
         "_send_voice_message",
         "_on_send_attachment",
         "_on_attach_contact",

--- a/tests/test_lid_merge_keeps_messages.py
+++ b/tests/test_lid_merge_keeps_messages.py
@@ -1,0 +1,260 @@
+"""Regression test: the first message from a contact whose @lid wasn't cached
+yet disappeared the moment the conversation was opened.
+
+Reported from a user's log: a message arrived from a long-quiet contact, the
+chat list showed its preview, and opening the conversation showed "no
+messages" — and the message was gone from the database for good.
+
+What happened. A live message arrives with remoteJid=<something>@lid. When
+that @lid isn't in _lid_to_phone yet, on_new_message() keeps the raw @lid as
+the chat JID (it resolves the phone number in the background, via
+/contact/pn-lid) and files the message under it. Once the answer comes back,
+_merge_lid_into_phone() merges the two chats — in memory correctly, but for
+the database it called db.delete_chat(lid_jid), which deletes that chat's
+message rows outright instead of moving them.
+
+That left the message nowhere the app would ever look again:
+navigate_to_conversation() reloads a conversation's messages straight from the
+database by JID, and get_messages()'s _jid_variants() knows
+@c.us <-> @s.whatsapp.net but nothing about @lid. The chat-list preview still
+looked right because it reads the merged in-memory records — and opening the
+conversation overwrote exactly those records with the empty DB read.
+
+The fix uses db.merge_or_rename_chat(), the same operation deduplicate_chats()
+already uses on the sync path (moves every row it safely can, and only deletes
+an old_jid row once an equivalent survives under new_jid), and waits for any
+message insert still in flight for that @lid before moving the chat.
+
+MainWindow is a wx.Frame and cannot be instantiated without a running wx.App,
+so the method under test is bound to a small stub — same approach as
+tests/test_group_admin_restriction.py.
+"""
+
+import inspect
+
+import pytest
+
+import main
+from main import MainWindow
+
+
+class _FakeDB:
+    def __init__(self):
+        self.merge_calls = []
+        self.deleted = []
+        self.events = []
+
+    def merge_or_rename_chat(self, old_jid, new_jid):
+        self.merge_calls.append((old_jid, new_jid))
+        self.events.append("merge")
+
+    def delete_chat(self, jid):
+        self.deleted.append(jid)
+        self.events.append("delete")
+
+
+class _FakeFuture:
+    """Stand-in for the insert Future _msg_bg_executor hands back."""
+
+    def __init__(self, events, raises=None):
+        self._events = events
+        self._raises = raises
+        self.waited_with = None
+
+    def result(self, timeout=None):
+        self.waited_with = timeout
+        if self._raises is not None:
+            raise self._raises
+        self._events.append("insert")
+
+
+class _SyncThread:
+    """threading.Thread stand-in that runs the target on .start()."""
+
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        self._target(*self._args, **self._kwargs)
+
+
+class _Stub:
+    _merge_lid_into_phone = MainWindow._merge_lid_into_phone
+
+    def __init__(self, chats=None):
+        self.chats = chats if chats is not None else {}
+        self.db = _FakeDB()
+        self._pending_lid_inserts = {}
+
+
+def _chat(jid, msg_ids=()):
+    return {
+        "remoteJid": jid,
+        "messages": {"messages": {"records": [
+            {"key": {"id": mid, "remoteJid": jid}, "messageTimestamp": i}
+            for i, mid in enumerate(msg_ids)
+        ]}},
+    }
+
+
+def _records(chat):
+    return chat["messages"]["messages"]["records"]
+
+
+@pytest.fixture(autouse=True)
+def _synchronous_threads(monkeypatch):
+    monkeypatch.setattr(main.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(main.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+
+
+LID = "11111111111111@lid"
+PHONE = "999999999999@s.whatsapp.net"
+
+
+class TestDatabaseSideOfTheMerge:
+    def test_messages_are_moved_to_the_phone_jid_not_deleted(self):
+        stub = _Stub({LID: _chat(LID, ["m1"])})
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert stub.db.merge_calls == [(LID, PHONE)]
+        assert stub.db.deleted == [], (
+            "delete_chat() drops the @lid chat's message rows — the message "
+            "has to be moved to the phone JID, which is the only one "
+            "navigate_to_conversation() will ever query again"
+        )
+
+    def test_merge_runs_for_the_both_chats_exist_case_too(self):
+        stub = _Stub({LID: _chat(LID, ["m1"]), PHONE: _chat(PHONE, ["m0"])})
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert stub.db.merge_calls == [(LID, PHONE)]
+
+    def test_nothing_touches_the_database_when_there_is_no_lid_chat(self):
+        stub = _Stub({PHONE: _chat(PHONE)})
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert stub.db.merge_calls == []
+        assert stub.db.deleted == []
+
+
+class TestWaitsForAnInsertStillInFlight:
+    def test_the_pending_insert_lands_before_the_chat_is_moved(self):
+        """on_new_message() hands the insert to a pool thread. Renaming the
+        chat first would file that message under a JID nothing queries."""
+        stub = _Stub({LID: _chat(LID, ["m1"])})
+        fut = _FakeFuture(stub.db.events)
+        stub._pending_lid_inserts[LID] = fut
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert stub.db.events == ["insert", "merge"]
+        assert fut.waited_with, "the wait must be bounded, not indefinite"
+
+    def test_an_insert_that_never_lands_does_not_block_the_merge(self):
+        """A failed/timed-out insert is worth a warning, but skipping the
+        merge would leave the chat split in the database indefinitely."""
+        stub = _Stub({LID: _chat(LID, ["m1"])})
+        stub._pending_lid_inserts[LID] = _FakeFuture(
+            stub.db.events, raises=TimeoutError("still queued")
+        )
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert stub.db.merge_calls == [(LID, PHONE)]
+
+    def test_the_tracked_future_is_dropped_so_the_dict_does_not_grow(self):
+        stub = _Stub({LID: _chat(LID, ["m1"])})
+        stub._pending_lid_inserts[LID] = _FakeFuture(stub.db.events)
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert stub._pending_lid_inserts == {}
+
+    def test_no_pending_insert_merges_straight_away(self):
+        stub = _Stub({LID: _chat(LID, ["m1"])})
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert stub.db.events == ["merge"]
+
+
+class TestInMemoryMergeStillWorks:
+    def test_lid_only_chat_is_renamed_keeping_its_records(self):
+        stub = _Stub({LID: _chat(LID, ["m1", "m2"])})
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert LID not in stub.chats
+        assert stub.chats[PHONE]["remoteJid"] == PHONE
+        assert [r["key"]["id"] for r in _records(stub.chats[PHONE])] == ["m1", "m2"]
+
+    def test_records_from_both_chats_are_combined(self):
+        stub = _Stub({LID: _chat(LID, ["from_lid"]), PHONE: _chat(PHONE, ["from_phone"])})
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert LID not in stub.chats
+        assert [r["key"]["id"] for r in _records(stub.chats[PHONE])] == [
+            "from_phone", "from_lid",
+        ]
+
+    def test_a_message_present_under_both_jids_is_not_duplicated(self):
+        stub = _Stub({LID: _chat(LID, ["shared"]), PHONE: _chat(PHONE, ["shared"])})
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert [r["key"]["id"] for r in _records(stub.chats[PHONE])] == ["shared"]
+
+
+class TestOpenConversationFollowsTheMerge:
+    class _Panel:
+        def __init__(self, jid):
+            self.conversation = {"remoteJid": jid}
+            self.refreshes = 0
+
+        def refresh_messages_if_changed(self):
+            self.refreshes += 1
+
+    def test_the_open_lid_conversation_is_repointed_at_the_phone_chat(self):
+        stub = _Stub({LID: _chat(LID, ["m1"])})
+        stub.conversations_panel = self._Panel(LID)
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert stub.conversations_panel.conversation is stub.chats[PHONE]
+        assert stub.conversations_panel.refreshes == 1
+
+    def test_the_open_phone_conversation_is_refreshed(self):
+        stub = _Stub({LID: _chat(LID, ["m1"]), PHONE: _chat(PHONE)})
+        stub.conversations_panel = self._Panel(PHONE)
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert stub.conversations_panel.refreshes == 1
+
+    def test_an_unrelated_open_conversation_is_left_alone(self):
+        stub = _Stub({LID: _chat(LID, ["m1"])})
+        stub.conversations_panel = self._Panel("outro@s.whatsapp.net")
+
+        stub._merge_lid_into_phone(LID, PHONE)
+
+        assert stub.conversations_panel.refreshes == 0
+
+
+def test_on_new_message_tracks_the_insert_for_lid_chats():
+    """The wait above only works if on_new_message actually registers the
+    future. That method is ~400 lines of wx/JID handling that can't be driven
+    end to end here, so this pins the registration structurally — same
+    approach as tests/test_edit_message_refreshes_chat_list.py.
+    """
+    src = inspect.getsource(MainWindow.on_new_message)
+    assert "_pending_lid_inserts[remote_jid]" in src, (
+        "on_new_message must record the insert future for @lid chats, or "
+        "_merge_lid_into_phone() has nothing to wait on"
+    )
+    assert 'remote_jid.endswith("@lid")' in src

--- a/tests/test_mass_selection.py
+++ b/tests/test_mass_selection.py
@@ -186,6 +186,7 @@ class _Panel:
     _select_chat_at = ConversationsPanel._select_chat_at
     _all_chat_jids = ConversationsPanel._all_chat_jids
     _refresh_message_rows_by_ids = ConversationsPanel._refresh_message_rows_by_ids
+    _set_message_row_texts = ConversationsPanel._set_message_row_texts
     _render_message_line = lambda self, msg, index=None, total=None: msg.get("key", {}).get("id", "")
     _extract_timestamp = ConversationsPanel._extract_timestamp
 
@@ -217,11 +218,20 @@ class _Panel:
         # The mass star/pin handlers apply the flag themselves and repaint
         # once, instead of delegating to the single-message handlers — these
         # record that they do exactly one repaint / one persist per batch.
+        # The repaint is per-row (_repaint_or_repopulate); populate_calls
+        # stays here to assert the full rebuild is NOT what happens.
         self.populate_calls = 0
+        self.repainted = []
+        self.repaint_ok = True
         self.persisted = []
 
     def populate_messages(self, preserve_focus=False):
         self.populate_calls += 1
+
+    def _repaint_or_repopulate(self, msg_ids):
+        self.repainted.append(sorted(i for i in msg_ids if i))
+        if not self.repaint_ok:
+            self.populate_messages(preserve_focus=True)
 
     def _persist_message_local_flags(self, jid, msgs):
         self.persisted.append((jid, [m.get("key", {}).get("id", "") for m in msgs]))
@@ -1214,20 +1224,44 @@ class TestMassStarAndPinAreBatched:
         panel.selected_messages = {"m1", "m2", "m3"}
         panel._on_mass_star_messages(None)
         assert all(m["starred"] for m in msgs)
-        assert panel.populate_calls == 1
+        assert panel.repainted == [["m1", "m2", "m3"]]
+        assert panel.populate_calls == 0, "the affected rows are repainted, not the whole list"
         assert panel.persisted == [("grupo@g.us", ["m1", "m2", "m3"])]
         assert panel.main_window.saves == 1
+
+    def test_starring_repaints_the_whole_selection_not_just_the_changed_rows(self):
+        """Clearing selected_messages drops the " selecionado" marker from
+        every row that was in it, including the ones already starred and
+        therefore left alone — those rows still have to be repainted."""
+        msgs = [_msg("m1"), _msg("m2")]
+        msgs[1]["starred"] = True
+        panel = _Panel(messages=msgs)
+        panel.selected_messages = {"m1", "m2"}
+        panel._on_mass_star_messages(None)
+        assert panel.repainted == [["m1", "m2"]]
 
     def test_pinning_a_batch_repaints_once_and_uses_one_thread(self, run_threads):
         msgs = [_msg("m1"), _msg("m2"), _msg("m3")]
         panel = _Panel(messages=msgs)
         panel.selected_messages = {"m1", "m2", "m3"}
         panel._on_mass_pin_messages(None)
-        assert panel.populate_calls == 1
+        assert panel.repainted == [["m1", "m2", "m3"]]
+        assert panel.populate_calls == 0
         assert len(_CapturedThread.created) == 1, "one worker for the batch, not one per message"
         run_threads()
         assert [c[1] for c in panel.main_window.pin_calls] == ["m1", "m2", "m3"]
-        assert panel.populate_calls == 1, "no repaint when nothing failed"
+        assert len(panel.repainted) == 1, "no repaint when nothing failed"
+
+    def test_a_repaint_that_cannot_be_done_falls_back_to_the_full_rebuild(self):
+        """A row that isn't rendered (paginated out, replaced by a resync)
+        can only be shown by populate_messages() — the caller must not be
+        left with the change applied and nothing on screen."""
+        msgs = [_msg("m1")]
+        panel = _Panel(messages=msgs)
+        panel.repaint_ok = False
+        panel.selected_messages = {"m1"}
+        panel._on_mass_star_messages(None)
+        assert panel.populate_calls == 1
 
     def test_server_rejections_produce_one_dialog_with_a_count(self, run_threads, boxes):
         msgs = [_msg("m1"), _msg("m2"), _msg("m3")]
@@ -1250,7 +1284,10 @@ class TestMassStarAndPinAreBatched:
         assert msgs[1]["pinInChat"] is False     # rejected, rolled back
         assert msgs[2]["pinInChat"] is False
         assert panel.persisted[-1] == ("grupo@g.us", ["m2", "m3"])
-        assert panel.populate_calls == 2, "one repaint to apply, one to roll back"
+        assert panel.repainted == [["m1", "m2", "m3"], ["m2", "m3"]], (
+            "one repaint to apply the batch, one for the rolled-back rows only"
+        )
+        assert panel.populate_calls == 0
 
     def test_a_raising_pin_call_is_treated_as_a_rejection(self, run_threads, boxes):
         """One message blowing up must not abandon the rest of the batch."""

--- a/tests/test_message_row_repaint.py
+++ b/tests/test_message_row_repaint.py
@@ -1,0 +1,244 @@
+"""Tests for repainting individual rows of the messages list instead of
+rebuilding it (ConversationsPanel._repaint_message_rows and friends).
+
+Starring, pinning and a remote "delete for everyone" only change the text of
+rows already on screen — the list is sorted by timestamp, which none of them
+touch — yet each of them went through populate_messages(), which re-sorts and
+de-duplicates every record in the conversation, rebuilds the reaction map,
+recomputes the unread separator and pagination window, and then
+DeleteAllItems() + Append()s every row. That is the same disproportion
+main.py's refresh_chat_row_text() fixed for the conversations list, plus a
+fresh flood of accessibility events for the screen reader every time.
+
+The signature bookkeeping is the subtle half: populate_messages() snapshots
+_messages_signature() on its way out, so a local change landed in the cache as
+a side effect of the rebuild. Repainting instead has to move that cache
+forward itself, or refresh_messages_if_changed() would see a mismatch on the
+next background poll and rebuild the whole list anyway (moving the user's
+focus for something already correct on screen) — but only when the rows that
+changed are the ones just repainted, or a change that arrived from somewhere
+else would be swallowed and never rendered.
+
+ConversationsPanel is a wx.Panel and cannot be instantiated without a running
+wx.App, so the methods under test are bound to a small stub — same approach as
+tests/test_message_bookmarks.py.
+"""
+
+import pytest
+
+from ui.conversations import ConversationsPanel
+
+
+class _FakeList:
+    def __init__(self, count=0):
+        self._count = count
+        self.texts = {}
+
+    def GetItemCount(self):
+        return self._count
+
+    def SetItemText(self, idx, text):
+        self.texts[idx] = text
+
+
+class _Panel:
+    _repaint_message_rows = ConversationsPanel._repaint_message_rows
+    _repaint_or_repopulate = ConversationsPanel._repaint_or_repopulate
+    _set_message_row_texts = ConversationsPanel._set_message_row_texts
+    _refresh_message_rows_by_ids = ConversationsPanel._refresh_message_rows_by_ids
+    _adopt_signature_after_repaint = ConversationsPanel._adopt_signature_after_repaint
+    _signature_changed_ids = staticmethod(ConversationsPanel._signature_changed_ids)
+    _is_separator = ConversationsPanel._is_separator
+
+    def __init__(self, messages=(), item_count=None):
+        self._sorted_messages = list(messages)
+        self.messages_list = _FakeList(
+            count=len(self._sorted_messages) if item_count is None else item_count
+        )
+        self._messages_signature_cache = None
+        self.populate_calls = 0
+        # Drives _messages_signature() without the real record plumbing: the
+        # test sets what the next fingerprint should look like.
+        self._next_signature = None
+        self.signature_raises = False
+
+    def populate_messages(self, preserve_focus=False):
+        self.populate_calls += 1
+
+    def _render_message_line(self, msg, index=None, total=None):
+        mid = msg.get("key", {}).get("id", "")
+        flags = "".join(f for f, k in (("*", "starred"), ("P", "pinInChat")) if msg.get(k))
+        return f"{mid}{flags}@{index}/{total}"
+
+    def _messages_signature(self):
+        if self.signature_raises:
+            raise RuntimeError("boom")
+        return self._next_signature
+
+
+def _msg(mid, **flags):
+    m = {"key": {"id": mid, "fromMe": False}, "messageType": "conversation"}
+    m.update(flags)
+    return m
+
+
+def _sig(*rows, jid="grupo@g.us", first_unread=None, pending=0):
+    """A _messages_signature()-shaped tuple: (jid, first_unread_id,
+    pending_unread, per-message rows), each row starting with the id."""
+    return (jid, first_unread, pending, tuple(rows))
+
+
+class TestRepaintMessageRows:
+    def test_repaints_only_the_requested_rows(self):
+        panel = _Panel([_msg("m1"), _msg("m2", starred=True), _msg("m3")])
+
+        assert panel._repaint_message_rows(["m2"]) is True
+        assert panel.messages_list.texts == {1: "m2*@1/3"}
+
+    def test_reports_the_rows_it_could_not_find(self):
+        """A row paginated out of the current window, or replaced by a resync
+        while a server call was in flight, can only be shown by a rebuild."""
+        panel = _Panel([_msg("m1")])
+
+        assert panel._repaint_message_rows(["m1", "gone"]) is False
+
+    def test_skips_separator_rows_without_matching_them(self):
+        panel = _Panel([{"_type": "unread_separator", "count": 2}, _msg("m1")])
+
+        assert panel._repaint_message_rows(["m1"]) is True
+        assert panel.messages_list.texts == {1: "m1@1/2"}
+
+    def test_a_control_out_of_step_with_the_rows_refuses(self):
+        """SetItemText against a stale index would write the right text into
+        the wrong row — that's a rebuild, not a repaint."""
+        panel = _Panel([_msg("m1"), _msg("m2")], item_count=5)
+
+        assert panel._repaint_message_rows(["m1"]) is False
+        assert panel.messages_list.texts == {}
+
+    def test_no_ids_and_no_rows_refuse(self):
+        assert _Panel([_msg("m1")])._repaint_message_rows([]) is False
+        assert _Panel([_msg("m1")])._repaint_message_rows([""]) is False
+        assert _Panel([])._repaint_message_rows(["m1"]) is False
+
+    def test_a_rendering_failure_falls_back_instead_of_raising(self):
+        panel = _Panel([_msg("m1")])
+        panel._render_message_line = lambda *a, **kw: (_ for _ in ()).throw(ValueError("nope"))
+
+        assert panel._repaint_message_rows(["m1"]) is False
+
+
+class TestRepaintOrRepopulate:
+    def test_a_successful_repaint_never_rebuilds(self):
+        panel = _Panel([_msg("m1")])
+        panel._repaint_or_repopulate(["m1"])
+        assert panel.populate_calls == 0
+
+    def test_an_impossible_repaint_rebuilds(self):
+        panel = _Panel([_msg("m1")])
+        panel._repaint_or_repopulate(["gone"])
+        assert panel.populate_calls == 1
+
+
+class TestSignatureChangedIds:
+    def test_reports_the_rows_whose_entry_differs(self):
+        old = _sig(("m1", False), ("m2", False))
+        new = _sig(("m1", False), ("m2", True))
+        assert ConversationsPanel._signature_changed_ids(old, new) == {"m2"}
+
+    def test_an_added_or_removed_row_counts_as_changed(self):
+        old = _sig(("m1", False))
+        new = _sig(("m1", False), ("m2", False))
+        assert ConversationsPanel._signature_changed_ids(old, new) == {"m2"}
+
+    def test_identical_snapshots_report_nothing(self):
+        sig = _sig(("m1", False))
+        assert ConversationsPanel._signature_changed_ids(sig, sig) == set()
+
+    @pytest.mark.parametrize("new", [
+        _sig(("m1", False), jid="outro@g.us"),      # different conversation
+        _sig(("m1", False), first_unread="m1"),     # separator moved
+        _sig(("m1", False), pending=3),             # unread count changed
+    ])
+    def test_a_header_difference_is_not_expressible_as_changed_rows(self, new):
+        old = _sig(("m1", False))
+        assert ConversationsPanel._signature_changed_ids(old, new) is None
+
+    def test_repeated_or_empty_ids_make_the_comparison_ambiguous(self):
+        old = _sig(("m1", False), ("m1", True))
+        assert ConversationsPanel._signature_changed_ids(old, _sig(("m1", False))) is None
+        assert ConversationsPanel._signature_changed_ids(
+            _sig(("", False)), _sig(("", True))
+        ) is None
+
+    def test_a_missing_snapshot_is_not_comparable(self):
+        assert ConversationsPanel._signature_changed_ids(None, _sig(("m1", False))) is None
+        assert ConversationsPanel._signature_changed_ids(_sig(("m1", False)), None) is None
+
+
+class TestAdoptSignatureAfterRepaint:
+    def test_adopts_when_only_the_repainted_rows_changed(self):
+        panel = _Panel([_msg("m1")])
+        panel._messages_signature_cache = _sig(("m1", False), ("m2", False))
+        panel._next_signature = _sig(("m1", True), ("m2", False))
+
+        panel._adopt_signature_after_repaint({"m1"})
+
+        assert panel._messages_signature_cache == panel._next_signature
+
+    def test_keeps_the_stale_cache_when_something_else_also_changed(self):
+        """That other change still needs the rebuild this repaint didn't do —
+        adopting here would swallow it and it would never be rendered."""
+        stale = _sig(("m1", False), ("m2", False))
+        panel = _Panel([_msg("m1")])
+        panel._messages_signature_cache = stale
+        panel._next_signature = _sig(("m1", True), ("m2", True))
+
+        panel._adopt_signature_after_repaint({"m1"})
+
+        assert panel._messages_signature_cache == stale
+
+    def test_keeps_the_stale_cache_when_the_rows_are_not_comparable(self):
+        stale = _sig(("m1", False))
+        panel = _Panel([_msg("m1")])
+        panel._messages_signature_cache = stale
+        panel._next_signature = _sig(("m1", True), jid="outro@g.us")
+
+        panel._adopt_signature_after_repaint({"m1"})
+
+        assert panel._messages_signature_cache == stale
+
+    def test_a_failing_fingerprint_clears_the_cache_so_the_next_refresh_rebuilds(self):
+        panel = _Panel([_msg("m1")])
+        panel._messages_signature_cache = _sig(("m1", False))
+        panel.signature_raises = True
+
+        panel._adopt_signature_after_repaint({"m1"})
+
+        assert panel._messages_signature_cache is None
+
+    def test_a_successful_repaint_moves_the_cache_forward(self):
+        """End-to-end: the repaint path itself must leave the fingerprint
+        describing what is now on screen, or the next background poll rebuilds
+        the list and moves the user's focus for nothing."""
+        panel = _Panel([_msg("m1", starred=True)])
+        panel._messages_signature_cache = _sig(("m1", False))
+        panel._next_signature = _sig(("m1", True))
+
+        assert panel._repaint_message_rows(["m1"]) is True
+        assert panel._messages_signature_cache == _sig(("m1", True))
+
+
+class TestSelectionRefreshIsUnaffected:
+    def test_selection_repaint_leaves_the_fingerprint_alone(self):
+        """_refresh_message_rows_by_ids() is the selection-marker path: the
+        selection isn't part of the fingerprint, and it must not adopt one —
+        it has no idea whether anything else is waiting for a rebuild."""
+        panel = _Panel([_msg("m1")])
+        panel._messages_signature_cache = _sig(("m1", False))
+        panel._next_signature = _sig(("m1", True))
+
+        panel._refresh_message_rows_by_ids(["m1"])
+
+        assert panel.messages_list.texts == {0: "m1@0/1"}
+        assert panel._messages_signature_cache == _sig(("m1", False))

--- a/tests/test_message_star_persists.py
+++ b/tests/test_message_star_persists.py
@@ -73,9 +73,15 @@ class _Stub:
         self.main_window = _FakeMainWindow()
         self.conversation = {"remoteJid": conversation_jid}
         self.populate_calls = []
+        self.repainted = []
 
     def populate_messages(self, preserve_focus=False):
         self.populate_calls.append(preserve_focus)
+
+    def _repaint_or_repopulate(self, msg_ids):
+        # The real one repaints the affected rows and only rebuilds the list
+        # when it can't — see ConversationsPanel._repaint_message_rows().
+        self.repainted.append(sorted(i for i in msg_ids if i))
 
 
 def _msg(msg_id="MSG1", starred=False, message_type="conversation"):
@@ -112,13 +118,14 @@ class TestStarPersistsToDatabase:
         [(jid, saved)] = panel.main_window.db.inserted
         assert saved["starred"] is False
 
-    def test_toggle_refreshes_the_message_list(self):
+    def test_toggle_refreshes_only_the_message_row(self):
         panel = _Stub()
         msg = _msg(starred=False)
 
         panel._on_menu_star(msg)
 
-        assert panel.populate_calls == [True]
+        assert panel.repainted == [["MSG1"]]
+        assert panel.populate_calls == [], "starring one message must not rebuild the whole list"
         assert panel.main_window.save_calls == 1
 
     def test_system_event_is_not_starred_or_persisted(self):
@@ -130,3 +137,4 @@ class TestStarPersistsToDatabase:
         assert msg["starred"] is False
         assert panel.main_window.db.inserted == []
         assert panel.populate_calls == []
+        assert panel.repainted == []

--- a/tests/test_pin_message.py
+++ b/tests/test_pin_message.py
@@ -73,9 +73,15 @@ class _Stub:
         self.main_window = main_window
         self.conversation = {"remoteJid": "5521999999999@s.whatsapp.net"}
         self.populate_calls = []
+        self.repainted = []
 
     def populate_messages(self, preserve_focus=False):
         self.populate_calls.append(preserve_focus)
+
+    def _repaint_or_repopulate(self, msg_ids):
+        # The real one repaints the affected rows and only rebuilds the list
+        # when it can't — see ConversationsPanel._repaint_message_rows().
+        self.repainted.append(sorted(i for i in msg_ids if i))
 
 
 def _msg(mid="a", pinned=False):
@@ -115,7 +121,7 @@ class TestPinMessage:
 
         assert msg["pinInChat"] is True
         assert mw.save_calls >= 1
-        assert s.populate_calls, "list should be re-rendered after the toggle"
+        assert s.repainted == [["a"]], "the message's own row should be re-rendered after the toggle"
         assert mw.pin_calls == [("5521999999999@s.whatsapp.net", {"id": "a", "fromMe": True}, True)]
         assert mw.db.inserted[0][1]["pinInChat"] is True, (
             "the optimistic pin must be written to the message's own DB row too — "

--- a/tests/test_probe_video_duration_on_download.py
+++ b/tests/test_probe_video_duration_on_download.py
@@ -23,6 +23,7 @@ import pathlib
 import pytest
 
 import main
+from core.utils import MEASURED_SECONDS_KEY
 from main import MainWindow
 
 
@@ -126,7 +127,7 @@ class TestTheSettingGatesIt:
         stub._maybe_probe_video_duration(msg, b"fake mp4 bytes")
 
         assert len(probed) == 1
-        assert msg["message"]["videoMessage"]["seconds"] == 137
+        assert msg["message"]["videoMessage"][MEASURED_SECONDS_KEY] == 137
 
 
 class TestWhatIsWorthProbing:
@@ -158,7 +159,7 @@ class TestWhatIsWorthProbing:
 
         stub._maybe_probe_video_duration(msg, b"bytes")
 
-        assert msg["message"]["videoMessage"]["seconds"] == 0
+        assert MEASURED_SECONDS_KEY not in msg["message"]["videoMessage"]
         assert stub.db.inserted == []
 
     def test_the_temporary_file_is_cleaned_up(self, probed):
@@ -203,6 +204,7 @@ class TestApplyingTheResult:
 
         stub._apply_probed_video_duration(msg, 137)
 
+        assert MEASURED_SECONDS_KEY not in msg["message"]["videoMessage"]
         assert msg["message"]["videoMessage"]["seconds"] == 42
         assert stub.db.inserted == []
 

--- a/tests/test_probe_video_duration_on_download.py
+++ b/tests/test_probe_video_duration_on_download.py
@@ -1,0 +1,215 @@
+"""Tests for Settings > Armazenamento > "descobrir a duração ao baixar".
+
+A video whose sender omitted the duration reads as a bare "vídeo" until it is
+played — playback decodes the file anyway, so _learn_video_duration() fills
+the gap there for free (see tests/test_video_duration_unknown.py). This option
+trades that wait for one media decode per downloaded video, so the length is
+already in the list without opening anything. Off by default: it is wasted
+work for anyone who doesn't care, and it costs a full BASS decode of a file
+that can be tens of megabytes.
+
+The probe runs on its own thread. handle_media_message() is called from the UI
+thread too (the play path downloads on demand before starting playback), so
+doing it inline would freeze the window for the length of the decode.
+
+MainWindow is a wx.Frame and cannot be instantiated without a running wx.App,
+so the methods under test are bound to a small stub — same approach as
+tests/test_lid_merge_keeps_messages.py.
+"""
+
+import json
+import pathlib
+
+import pytest
+
+import main
+from main import MainWindow
+
+
+class _FakeDB:
+    def __init__(self):
+        self.inserted = []
+
+    def insert_message(self, jid, msg):
+        self.inserted.append((jid, msg.get("key", {}).get("id", "")))
+
+
+class _FakeExecutor:
+    def submit(self, fn, *a, **kw):
+        fn(*a, **kw)
+
+
+class _FakePanel:
+    def __init__(self, open_jid=None):
+        self.conversation = {"remoteJid": open_jid} if open_jid else None
+        self.repainted = []
+
+    def _repaint_message_rows(self, msg_ids):
+        self.repainted.append(sorted(i for i in msg_ids if i))
+        return True
+
+
+class _SyncThread:
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None):
+        self._target, self._args, self._kwargs = target, args, kwargs or {}
+
+    def start(self):
+        self._target(*self._args, **self._kwargs)
+
+
+class _Stub:
+    _maybe_probe_video_duration = MainWindow._maybe_probe_video_duration
+    _apply_probed_video_duration = MainWindow._apply_probed_video_duration
+    # staticmethod on the real class; attribute access unwraps it, so it has
+    # to be re-wrapped here.
+    _normalize_jid = staticmethod(MainWindow._normalize_jid)
+
+    def __init__(self, enabled=False, open_jid=None):
+        self.settings = {"storage": {"probe_video_duration_on_download": enabled}}
+        self.db = _FakeDB()
+        self._msg_bg_executor = _FakeExecutor()
+        self.conversations_panel = _FakePanel(open_jid)
+        self.saved = []
+
+    def _schedule_save(self, dirty_jid=None):
+        self.saved.append(dirty_jid)
+
+
+JID = "grupo@g.us"
+
+
+def _video_msg(seconds=0):
+    return {
+        "key": {"id": "VID1", "remoteJid": JID, "fromMe": False},
+        "messageType": "videoMessage",
+        "message": {"videoMessage": {"seconds": seconds, "mimetype": "video/mp4"}},
+    }
+
+
+@pytest.fixture
+def probed(monkeypatch):
+    """Record every path handed to the probe and answer with a set length."""
+    calls = []
+
+    def _probe(path, answer=[137]):
+        calls.append(path)
+        return answer[0]
+
+    monkeypatch.setattr(main, "probe_media_duration", _probe)
+    monkeypatch.setattr(main.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(main.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+    return calls
+
+
+class TestTheSettingGatesIt:
+    def test_disabled_by_default_nothing_is_probed(self, probed):
+        stub = _Stub(enabled=False)
+        msg = _video_msg()
+
+        stub._maybe_probe_video_duration(msg, b"fake mp4 bytes")
+
+        assert probed == []
+        assert msg["message"]["videoMessage"]["seconds"] == 0
+
+    def test_a_missing_storage_section_is_treated_as_disabled(self, probed):
+        stub = _Stub()
+        stub.settings = {}
+
+        stub._maybe_probe_video_duration(_video_msg(), b"bytes")
+
+        assert probed == []
+
+    def test_enabled_probes_and_stores_the_length(self, probed):
+        stub = _Stub(enabled=True)
+        msg = _video_msg()
+
+        stub._maybe_probe_video_duration(msg, b"fake mp4 bytes")
+
+        assert len(probed) == 1
+        assert msg["message"]["videoMessage"]["seconds"] == 137
+
+
+class TestWhatIsWorthProbing:
+    def test_a_video_that_already_states_its_length_is_skipped(self, probed):
+        stub = _Stub(enabled=True)
+        msg = _video_msg(seconds=29)
+
+        stub._maybe_probe_video_duration(msg, b"bytes")
+
+        assert probed == []
+        assert msg["message"]["videoMessage"]["seconds"] == 29
+
+    def test_non_video_media_is_skipped(self, probed):
+        stub = _Stub(enabled=True)
+        msg = {"key": {"id": "IMG1", "remoteJid": JID},
+               "messageType": "imageMessage",
+               "message": {"imageMessage": {"caption": ""}}}
+
+        stub._maybe_probe_video_duration(msg, b"bytes")
+
+        assert probed == []
+
+    def test_a_probe_that_answers_nothing_leaves_the_record_alone(self, monkeypatch):
+        monkeypatch.setattr(main, "probe_media_duration", lambda path: None)
+        monkeypatch.setattr(main.threading, "Thread", _SyncThread)
+        monkeypatch.setattr(main.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+        stub = _Stub(enabled=True)
+        msg = _video_msg()
+
+        stub._maybe_probe_video_duration(msg, b"bytes")
+
+        assert msg["message"]["videoMessage"]["seconds"] == 0
+        assert stub.db.inserted == []
+
+    def test_the_temporary_file_is_cleaned_up(self, probed):
+        stub = _Stub(enabled=True)
+
+        stub._maybe_probe_video_duration(_video_msg(), b"bytes")
+
+        assert len(probed) == 1
+        assert not pathlib.Path(probed[0]).exists(), (
+            "a video can be tens of megabytes — the temp copy must not be left behind"
+        )
+
+
+class TestApplyingTheResult:
+    def test_the_record_is_persisted_and_the_chat_marked_dirty(self, probed):
+        stub = _Stub(enabled=True)
+
+        stub._maybe_probe_video_duration(_video_msg(), b"bytes")
+
+        assert stub.db.inserted == [(JID, "VID1")]
+        assert stub.saved == [JID]
+
+    def test_the_open_conversation_row_is_repainted(self, probed):
+        stub = _Stub(enabled=True, open_jid=JID)
+
+        stub._maybe_probe_video_duration(_video_msg(), b"bytes")
+
+        assert stub.conversations_panel.repainted == [["VID1"]]
+
+    def test_another_open_conversation_is_not_touched(self, probed):
+        stub = _Stub(enabled=True, open_jid="outro@s.whatsapp.net")
+
+        stub._maybe_probe_video_duration(_video_msg(), b"bytes")
+
+        assert stub.conversations_panel.repainted == []
+
+    def test_a_length_filled_in_meanwhile_is_not_overwritten(self):
+        """Playback probes the same file (_learn_video_duration). Whichever
+        lands first wins; the other must not rewrite the record."""
+        stub = _Stub(enabled=True)
+        msg = _video_msg(seconds=42)
+
+        stub._apply_probed_video_duration(msg, 137)
+
+        assert msg["message"]["videoMessage"]["seconds"] == 42
+        assert stub.db.inserted == []
+
+
+def test_the_setting_ships_in_the_defaults():
+    defaults = json.loads(
+        (pathlib.Path(__file__).resolve().parents[1] / "client" / "data" /
+         "settings_default.json").read_text(encoding="utf-8")
+    )
+    assert defaults["storage"]["probe_video_duration_on_download"] is False

--- a/tests/test_stop_playback_on_delete.py
+++ b/tests/test_stop_playback_on_delete.py
@@ -102,6 +102,14 @@ class _Stub:
         self.hide_audio_calls = 0
         self.hide_all_media_calls = 0
         self.refresh_calls = 0
+        self.repainted = []
+        self.repaint_ok = True
+
+    def _repaint_message_rows(self, msg_ids):
+        # Stands in for the real per-row repaint (which needs the whole
+        # rendering stack); repaint_ok drives the "couldn't repaint" branch.
+        self.repainted.append(sorted(i for i in msg_ids if i))
+        return self.repaint_ok
 
     def _stop_audio(self):
         self.stop_audio_calls += 1
@@ -202,8 +210,18 @@ class TestOnMessageRevokedStopsPlayback:
 
         assert s.hide_all_media_calls == 1
 
-    def test_still_refreshes_the_conversation(self):
+    def test_repaints_only_the_revoked_row(self):
+        """A revoke swaps one row's text for "Mensagem apagada" and moves
+        nothing, so re-rendering every row of the conversation for it was
+        disproportionate."""
         s = _Stub(sorted_messages=[_msg("A")])
+        s.on_message_revoked("A")
+        assert s.repainted == [["A"]]
+        assert s.refresh_calls == 0
+
+    def test_falls_back_to_the_full_refresh_when_the_row_cannot_be_repainted(self):
+        s = _Stub(sorted_messages=[_msg("A")])
+        s.repaint_ok = False
         s.on_message_revoked("A")
         assert s.refresh_calls == 1
 

--- a/tests/test_system_event_actions_blocked.py
+++ b/tests/test_system_event_actions_blocked.py
@@ -75,6 +75,10 @@ class _Stub:
         self.main_window = _FakeMainWindow()
         self.conversation = {"remoteJid": "group@g.us"}
         self.populated = 0
+        self.repainted = []
+
+    def _repaint_or_repopulate(self, msg_ids):
+        self.repainted.append(sorted(i for i in msg_ids if i))
 
     def populate_messages(self, preserve_focus=False):
         self.populated += 1
@@ -113,6 +117,7 @@ class TestStarIsGuarded:
         assert "starred" not in msg
         assert stub.main_window.saves == 0
         assert stub.populated == 0
+        assert stub.repainted == []
         assert stub.main_window.announced == ["system_event_action_unavailable"]
 
     def test_normal_message_is_still_starred(self):
@@ -123,7 +128,7 @@ class TestStarIsGuarded:
 
         assert msg["starred"] is True
         assert stub.main_window.saves == 1
-        assert stub.populated == 1
+        assert stub.repainted == [[NORMAL_MESSAGE["key"]["id"]]]
         assert stub.main_window.announced == []
 
 

--- a/tests/test_updater_unicode_paths.py
+++ b/tests/test_updater_unicode_paths.py
@@ -1,0 +1,204 @@
+"""Tests for issue #83: the auto-updater never applied the update on a Windows
+account whose name contains a non-ASCII character ("Paweł").
+
+The updater downloaded and extracted correctly, closed the app — and nothing
+happened. On the next manual start the same update was offered again. No
+update_failed.marker, no relaunch, no trace of a failure anywhere.
+
+Root cause: the batch installer was written with encoding="utf-8", but cmd.exe
+decodes a .bat file in the console's OEM code page (CP852 on a Polish Windows,
+CP850 here). "Paweł" written as UTF-8 and read back as CP852 is mojibake, so
+every path in the script — source, target, marker, exe — pointed at a
+directory that does not exist. That single fact explains all four symptoms at
+once: nothing copied, no marker written (its path has the same character), no
+relaunch (so does the exe path), and the script deleted itself afterwards,
+taking the only evidence with it.
+
+The fix writes the script in the code page cmd will actually read it with,
+prefers 8.3 short paths (pure ASCII) where the volume still generates them,
+refuses to write a script it cannot represent instead of running a broken one,
+and leaves a log next to the install.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+import updater
+
+
+_OEM = updater._oem_encoding()
+
+
+def _oem_can_encode(text: str) -> bool:
+    try:
+        text.encode(_OEM)
+        return True
+    except (UnicodeEncodeError, LookupError):
+        return False
+
+
+class TestOemEncoding:
+    def test_it_names_a_code_page_python_knows(self):
+        assert _OEM.startswith("cp")
+        "abc".encode(_OEM)  # must be a real codec
+
+    def test_it_falls_back_when_the_api_is_unavailable(self, monkeypatch):
+        class _Boom:
+            def __getattr__(self, name):
+                raise OSError("no windll here")
+
+        monkeypatch.setattr(updater.ctypes, "windll", _Boom(), raising=False)
+        assert updater._oem_encoding() == "cp850"
+
+
+class TestConsoleSafePath:
+    def test_an_ascii_path_is_returned_untouched(self):
+        assert updater._console_safe_path(r"C:\WinZapp") == r"C:\WinZapp"
+
+    def test_an_empty_path_is_returned_untouched(self):
+        assert updater._console_safe_path("") == ""
+
+    def test_a_failing_lookup_falls_back_to_the_long_path(self, monkeypatch):
+        """8.3 generation is disabled on many modern volumes, and the path may
+        not exist yet — either way the long path is returned and the encoding
+        step is what has to carry it."""
+        long_path = r"C:\Users\Pawe\u0142\AppData\Local\WinZapp".replace("\\u0142", "\u0142")
+
+        class _Kernel:
+            def GetShortPathNameW(self, path, buf, size):
+                return 0
+
+        monkeypatch.setattr(updater.ctypes, "windll",
+                            type("W", (), {"kernel32": _Kernel()})(), raising=False)
+        assert updater._console_safe_path(long_path) == long_path
+
+    def test_a_short_name_is_used_when_it_is_ascii(self, monkeypatch):
+        class _Kernel:
+            def GetShortPathNameW(self, path, buf, size):
+                buf.value = r"C:\Users\PAWE~1\AppData\Local\WinZapp"
+                return len(buf.value)
+
+        monkeypatch.setattr(updater.ctypes, "windll",
+                            type("W", (), {"kernel32": _Kernel()})(), raising=False)
+        out = updater._console_safe_path("C:\\Users\\Pawe\u0142\\AppData\\Local\\WinZapp")
+        assert out == r"C:\Users\PAWE~1\AppData\Local\WinZapp"
+        assert out.isascii()
+
+    def test_a_non_ascii_short_name_is_rejected(self, monkeypatch):
+        """A "short" name that is still non-ASCII buys nothing — the long path
+        is just as usable and the encoding step handles both the same way."""
+        class _Kernel:
+            def GetShortPathNameW(self, path, buf, size):
+                buf.value = "C:\\PAWE\u0142~1"
+                return len(buf.value)
+
+        monkeypatch.setattr(updater.ctypes, "windll",
+                            type("W", (), {"kernel32": _Kernel()})(), raising=False)
+        original = "C:\\Users\\Pawe\u0142\\WinZapp"
+        assert updater._console_safe_path(original) == original
+
+
+def _script(install=r"C:\WinZapp", source=r"C:\tmp\ext"):
+    return updater._build_installer_script(
+        source, install,
+        os.path.join(install, "WinZapp.exe"),
+        os.path.join(install, "update_install.log"),
+        os.path.join(install, "update_failed.marker"),
+        pid=4242, api_port=6300,
+    )
+
+
+class TestInstallerScript:
+    def test_it_copies_from_the_source_to_the_install_dir(self):
+        s = _script()
+        assert r'xcopy /E /Y /I /H "C:\tmp\ext\*" "C:\WinZapp\"' in s
+
+    def test_it_waits_for_the_pid_and_frees_the_api_port(self):
+        s = _script()
+        assert '"PID eq 4242"' in s
+        assert ":6300" in s
+        assert ":5433" in s
+
+    def test_it_writes_a_log_next_to_the_install(self):
+        """The original script recorded nothing anywhere, which is why a user
+        could only report "it just doesn't update"."""
+        s = _script()
+        assert r'"C:\WinZapp\update_install.log"' in s
+        assert "chcp" in s, "the active code page is the fact that explains a bad path"
+
+    def test_a_failed_copy_marks_it_and_keeps_the_evidence(self):
+        s = _script()
+        assert r'echo update failed > "C:\WinZapp\update_failed.marker"' in s
+        failure_block = s[s.index("if errorlevel 4"):s.index(")\n", s.index("if errorlevel 4"))]
+        assert "exit /b 1" in failure_block
+        assert 'del "%~f0"' not in failure_block, (
+            "deleting the script on failure erases the only evidence of what went wrong"
+        )
+
+    def test_a_successful_copy_relaunches_and_cleans_up(self):
+        s = _script()
+        assert r'if exist "C:\WinZapp\WinZapp.exe" start "" "C:\WinZapp\WinZapp.exe"' in s
+        assert s.rstrip().endswith('del "%~f0"')
+
+
+class TestWritingTheScript:
+    def test_an_ascii_script_is_written_as_ascii(self, tmp_path):
+        bat = tmp_path / "u.bat"
+        assert updater._write_installer_script(str(bat), _script()) is True
+        assert bat.read_bytes().decode("ascii")
+
+    @pytest.mark.skipif(not _oem_can_encode("\u00e9"), reason="OEM code page has no accents")
+    def test_a_non_ascii_script_is_written_in_the_oem_code_page(self, tmp_path):
+        """Not UTF-8 — that is the whole bug. cmd.exe reads the file in the
+        OEM code page, so that is what it has to be written in."""
+        bat = tmp_path / "u.bat"
+        script = _script(install="C:\\Users\\Jos\u00e9\\WinZapp")
+
+        assert updater._write_installer_script(str(bat), script) is True
+
+        raw = bat.read_bytes()
+        assert "Jos\u00e9" in raw.decode(_OEM), "cmd.exe must read the real path back"
+        with pytest.raises(UnicodeDecodeError):
+            raw.decode("ascii")
+
+    def test_a_script_the_code_page_cannot_hold_is_refused(self, tmp_path, monkeypatch):
+        """Refusing beats writing a corrupt script: the caller then reports a
+        failed update instead of closing the app for an installer that would
+        quietly do nothing — which is exactly what issue #83 looked like."""
+        monkeypatch.setattr(updater, "_oem_encoding", lambda: "ascii")
+        bat = tmp_path / "u.bat"
+
+        assert updater._write_installer_script(
+            str(bat), _script(install="C:\\Users\\Pawe\u0142\\WinZapp")
+        ) is False
+
+    def test_lines_end_crlf_so_cmd_can_parse_them(self, tmp_path):
+        bat = tmp_path / "u.bat"
+        updater._write_installer_script(str(bat), _script())
+        assert b"\r\n" in bat.read_bytes()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="cmd.exe only")
+@pytest.mark.skipif(not _oem_can_encode("\u00e9"), reason="OEM code page has no accents")
+class TestAgainstRealCmd:
+    """The mechanism itself, proven with the real interpreter: same command,
+    same path, same cmd.exe — only the encoding of the .bat differs."""
+
+    def _run(self, tmp_path, encoding):
+        target_dir = tmp_path / "Jos\u00e9"
+        target_dir.mkdir()
+        proof = target_dir / "ran.txt"
+        bat = tmp_path / f"t_{encoding}.bat"
+        with open(bat, "w", encoding=encoding, newline="\r\n") as f:
+            f.write(f'@echo off\r\necho hello > "{proof}"\r\n')
+        subprocess.run(["cmd.exe", "/c", str(bat)], capture_output=True)
+        return proof.is_file()
+
+    def test_utf8_sends_the_command_to_a_path_that_does_not_exist(self, tmp_path):
+        assert self._run(tmp_path, "utf-8") is False
+
+    def test_the_oem_code_page_reaches_the_real_path(self, tmp_path):
+        assert self._run(tmp_path, _OEM) is True

--- a/tests/test_video_duration_persists.py
+++ b/tests/test_video_duration_persists.py
@@ -1,0 +1,218 @@
+"""Tests for a measured video duration surviving a resync and a restart.
+
+Reported live: playing a video with no stated duration filled the length in on
+the list, and closing and reopening the app brought it back without one.
+
+A duration WinZapp measures from the file is not something the server knows —
+WhatsApp Web keeps handing that message over with duration 0 — so every path
+that refreshes a chat from the API used to erase it:
+
+* sync_chat_messages() replaces the in-memory records with the API copy;
+* every one of those paths then batch-inserts the API copy over the stored
+  rows, which is what made it survive nothing at all across restarts.
+
+Two rules close it, one per side of the same fact:
+
+* DatabaseManager._with_known_video_duration() — at the single point every
+  write passes through, an incoming video that states no duration keeps the
+  one already on the row. No sync path can forget it.
+* carry_over_video_durations() — the same rule for the records held in
+  memory, so the length doesn't vanish from the open list until the next
+  restart.
+
+A message's video is immutable, so a duration measured once stays valid for
+that message id; a copy that DOES state a duration always wins, since that is
+the sender's own answer finally arriving.
+"""
+
+import pytest
+
+from core.utils import carry_over_video_durations, video_seconds
+
+
+def _video_msg(mid="VID1", seconds=0, jid="grupo@g.us"):
+    return {
+        "key": {"id": mid, "remoteJid": jid, "fromMe": False},
+        "messageType": "videoMessage",
+        "messageTimestamp": 1000,
+        "message": {"videoMessage": {"seconds": seconds, "mimetype": "video/mp4"}},
+    }
+
+
+def _seconds_of(msg):
+    return video_seconds((msg.get("message") or {}).get("videoMessage"))
+
+
+# =============================================================================
+#  In-memory side — carry_over_video_durations()
+# =============================================================================
+
+
+class TestCarryOverVideoDurations:
+    def test_a_measured_length_survives_the_api_copy_replacing_the_record(self):
+        api = [_video_msg(seconds=0)]
+        local = [_video_msg(seconds=422)]
+
+        assert carry_over_video_durations(api, local) == 1
+        assert _seconds_of(api[0]) == 422
+
+    def test_a_length_the_sender_finally_states_wins(self):
+        """Not a conflict to protect against — that is the real answer
+        arriving, and it outranks anything measured locally."""
+        api = [_video_msg(seconds=30)]
+        local = [_video_msg(seconds=422)]
+
+        assert carry_over_video_durations(api, local) == 0
+        assert _seconds_of(api[0]) == 30
+
+    def test_only_the_matching_message_is_touched(self):
+        api = [_video_msg("A", seconds=0), _video_msg("B", seconds=0)]
+        local = [_video_msg("B", seconds=17)]
+
+        carry_over_video_durations(api, local)
+
+        assert _seconds_of(api[0]) is None
+        assert _seconds_of(api[1]) == 17
+
+    def test_a_local_record_with_no_measurement_carries_nothing(self):
+        api = [_video_msg(seconds=0)]
+        assert carry_over_video_durations(api, [_video_msg(seconds=0)]) == 0
+        assert _seconds_of(api[0]) is None
+
+    def test_non_video_records_are_ignored_on_both_sides(self):
+        audio = {"key": {"id": "AUD1"}, "messageType": "audioMessage",
+                 "message": {"audioMessage": {"seconds": 0}}}
+        assert carry_over_video_durations([audio], [dict(audio)]) == 0
+        assert audio["message"]["audioMessage"]["seconds"] == 0
+
+    @pytest.mark.parametrize("junk", [None, [], [None, "texto", 42]])
+    def test_junk_input_is_tolerated(self, junk):
+        assert carry_over_video_durations(junk, junk) == 0
+        assert carry_over_video_durations([_video_msg()], junk) == 0
+
+
+# =============================================================================
+#  Database side — DatabaseManager._with_known_video_duration()
+# =============================================================================
+
+
+class TestStoredDurationIsNotOverwritten:
+    async def test_a_resync_copy_cannot_erase_a_measured_duration(self, in_memory_db):
+        """The restart case, end to end: the length is stored, the server's
+        copy comes back stating none, and reading the chat back still has it."""
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=422))
+
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))
+
+        [stored] = await in_memory_db.get_messages("grupo@g.us")
+        assert _seconds_of(stored) == 422
+
+    async def test_batch_insert_keeps_it_too(self, in_memory_db):
+        """Every sync path inserts in batches — that is the write that
+        actually ran on restart."""
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=422))
+
+        await in_memory_db.insert_messages_batch("grupo@g.us", [_video_msg(seconds=0)])
+
+        [stored] = await in_memory_db.get_messages("grupo@g.us")
+        assert _seconds_of(stored) == 422
+
+    async def test_a_stated_duration_replaces_the_measured_one(self, in_memory_db):
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=422))
+
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=30))
+
+        [stored] = await in_memory_db.get_messages("grupo@g.us")
+        assert _seconds_of(stored) == 30
+
+    async def test_a_first_insert_with_no_duration_stores_none(self, in_memory_db):
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))
+
+        [stored] = await in_memory_db.get_messages("grupo@g.us")
+        assert _seconds_of(stored) is None
+
+    async def test_the_measurement_written_later_is_stored(self, in_memory_db):
+        """The forward direction: the video arrives stating nothing, playback
+        measures it, and that write is what has to land."""
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))
+
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=137))
+
+        [stored] = await in_memory_db.get_messages("grupo@g.us")
+        assert _seconds_of(stored) == 137
+
+    async def test_another_chats_copy_of_the_same_id_is_not_consulted(self, in_memory_db):
+        """Rows are keyed (message_id, remote_jid); the lookup must stay
+        inside the chat being written."""
+        await in_memory_db.insert_message("outro@g.us", _video_msg(seconds=422))
+
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))
+
+        [stored] = await in_memory_db.get_messages("grupo@g.us")
+        assert _seconds_of(stored) is None
+
+    async def test_a_message_with_no_id_is_still_rejected(self, in_memory_db):
+        """The id-less guard runs after the duration lookup now — it must
+        still drop the record rather than store it."""
+        msg = _video_msg(seconds=0)
+        msg["key"]["id"] = ""
+
+        await in_memory_db.insert_message("grupo@g.us", msg)
+
+        assert await in_memory_db.get_messages("grupo@g.us") == []
+
+    async def test_a_deleted_message_takes_its_duration_with_it(self, in_memory_db):
+        """The measurement lives inside the message row's own JSON, nowhere
+        else — deleting the message (for me, for everyone, mirrored from the
+        phone, or a cleared chat) must leave nothing behind for a later copy
+        of the same id to inherit."""
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=422))
+        await in_memory_db.delete_message("grupo@g.us", "VID1")
+
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))
+
+        [stored] = await in_memory_db.get_messages("grupo@g.us")
+        assert _seconds_of(stored) is None
+
+    async def test_a_revoke_does_not_bring_the_duration_back(self, in_memory_db):
+        """"Apagar para todos" received live is the one deletion that KEEPS
+        the row: _apply_remote_revoke() rewrites it as a protocolMessage so it
+        still reads as "Mensagem apagada" in the timeline. The video (and its
+        measured length) must go with the content — this rule only ever fills
+        in a video that is still a video."""
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=422))
+
+        revoked = {
+            "key": {"id": "VID1", "remoteJid": "grupo@g.us", "fromMe": False},
+            "messageType": "protocolMessage",
+            "messageTimestamp": 1000,
+            "message": {"protocolMessage": {"type": 3}},
+        }
+        await in_memory_db.insert_message("grupo@g.us", revoked)
+
+        [stored] = await in_memory_db.get_messages("grupo@g.us")
+        assert stored["messageType"] == "protocolMessage"
+        assert "videoMessage" not in stored["message"]
+
+    async def test_clearing_a_chat_leaves_nothing_to_inherit(self, in_memory_db):
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=422))
+        await in_memory_db.delete_chat_messages("grupo@g.us")
+
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))
+
+        [stored] = await in_memory_db.get_messages("grupo@g.us")
+        assert _seconds_of(stored) is None
+
+    async def test_an_audio_message_is_left_to_its_own_rule(self, in_memory_db):
+        """A voice note of 0 seconds is a real answer — nothing here may
+        resurrect an older length over it."""
+        audio = {"key": {"id": "AUD1", "remoteJid": "grupo@g.us"},
+                 "messageType": "audioMessage", "messageTimestamp": 1,
+                 "message": {"audioMessage": {"seconds": 12}}}
+        await in_memory_db.insert_message("grupo@g.us", audio)
+
+        audio_zero = {**audio, "message": {"audioMessage": {"seconds": 0}}}
+        await in_memory_db.insert_message("grupo@g.us", audio_zero)
+
+        [stored] = await in_memory_db.get_messages("grupo@g.us")
+        assert stored["message"]["audioMessage"]["seconds"] == 0

--- a/tests/test_video_duration_persists.py
+++ b/tests/test_video_duration_persists.py
@@ -27,15 +27,23 @@ the sender's own answer finally arriving.
 
 import pytest
 
-from core.utils import carry_over_video_durations, video_seconds
+from core.utils import (
+    MEASURED_SECONDS_KEY, carry_over_video_durations, video_seconds,
+)
 
 
-def _video_msg(mid="VID1", seconds=0, jid="grupo@g.us"):
+def _video_msg(mid="VID1", seconds=0, measured=None, jid="grupo@g.us"):
+    """*seconds* is what the message arrived with (the server's own field);
+    *measured* is what WinZapp read off the file, which is the value that has
+    to survive a resync."""
+    body = {"seconds": seconds, "mimetype": "video/mp4"}
+    if measured is not None:
+        body[MEASURED_SECONDS_KEY] = measured
     return {
         "key": {"id": mid, "remoteJid": jid, "fromMe": False},
         "messageType": "videoMessage",
         "messageTimestamp": 1000,
-        "message": {"videoMessage": {"seconds": seconds, "mimetype": "video/mp4"}},
+        "message": {"videoMessage": body},
     }
 
 
@@ -51,23 +59,21 @@ def _seconds_of(msg):
 class TestCarryOverVideoDurations:
     def test_a_measured_length_survives_the_api_copy_replacing_the_record(self):
         api = [_video_msg(seconds=0)]
-        local = [_video_msg(seconds=422)]
+        local = [_video_msg(seconds=0, measured=422)]
 
         assert carry_over_video_durations(api, local) == 1
         assert _seconds_of(api[0]) == 422
 
-    def test_a_length_the_sender_finally_states_wins(self):
-        """Not a conflict to protect against — that is the real answer
-        arriving, and it outranks anything measured locally."""
-        api = [_video_msg(seconds=30)]
-        local = [_video_msg(seconds=422)]
+    def test_a_copy_that_already_carries_a_measurement_is_left_alone(self):
+        api = [_video_msg(seconds=0, measured=30)]
+        local = [_video_msg(seconds=0, measured=422)]
 
         assert carry_over_video_durations(api, local) == 0
         assert _seconds_of(api[0]) == 30
 
     def test_only_the_matching_message_is_touched(self):
         api = [_video_msg("A", seconds=0), _video_msg("B", seconds=0)]
-        local = [_video_msg("B", seconds=17)]
+        local = [_video_msg("B", seconds=0, measured=17)]
 
         carry_over_video_durations(api, local)
 
@@ -75,9 +81,20 @@ class TestCarryOverVideoDurations:
         assert _seconds_of(api[1]) == 17
 
     def test_a_local_record_with_no_measurement_carries_nothing(self):
+        """A local record holding only the server's own 0 has nothing to
+        contribute — carrying that across would be carrying the bug."""
         api = [_video_msg(seconds=0)]
         assert carry_over_video_durations(api, [_video_msg(seconds=0)]) == 0
         assert _seconds_of(api[0]) is None
+
+    def test_a_measured_zero_travels_too(self):
+        """A clip really under a second: the measurement says 0, and that has
+        to survive a resync exactly like any other measured length."""
+        api = [_video_msg(seconds=0)]
+        local = [_video_msg(seconds=0, measured=0)]
+
+        assert carry_over_video_durations(api, local) == 1
+        assert _seconds_of(api[0]) == 0
 
     def test_non_video_records_are_ignored_on_both_sides(self):
         audio = {"key": {"id": "AUD1"}, "messageType": "audioMessage",
@@ -100,7 +117,7 @@ class TestStoredDurationIsNotOverwritten:
     async def test_a_resync_copy_cannot_erase_a_measured_duration(self, in_memory_db):
         """The restart case, end to end: the length is stored, the server's
         copy comes back stating none, and reading the chat back still has it."""
-        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=422))
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0, measured=422))
 
         await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))
 
@@ -110,20 +127,30 @@ class TestStoredDurationIsNotOverwritten:
     async def test_batch_insert_keeps_it_too(self, in_memory_db):
         """Every sync path inserts in batches — that is the write that
         actually ran on restart."""
-        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=422))
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0, measured=422))
 
         await in_memory_db.insert_messages_batch("grupo@g.us", [_video_msg(seconds=0)])
 
         [stored] = await in_memory_db.get_messages("grupo@g.us")
         assert _seconds_of(stored) == 422
 
-    async def test_a_stated_duration_replaces_the_measured_one(self, in_memory_db):
-        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=422))
+    async def test_a_newer_measurement_replaces_the_stored_one(self, in_memory_db):
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0, measured=422))
 
-        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=30))
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0, measured=30))
 
         [stored] = await in_memory_db.get_messages("grupo@g.us")
         assert _seconds_of(stored) == 30
+
+    async def test_a_measured_zero_is_kept_like_any_other_measurement(self, in_memory_db):
+        """The point of the separate key: a measured 0 is an answer, and a
+        resync must not be able to turn it back into "unknown"."""
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0, measured=0))
+
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))
+
+        [stored] = await in_memory_db.get_messages("grupo@g.us")
+        assert _seconds_of(stored) == 0
 
     async def test_a_first_insert_with_no_duration_stores_none(self, in_memory_db):
         await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))
@@ -136,7 +163,7 @@ class TestStoredDurationIsNotOverwritten:
         measures it, and that write is what has to land."""
         await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))
 
-        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=137))
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0, measured=137))
 
         [stored] = await in_memory_db.get_messages("grupo@g.us")
         assert _seconds_of(stored) == 137
@@ -144,7 +171,7 @@ class TestStoredDurationIsNotOverwritten:
     async def test_another_chats_copy_of_the_same_id_is_not_consulted(self, in_memory_db):
         """Rows are keyed (message_id, remote_jid); the lookup must stay
         inside the chat being written."""
-        await in_memory_db.insert_message("outro@g.us", _video_msg(seconds=422))
+        await in_memory_db.insert_message("outro@g.us", _video_msg(seconds=0, measured=422))
 
         await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))
 
@@ -166,7 +193,7 @@ class TestStoredDurationIsNotOverwritten:
         else — deleting the message (for me, for everyone, mirrored from the
         phone, or a cleared chat) must leave nothing behind for a later copy
         of the same id to inherit."""
-        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=422))
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0, measured=422))
         await in_memory_db.delete_message("grupo@g.us", "VID1")
 
         await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))
@@ -180,7 +207,7 @@ class TestStoredDurationIsNotOverwritten:
         still reads as "Mensagem apagada" in the timeline. The video (and its
         measured length) must go with the content — this rule only ever fills
         in a video that is still a video."""
-        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=422))
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0, measured=422))
 
         revoked = {
             "key": {"id": "VID1", "remoteJid": "grupo@g.us", "fromMe": False},
@@ -195,7 +222,7 @@ class TestStoredDurationIsNotOverwritten:
         assert "videoMessage" not in stored["message"]
 
     async def test_clearing_a_chat_leaves_nothing_to_inherit(self, in_memory_db):
-        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=422))
+        await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0, measured=422))
         await in_memory_db.delete_chat_messages("grupo@g.us")
 
         await in_memory_db.insert_message("grupo@g.us", _video_msg(seconds=0))

--- a/tests/test_video_duration_unknown.py
+++ b/tests/test_video_duration_unknown.py
@@ -1,0 +1,208 @@
+"""Tests for a video whose message never stated its duration.
+
+Reported live: a video that plays for minutes was announced as
+"vídeo, duração: 0 segundos". Checked against the running WPPConnect server
+(GET /get-messages for that chat): WhatsApp Web itself hands the message over
+with `duration` set to the string "0", and neither the payload nor its
+mediaData carries the real length anywhere else — the sending client simply
+left the field out. Two other videos in the same chat came through with
+duration "29" and rendered fine, so this is per-message, not a broken parse.
+
+Nothing can invent the length from the message alone, so:
+
+* video_seconds() treats a stated 0 as "not stated" and the row renders as a
+  bare "vídeo" — no video lasts no time, and saying so was the actual
+  complaint. Audio deliberately keeps the opposite rule: a voice note under a
+  second really does report 0 and WhatsApp shows "0:00" for it.
+* _learn_video_duration() fills the gap from the decoded file the moment the
+  video is played (BASS opens the .mp4 directly, so _probe_audio_duration()
+  covers it), persists it, and repaints just that row.
+
+ConversationsPanel is a wx.Panel and cannot be instantiated without a running
+wx.App, so the methods under test are bound to a small stub — same approach as
+tests/test_get_message_content_caption.py.
+"""
+
+import pytest
+
+import ui.conversations as conversations
+from ui.conversations import ConversationsPanel, video_seconds
+
+
+@pytest.fixture(autouse=True)
+def _immediate_callafter(monkeypatch):
+    """_learn_video_duration() runs on the playback worker and bounces the
+    repaint to the UI thread; there is no wx.App here to bounce it to."""
+    monkeypatch.setattr(conversations.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+
+
+class _FakeI18n:
+    _STRINGS = {
+        "video": "Vídeo",
+        "sticker": "Figurinha",
+        "duration": "duração",
+        "second": "segundo", "seconds": "segundos",
+        "minute": "minuto", "minutes": "minutos",
+        "hour": "hora", "hours": "horas",
+        "and": "e",
+        "decimal_separator": ".",
+    }
+
+    def t(self, key):
+        return self._STRINGS.get(key, f"[{key}]")
+
+
+class _FakeMainWindow:
+    def __init__(self):
+        self.i18n = _FakeI18n()
+        self.saves = []
+
+    def _schedule_save(self, dirty_jid=None):
+        self.saves.append(dirty_jid)
+
+
+class _Stub:
+    _get_message_content = ConversationsPanel._get_message_content
+    _format_duration = ConversationsPanel._format_duration
+    _format_filesize = ConversationsPanel._format_filesize
+    _learn_video_duration = ConversationsPanel._learn_video_duration
+
+    def __init__(self, probed=None):
+        self.main_window = _FakeMainWindow()
+        self._download_progress = {}
+        self.conversation = {"remoteJid": "grupo@g.us"}
+        self._probed = probed
+        self.persisted = []
+        self.repainted = []
+
+    def _probe_audio_duration(self, path):
+        return self._probed
+
+    def _persist_message_local_flag(self, jid, msg):
+        self.persisted.append((jid, msg.get("key", {}).get("id", "")))
+
+    def _repaint_message_rows(self, msg_ids):
+        self.repainted.append(sorted(i for i in msg_ids if i))
+        return True
+
+
+def _video(**inner):
+    body = {"caption": "", "gifPlayback": False, "mimetype": "video/mp4"}
+    body.update(inner)
+    return {
+        "messageType": "videoMessage",
+        "message": {"videoMessage": body},
+        "key": {"id": "VID1"},
+    }
+
+
+class TestVideoSeconds:
+    @pytest.mark.parametrize("raw", [0, "0", 0.0, "0.0"])
+    def test_a_stated_zero_means_not_stated(self, raw):
+        assert video_seconds({"seconds": raw}) is None
+
+    @pytest.mark.parametrize("raw", [None, "", "abc", {}, []])
+    def test_missing_or_unparseable_is_not_stated(self, raw):
+        assert video_seconds({"seconds": raw}) is None
+
+    def test_an_absent_field_is_not_stated(self):
+        assert video_seconds({}) is None
+
+    def test_a_negative_length_is_not_stated(self):
+        assert video_seconds({"seconds": -3}) is None
+
+    @pytest.mark.parametrize("raw,expected", [(29, 29), ("29", 29), (29.7, 29)])
+    def test_a_real_length_survives_either_type(self, raw, expected):
+        """WebSocketClient._media_seconds() casts to int, but a record
+        restored straight from a REST sync can still carry the string."""
+        assert video_seconds({"seconds": raw}) == expected
+
+    def test_a_non_dict_is_tolerated(self):
+        assert video_seconds(None) is None
+        assert video_seconds("videoMessage") is None
+
+
+class TestRendering:
+    def test_a_video_with_no_stated_duration_omits_the_clause(self):
+        text = _Stub()._get_message_content(_video(seconds=0))
+        assert text == "Vídeo"
+        assert "0 segundos" not in text
+
+    def test_a_video_with_a_real_duration_still_states_it(self):
+        text = _Stub()._get_message_content(_video(seconds=29))
+        assert text == "Vídeo, duração: 29 segundos"
+
+    def test_the_caption_survives_a_missing_duration(self):
+        text = _Stub()._get_message_content(_video(seconds=0, caption="olha isso"))
+        assert text == "Vídeo, olha isso"
+
+
+class TestLearningTheDurationFromTheFile:
+    def test_a_probed_length_is_written_back_persisted_and_repainted(self):
+        stub = _Stub(probed=137)
+        msg = _video(seconds=0)
+
+        stub._learn_video_duration(msg, "algum.mp4")
+
+        assert msg["message"]["videoMessage"]["seconds"] == 137
+        assert stub.persisted == [("grupo@g.us", "VID1")]
+        assert stub.main_window.saves == ["grupo@g.us"]
+        assert stub.repainted == [["VID1"]]
+        assert stub._get_message_content(msg) == "Vídeo, duração: 2 minutos e 17 segundos"
+
+    def test_a_video_that_already_states_its_length_is_left_alone(self):
+        """Probing would cost a BASS stream open per playback, and the
+        message's own answer is the authoritative one when it has one."""
+        stub = _Stub(probed=999)
+        msg = _video(seconds=29)
+
+        stub._learn_video_duration(msg, "algum.mp4")
+
+        assert msg["message"]["videoMessage"]["seconds"] == 29
+        assert stub.persisted == []
+        assert stub.repainted == []
+
+    @pytest.mark.parametrize("probed", [None, 0, -1])
+    def test_a_probe_that_answers_nothing_changes_nothing(self, probed):
+        stub = _Stub(probed=probed)
+        msg = _video(seconds=0)
+
+        stub._learn_video_duration(msg, "algum.mp4")
+
+        assert msg["message"]["videoMessage"]["seconds"] == 0
+        assert stub.persisted == []
+        assert stub.repainted == []
+
+    def test_a_non_video_message_is_ignored(self):
+        stub = _Stub(probed=42)
+        msg = {"messageType": "audioMessage",
+               "message": {"audioMessage": {"seconds": 0}},
+               "key": {"id": "AUD1"}}
+
+        stub._learn_video_duration(msg, "algum.mp4")
+
+        assert msg["message"]["audioMessage"]["seconds"] == 0
+        assert stub.persisted == []
+
+    def test_no_open_conversation_still_repaints_without_persisting(self):
+        stub = _Stub(probed=50)
+        stub.conversation = None
+        msg = _video(seconds=0)
+
+        stub._learn_video_duration(msg, "algum.mp4")
+
+        assert msg["message"]["videoMessage"]["seconds"] == 50
+        assert stub.persisted == []
+        assert stub.repainted == [["VID1"]]
+
+
+class TestAudioKeepsTheOppositeRule:
+    def test_a_zero_second_voice_note_still_states_its_length(self):
+        """WhatsApp shows "0:00" for a sub-second voice note — that 0 is a
+        real answer, unlike a video's."""
+        stub = _Stub()
+        msg = {"messageType": "audioMessage",
+               "message": {"audioMessage": {"seconds": 0}},
+               "key": {"id": "AUD1"}}
+
+        assert "0 segundos" in stub._get_message_content(msg)

--- a/tests/test_video_duration_unknown.py
+++ b/tests/test_video_duration_unknown.py
@@ -26,6 +26,7 @@ tests/test_get_message_content_caption.py.
 import pytest
 
 import ui.conversations as conversations
+from core.utils import MEASURED_SECONDS_KEY
 from ui.conversations import ConversationsPanel, video_seconds
 
 
@@ -144,7 +145,10 @@ class TestLearningTheDurationFromTheFile:
 
         stub._learn_video_duration(msg, "algum.mp4")
 
-        assert msg["message"]["videoMessage"]["seconds"] == 137
+        assert msg["message"]["videoMessage"][MEASURED_SECONDS_KEY] == 137
+        assert msg["message"]["videoMessage"]["seconds"] == 0, (
+            "the message's own field is the server's; the measurement gets its own key"
+        )
         assert stub.persisted == [("grupo@g.us", "VID1")]
         assert stub.main_window.saves == ["grupo@g.us"]
         assert stub.repainted == [["VID1"]]
@@ -159,19 +163,33 @@ class TestLearningTheDurationFromTheFile:
         stub._learn_video_duration(msg, "algum.mp4")
 
         assert msg["message"]["videoMessage"]["seconds"] == 29
+        assert MEASURED_SECONDS_KEY not in msg["message"]["videoMessage"]
         assert stub.persisted == []
         assert stub.repainted == []
 
-    @pytest.mark.parametrize("probed", [None, 0, -1])
+    @pytest.mark.parametrize("probed", [None, -1])
     def test_a_probe_that_answers_nothing_changes_nothing(self, probed):
         stub = _Stub(probed=probed)
         msg = _video(seconds=0)
 
         stub._learn_video_duration(msg, "algum.mp4")
 
-        assert msg["message"]["videoMessage"]["seconds"] == 0
+        assert MEASURED_SECONDS_KEY not in msg["message"]["videoMessage"]
         assert stub.persisted == []
         assert stub.repainted == []
+
+    def test_a_file_measured_at_zero_is_recorded_as_a_real_zero(self):
+        """The distinction the message alone cannot make: a stated 0 means the
+        sender omitted the field, a MEASURED 0 means the clip really is under
+        a second — and only the second one is worth announcing."""
+        stub = _Stub(probed=0)
+        msg = _video(seconds=0)
+
+        stub._learn_video_duration(msg, "algum.mp4")
+
+        assert msg["message"]["videoMessage"][MEASURED_SECONDS_KEY] == 0
+        assert stub.persisted == [("grupo@g.us", "VID1")]
+        assert stub._get_message_content(msg) == "Vídeo, duração: 0 segundos"
 
     def test_a_non_video_message_is_ignored(self):
         stub = _Stub(probed=42)
@@ -191,7 +209,7 @@ class TestLearningTheDurationFromTheFile:
 
         stub._learn_video_duration(msg, "algum.mp4")
 
-        assert msg["message"]["videoMessage"]["seconds"] == 50
+        assert msg["message"]["videoMessage"][MEASURED_SECONDS_KEY] == 50
         assert stub.persisted == []
         assert stub.repainted == [["VID1"]]
 
@@ -206,3 +224,72 @@ class TestAudioKeepsTheOppositeRule:
                "key": {"id": "AUD1"}}
 
         assert "0 segundos" in stub._get_message_content(msg)
+
+
+class TestStatedZeroVersusMeasuredZero:
+    """The guard the audio path always had, now available to video.
+
+    Audio never needed it: a voice note under a second reports its own 0 and
+    that is the truth. A video's 0 is ambiguous — WhatsApp Web writes it both
+    for "the clip is that short" and for "the sender's client omitted the
+    field" — so the two are separated by WHERE the number came from. The
+    message's own field is only believed above zero; the value WinZapp read
+    off the file is believed at any value, including 0.
+    """
+
+    def test_a_stated_zero_is_still_no_answer(self):
+        assert video_seconds({"seconds": 0}) is None
+
+    def test_a_measured_zero_is_an_answer(self):
+        assert video_seconds({"seconds": 0, MEASURED_SECONDS_KEY: 0}) == 0
+
+    def test_the_measurement_outranks_a_stated_length(self):
+        """Both are about the same immutable file, and the measurement read
+        it directly — a mismatch means the sender's metadata was wrong."""
+        assert video_seconds({"seconds": 30, MEASURED_SECONDS_KEY: 422}) == 422
+
+    @pytest.mark.parametrize("raw,expected", [(0, 0), ("0", 0), (7, 7), ("7", 7), (7.9, 7)])
+    def test_a_measurement_is_read_in_any_shape_it_is_stored(self, raw, expected):
+        assert video_seconds({"seconds": 0, MEASURED_SECONDS_KEY: raw}) == expected
+
+    @pytest.mark.parametrize("junk", [None, "", "abc", -1])
+    def test_junk_in_the_measurement_falls_back_to_the_stated_value(self, junk):
+        assert video_seconds({"seconds": 30, MEASURED_SECONDS_KEY: junk}) == 30
+        assert video_seconds({"seconds": 0, MEASURED_SECONDS_KEY: junk}) is None
+
+    def test_a_measured_zero_renders_as_zero_seconds(self):
+        stub = _Stub()
+        msg = _video(seconds=0)
+        msg["message"]["videoMessage"][MEASURED_SECONDS_KEY] = 0
+
+        assert stub._get_message_content(msg) == "Vídeo, duração: 0 segundos"
+
+
+class TestProbeTellsShortFromUnreadable:
+    """probe_media_duration() is what makes the distinction possible, so it
+    has to answer 0 for a real sub-second file and None when it cannot read
+    one — proven against files written here, not mocks."""
+
+    def _wav(self, tmp_path, seconds, rate=8000):
+        import wave
+        path = tmp_path / f"clip_{seconds}.wav"
+        with wave.open(str(path), "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(rate)
+            wf.writeframes(b"\x00\x00" * int(rate * seconds))
+        return str(path)
+
+    def test_a_sub_second_clip_measures_zero(self, tmp_path):
+        assert conversations.probe_media_duration(self._wav(tmp_path, 0.4)) == 0
+
+    def test_a_normal_clip_measures_its_length(self, tmp_path):
+        assert conversations.probe_media_duration(self._wav(tmp_path, 2)) == 2
+
+    def test_an_empty_file_cannot_be_measured(self, tmp_path):
+        path = tmp_path / "vazio.wav"
+        path.write_bytes(b"")
+        assert conversations.probe_media_duration(str(path)) is None
+
+    def test_a_missing_file_cannot_be_measured(self, tmp_path):
+        assert conversations.probe_media_duration(str(tmp_path / "nao_existe.wav")) is None


### PR DESCRIPTION
Nove commits: três bugs em que **mensagem ou dado sumia**, um bug que impedia
o **atualizador automático** de funcionar para parte dos usuários, uma
otimização da lista de mensagens e dois ajustes de acessibilidade no compositor.

Closes #83

---

## Dados que sumiam

**A primeira mensagem de um contato desaparecia ao abrir a conversa** (`3b9fa94`)

Chegava mensagem de alguém que fazia tempo não escrevia, a lista mostrava a
prévia, e ao abrir a conversa aparecia "nenhuma mensagem" â€” a mensagem tinha
sido apagada do banco.

Quando o `@lid` de quem envia ainda não está em cache, a mensagem é gravada sob
o próprio `@lid` até o número ser resolvido em background. Ao resolver,
`_merge_lid_into_phone()` juntava os dois chats corretamente em memória, mas no
banco chamava `db.delete_chat(lid_jid)` â€” que **apaga** as linhas de mensagem em
vez de movê-las. Como `navigate_to_conversation()` recarrega a conversa direto
do banco pelo JID, e a busca conhece `@c.us`â†”`@s.whatsapp.net` mas nada sobre
`@lid`, a mensagem ficava em lugar nenhum que o app fosse olhar de novo.

Passa a usar `db.merge_or_rename_chat()`, a mesma operação que o caminho de sync
já usava. Fecha junto a corrida entre o insert em voo e o merge.

**Vídeo dizia "duração: 0 segundos" e perdia a duração descoberta**
(`488571e`, `cc3301f`)

Um vídeo que toca por minutos aparecia como "0 segundos". Conferido contra o
WPPConnect em execução: o próprio WhatsApp Web entrega a mensagem com
`duration: "0"` quando o cliente de quem enviou omitiu o campo, e nenhum outro
campo do payload carrega a duração real.

- Um `0` **declarado** passa a significar "não sei", e a linha renderiza só
  "vídeo" â€” nenhum vídeo dura zero.
- A duração é **medida do próprio arquivo** ao reproduzir o vídeo (o arquivo é
  decodificado para tocar de qualquer forma, então sai de graça).
- A medição **persiste**: ela vive só no registro local, e todo resync a
  apagava â€” aparecia ao tocar e sumia no restart seguinte.
- Um `0` **medido** é preservado como resposta real (clipe de menos de um
  segundo), separado do falso `0` por uma chave própria no registro.

O áudio mantém deliberadamente a regra oposta: uma mensagem de voz curta reporta
o próprio `0` e o WhatsApp mostra "0:00" para ela.

---

## Atualizador automático â€” issue #83

**A atualização nunca era aplicada em caminho com caractere não-ASCII**
(`e491838`)

Baixava, extraía, fechava o app â€” e nada acontecia; ao reabrir, a mesma
atualização era oferecida de novo, sem marker de falha, sem relançamento e sem
rastro de erro.

O script instalador era gravado em UTF-8, mas o `cmd.exe` decodifica um `.bat`
na página de código OEM do console. Um caminho como
`C:\Users\<nome com acento>\AppData\Local\WinZapp` virava mojibake, então
**todos** os caminhos do script â€” origem, destino, marker, exe â€” apontavam para
um diretório inexistente. Isso explica os quatro sintomas de uma vez.

Reproduzido aqui com o `cmd.exe` de verdade: mesmo comando, mesmo caminho, só
mudando a codificação do arquivo â€” em UTF-8 erra o caminho, na OEM acerta.

**O bug nunca foi específico do polonês.** Um usuário brasileiro com "João" ou
"Conceição" no nome da conta do Windows quebrava igual â€” ninguém tinha ligado
uma coisa à outra.

A correção tenta o nome curto 8.3 (ASCII puro) e, quando ele não está
disponível, grava na página de código que o `cmd` realmente usa. Cada sistema
cobre o próprio idioma, que é o caso real. Um caractere fora da página de código
do sistema com 8.3 desabilitado é **recusado** em vez de gravado corrompido: o
app reporta falha e não se fecha, em vez de encerrar para um instalador que não
faria nada.

Junto: `update_install.log` ao lado da instalação (com a página de código ativa,
os caminhos e a saída do `xcopy`), e o `.bat` deixa de ser apagado quando a
cópia falha â€” apagar a evidência foi o que tornou isso indiagnosticável.

---

## Desempenho

**Ação sobre uma mensagem repinta a linha, não a lista toda** (`015493d`)

Favoritar, fixar/desafixar, os equivalentes em massa, os rollbacks quando o
servidor recusa, e o "apagado para todos" recebido ao vivo passavam todos por um
rebuild completo da lista de mensagens: reordenar e deduplicar todos os
registros da conversa, reconstruir o mapa de reações, recalcular separador e
paginação, e então `DeleteAllItems()` + `Append()` linha a linha â€” além de
entregar ao leitor de tela uma lista inteiramente nova a cada ação.

Nenhuma dessas ações move linha alguma. Numa conversa com 200 mensagens
paginadas, favoritar uma sai de 200 renders + `DeleteAllItems` + 200 `Append`
para **1 `SetItemText`**.

Mesma ideia do `refresh_chat_row_text()`/`move_chat_row_to_top()` já usados na
lista de conversas, incluindo a recusa: quando a repintura não é possível
(linha paginada para fora, lista fora de sincronia), o caminho completo assume.

**Editar mensagem travava a UI por 1-2 segundos** (`94915da`)

`edit_message()` rodava inline na thread da UI, e o POST ao WPPConnect dirige o
Puppeteer/WhatsApp Web â€” 1 a 2 segundos de janela congelada a cada edição. Era a
última ação de mensagem apoiada no servidor ainda fazendo isso; envio, fixar e
apagar já usavam thread própria.

---

## Acessibilidade e configurações

- **Botão "remover citação" antes do de emojis** (`573f81a`) â€” quando há citação
  ativa, remover é a ação mais imediata e deve ser a primeira que o leitor de
  tela encontra. Movida a criação do controle, não só a posição no sizer: no wx
  a ordem de tabulação segue a ordem de criação.

- **Botão de emojis desabilitado quando só admins podem enviar** (`405a737`) â€”
  canais e grupos restritos já desabilitavam enviar/gravar/anexar e deixavam o
  campo somente leitura; o botão de emojis continuava clicável, abrindo o
  seletor para inserir texto num campo read-only.

- **Opção "descobrir a duração do vídeo já ao baixar"** (`42093ac`) â€”
  Configurações > Armazenamento, desligada por padrão. Quem reproduz o vídeo já
  ganha a duração de graça; a opção troca essa espera por um decode por vídeo
  baixado, para quem quer a duração na lista sem abrir nada. Chave adicionada
  nos cinco idiomas.

---

## Testes

`3306 passed` na suíte completa. **~150 testes novos** distribuídos em 6 arquivos
novos e 8 existentes atualizados.

Cada correção de bug teve a regressão verificada de verdade: o código antigo foi
reintroduzido temporariamente para confirmar que os testes novos falham, e
restaurado em seguida.

Verificações que foram além de teste unitário:

- **Atualizador**: instalação simulada num caminho com acento, script gerado
  pelo código corrigido e executado pelo `cmd.exe` real â€” arquivos copiados,
  versão avançando, sem marker de falha e com o log escrito. Mais dois testes de
  integração contra o `cmd.exe` provando o mecanismo (UTF-8 erra, OEM acerta).
- **Duração de vídeo**: medida no arquivo real que gerou o relato â€” 422 segundos
  onde a mensagem declarava 0. O comportamento do probe é travado por testes que
  medem arquivos escritos no próprio teste (0,4s â†’ 0, 2s â†’ 2, vazio â†’ None).
- **`@lid`**: diagnóstico feito sobre o log real do usuário afetado, com o
  encadeamento identificado linha a linha.

---

## Limitações conhecidas (deliberadas)

1. **Janela curta no merge de `@lid`.** Abrir a conversa entre a chegada da
   mensagem e o fim do merge ainda mostra vazio (~1s, contra os quase 3 minutos
   do caso relatado), e não se recupera sozinho até reabrir a conversa. Fechar
   isso exige mudar a semântica de carregamento de `navigate_to_conversation()`,
   que hoje **substitui** os registros em memória pelo que vem do banco em vez de
   mesclar â€” mudança de risco médio no caminho por onde passa toda abertura de
   conversa.

2. **Edição recusada pelo servidor.** Continua como antes: o texto novo fica na
   tela enquanto os outros veem o original, já que `edit_message()` não devolve
   sucesso/falha. Fazer rollback arriscaria reverter na tela uma edição que o
   WhatsApp aplicou apesar da resposta ruim.

3. **Atualizador com caractere fora da página de código do sistema** (nome
   polonês em Windows brasileiro, cirílico, chinês) e 8.3 desabilitado: falha
   visível, não corrigida. Cobertura universal exigiria trocar o `.bat` por
   PowerShell com `-EncodedCommand`, mexendo no caminho crítico por onde toda
   atualização de todo usuário passa.

4. **Mensagens já apagadas** pelo bug do `@lid` não voltam. As que ficaram sob um
   `@lid` sem nunca terem sido mescladas continuam sendo recuperadas pelo
   `deduplicate_chats()` do startup.