### PR TITLE
fix(status): melhora áudio e corrige curtida nativa

### DIFF
--- a/client/api_patches/src/controller/deviceController.ts
+++ b/client/api_patches/src/controller/deviceController.ts
@@ -1257,12 +1257,12 @@ export async function reactMessage(req: Request, res: Response) {
               detail: `message-not-found; models=${statusModels.length}`,
             };
           }
-          // A status like is a reaction message sent *through the status
-          // broadcast*, addressed only to the status author. Calling the
-          // ordinary chat reaction helper with the StatusV3 model reaches
-          // WA Web but is rejected with "Reaction send error" because that
-          // helper does not provide the status audience. Sending a text/heart
-          // to the author's chat is not equivalent either: it becomes a DM.
+          // Status likes have their own WhatsApp Web action. It converts the
+          // author's LID/phone-number identity, builds the addon payload and
+          // fans it out directly to both the author's devices and our linked
+          // devices. The generic status-post path uses the account's status
+          // privacy audience instead, which can acknowledge the local copy
+          // while never delivering the like to this status author.
           const modelAuthor =
             model.author || model.id?.participant || posterJid || null;
           const authorText = String(
@@ -1272,54 +1272,30 @@ export async function reactMessage(req: Request, res: Response) {
             return { ok: false, detail: 'status-author-not-found' };
           }
 
-          const authorWid = WPP.util.createWid(authorText);
-          const me = WPP.conn.getMyUserWid();
-          const statusWid = WPP.util.createWid('status@broadcast');
-          // randomHex exists inside WA-JS's private module graph but is not
-          // exported on window.WPP.whatsapp in the installed 4.5.0 build.
-          // Using it here failed before the reaction reached WhatsApp. A
-          // cryptographically random 20-hex-character stanza id has the same
-          // shape as WhatsApp Web's generated message ids and needs no
-          // version-sensitive private export.
-          const reactionMessageId = Array.from(
-            crypto.getRandomValues(new Uint8Array(10)),
-            (byte: number) => byte.toString(16).padStart(2, '0')
-          )
-            .join('')
-            .toUpperCase();
-          const reactionId = new WPP.whatsapp.MsgKey({
-            fromMe: true,
-            remote: statusWid,
-            participant: me,
-            id: reactionMessageId,
-          });
-          const result = await WPP.chat.sendRawMessage(
-            statusWid,
-            {
-              type: 'reaction',
-              author: me,
-              reactionParentKey: model.id,
-              reactionText: reaction || '',
-              // encryptAndSendStatusMsg uses this audience for the status
-              // sender-key fanout. Without it WhatsApp rejects the reaction.
-              broadcastParticipants: [authorWid],
-            },
-            {
-              messageId: reactionId,
-              markIsRead: false,
-              waitForAck: true,
-            }
-          );
-          const sendMsgResult = String(result?.sendMsgResult ?? '');
-          const rejected = /error|fail/i.test(sendMsgResult);
-          const accepted =
-            Boolean(result) &&
-            (Number(result?.ack ?? 0) > 0 || result?.sendMsgResult != null);
+          const pageWindow = window as any;
+          let statusReactionAction: any = null;
+          try {
+            statusReactionAction = pageWindow.require?.(
+              'WAWebSendStatusReactionAction'
+            );
+          } catch (error) {
+            return {
+              ok: false,
+              detail: `native-status-reaction-module-error: ${String(
+                (error as any)?.message || error
+              )}`,
+            };
+          }
+          if (typeof statusReactionAction?.sendStatusReaction !== 'function') {
+            return {
+              ok: false,
+              detail: 'native-status-reaction-action-not-found',
+            };
+          }
+          await statusReactionAction.sendStatusReaction(model, reaction || '');
           return {
-            ok: accepted && !rejected,
-            detail:
-              sendMsgResult ||
-              `reaction-call-returned; ack=${String(result?.ack ?? '')}`,
+            ok: true,
+            detail: `native-status-reaction-completed; author=${authorText}`,
           };
         },
         { msgId, reaction }

--- a/client/api_patches/src/controller/deviceController.ts
+++ b/client/api_patches/src/controller/deviceController.ts
@@ -1142,6 +1142,11 @@ export async function reactMessage(req: Request, res: Response) {
 
   try {
     if (typeof msgId === 'string' && msgId.includes('status@broadcast')) {
+      req.logger.info(
+        `[status-reaction] begin msgId=${msgId} action=${
+          reaction === false ? 'remove' : 'set'
+        }`
+      );
       // wa-js's WPP.chat.sendReactionToMessage(msgId, reaction) resolves a
       // string id via getMessageById(), which — for any @broadcast id —
       // unconditionally looks the message up in
@@ -1270,11 +1275,23 @@ export async function reactMessage(req: Request, res: Response) {
           const authorWid = WPP.util.createWid(authorText);
           const me = WPP.conn.getMyUserWid();
           const statusWid = WPP.util.createWid('status@broadcast');
+          // randomHex exists inside WA-JS's private module graph but is not
+          // exported on window.WPP.whatsapp in the installed 4.5.0 build.
+          // Using it here failed before the reaction reached WhatsApp. A
+          // cryptographically random 20-hex-character stanza id has the same
+          // shape as WhatsApp Web's generated message ids and needs no
+          // version-sensitive private export.
+          const reactionMessageId = Array.from(
+            crypto.getRandomValues(new Uint8Array(10)),
+            (byte: number) => byte.toString(16).padStart(2, '0')
+          )
+            .join('')
+            .toUpperCase();
           const reactionId = new WPP.whatsapp.MsgKey({
             fromMe: true,
             remote: statusWid,
             participant: me,
-            id: WPP.whatsapp.randomHex(16),
+            id: reactionMessageId,
           });
           const result = await WPP.chat.sendRawMessage(
             statusWid,
@@ -1314,6 +1331,11 @@ export async function reactMessage(req: Request, res: Response) {
           }`
         );
       }
+      req.logger.info(
+        `[status-reaction] accepted msgId=${msgId} detail=${
+          outcome.detail || 'none'
+        }`
+      );
     } else {
       await req.client.sendReactionToMessage(msgId, reaction);
     }
@@ -1329,7 +1351,11 @@ export async function reactMessage(req: Request, res: Response) {
     // showed up in WinZapp's log.log for every failed status reaction
     // ({"level":"error"}, no actual cause). Pull message/stack out
     // explicitly so the next failure is actually diagnosable.
-    req.logger.error(e);
+    req.logger.error(
+      `[status-reaction] failed msgId=${String(msgId)} error=${
+        e && e.message ? e.message : String(e)
+      }`
+    );
     res.status(500).json({
       status: 'error',
       message: 'Error on send reaction to message',

--- a/client/api_patches/src/controller/deviceController.ts
+++ b/client/api_patches/src/controller/deviceController.ts
@@ -1252,12 +1252,57 @@ export async function reactMessage(req: Request, res: Response) {
               detail: `message-not-found; models=${statusModels.length}`,
             };
           }
-          const result = await WPP.chat.sendReactionToMessage(model, reaction);
+          // A status like is a reaction message sent *through the status
+          // broadcast*, addressed only to the status author. Calling the
+          // ordinary chat reaction helper with the StatusV3 model reaches
+          // WA Web but is rejected with "Reaction send error" because that
+          // helper does not provide the status audience. Sending a text/heart
+          // to the author's chat is not equivalent either: it becomes a DM.
+          const modelAuthor =
+            model.author || model.id?.participant || posterJid || null;
+          const authorText = String(
+            modelAuthor?._serialized ?? modelAuthor?.$1 ?? modelAuthor ?? ''
+          );
+          if (!authorText) {
+            return { ok: false, detail: 'status-author-not-found' };
+          }
+
+          const authorWid = WPP.util.createWid(authorText);
+          const me = WPP.conn.getMyUserWid();
+          const statusWid = WPP.util.createWid('status@broadcast');
+          const reactionId = new WPP.whatsapp.MsgKey({
+            fromMe: true,
+            remote: statusWid,
+            participant: me,
+            id: WPP.whatsapp.randomHex(16),
+          });
+          const result = await WPP.chat.sendRawMessage(
+            statusWid,
+            {
+              type: 'reaction',
+              author: me,
+              reactionParentKey: model.id,
+              reactionText: reaction || '',
+              // encryptAndSendStatusMsg uses this audience for the status
+              // sender-key fanout. Without it WhatsApp rejects the reaction.
+              broadcastParticipants: [authorWid],
+            },
+            {
+              messageId: reactionId,
+              markIsRead: false,
+              waitForAck: true,
+            }
+          );
           const sendMsgResult = String(result?.sendMsgResult ?? '');
           const rejected = /error|fail/i.test(sendMsgResult);
+          const accepted =
+            Boolean(result) &&
+            (Number(result?.ack ?? 0) > 0 || result?.sendMsgResult != null);
           return {
-            ok: result !== false && !rejected,
-            detail: sendMsgResult || 'reaction-call-returned',
+            ok: accepted && !rejected,
+            detail:
+              sendMsgResult ||
+              `reaction-call-returned; ack=${String(result?.ack ?? '')}`,
           };
         },
         { msgId, reaction }

--- a/client/api_patches/src/controller/deviceController.ts
+++ b/client/api_patches/src/controller/deviceController.ts
@@ -1164,11 +1164,32 @@ export async function reactMessage(req: Request, res: Response) {
           const parts = msgId.split('_');
           const rawId = parts.length > 2 ? parts[2] : msgId;
           const posterJid = parts.length > 3 ? parts[3] : null;
+          const WPP = (window as any).WPP;
           let model: any = null;
 
-          if (posterJid && (window as any).WPP && (window as any).WPP.status) {
-            const statusChat = (window as any).WPP.status.get(posterJid);
-            if (statusChat) {
+          // Use the same lookup strategy as the real status-reply route:
+          // prefer the serialized poster, but scan StatusV3Store as well.
+          // Status collections may be keyed by @c.us while Python knows the
+          // same contact as @lid (or vice versa), so WPP.status.get(posterJid)
+          // alone can miss a status that is visibly open in WinZapp.
+          const statusModels: any[] = [];
+          const expected = posterJid ? WPP?.status?.get?.(posterJid) : null;
+          if (expected) statusModels.push(expected);
+          const statusStore = WPP?.whatsapp?.StatusV3Store;
+          const storedModels =
+            (typeof statusStore?.getModels === 'function' &&
+              statusStore.getModels()) ||
+            (Array.isArray(statusStore?._models) && statusStore._models) ||
+            (Array.isArray(statusStore?.models) && statusStore.models) ||
+            [];
+          for (const statusChat of storedModels) {
+            if (statusChat && !statusModels.includes(statusChat)) {
+              statusModels.push(statusChat);
+            }
+          }
+
+          for (const statusChat of statusModels) {
+            if (!model) {
               const msgs =
                 (typeof statusChat.getAllMsgs === 'function' &&
                   statusChat.getAllMsgs()) ||
@@ -1209,8 +1230,8 @@ export async function reactMessage(req: Request, res: Response) {
             });
           }
           if (!model) return false;
-          await (window as any).WPP.chat.sendReactionToMessage(model, reaction);
-          return true;
+          const result = await WPP.chat.sendReactionToMessage(model, reaction);
+          return result !== false;
         },
         { msgId, reaction }
       );

--- a/client/api_patches/src/controller/deviceController.ts
+++ b/client/api_patches/src/controller/deviceController.ts
@@ -1159,13 +1159,40 @@ export async function reactMessage(req: Request, res: Response) {
       // exactly that poster JID. Store.Msg.models is kept as a fallback in
       // case a status is ever ALSO mirrored there on some WhatsApp Web
       // version.
-      const ok = await req.client.page.evaluate(
+      const outcome = await req.client.page.evaluate(
         async ({ msgId, reaction }) => {
           const parts = msgId.split('_');
           const rawId = parts.length > 2 ? parts[2] : msgId;
           const posterJid = parts.length > 3 ? parts[3] : null;
           const WPP = (window as any).WPP;
           let model: any = null;
+
+          const asModels = (value: any): any[] => {
+            if (!value) return [];
+            if (Array.isArray(value)) return value;
+            if (typeof value.getModelsArray === 'function') {
+              return value.getModelsArray() || [];
+            }
+            if (typeof value.values === 'function') {
+              try {
+                return Array.from(value.values());
+              } catch (_) {
+                return [];
+              }
+            }
+            return [];
+          };
+
+          const matchesStatusId = (item: any): boolean => {
+            if (!item?.id) return false;
+            const serialized = String(item.id._serialized ?? item.id.$1 ?? '');
+            const itemId = String(item.id.id ?? item.id.$1 ?? '');
+            return (
+              itemId === rawId ||
+              serialized === msgId ||
+              Boolean(rawId && serialized.includes(rawId))
+            );
+          };
 
           // Use the same lookup strategy as the real status-reply route:
           // prefer the serialized poster, but scan StatusV3Store as well.
@@ -1176,12 +1203,21 @@ export async function reactMessage(req: Request, res: Response) {
           const expected = posterJid ? WPP?.status?.get?.(posterJid) : null;
           if (expected) statusModels.push(expected);
           const statusStore = WPP?.whatsapp?.StatusV3Store;
-          const storedModels =
+          if (typeof statusStore?.sync === 'function') {
+            try {
+              await statusStore.sync();
+            } catch (_) {
+              // The already-loaded collection is still useful when sync fails.
+            }
+          }
+          const storedModels = asModels(
             (typeof statusStore?.getModels === 'function' &&
               statusStore.getModels()) ||
-            (Array.isArray(statusStore?._models) && statusStore._models) ||
-            (Array.isArray(statusStore?.models) && statusStore.models) ||
-            [];
+              statusStore?._models ||
+              statusStore?.models ||
+              (typeof statusStore?.getUnexpired === 'function' &&
+                statusStore.getUnexpired())
+          );
           for (const statusChat of storedModels) {
             if (statusChat && !statusModels.includes(statusChat)) {
               statusModels.push(statusChat);
@@ -1190,24 +1226,14 @@ export async function reactMessage(req: Request, res: Response) {
 
           for (const statusChat of statusModels) {
             if (!model) {
-              const msgs =
+              const msgs = asModels(
                 (typeof statusChat.getAllMsgs === 'function' &&
                   statusChat.getAllMsgs()) ||
-                (statusChat.msgs &&
-                typeof statusChat.msgs.getModelsArray === 'function'
-                  ? statusChat.msgs.getModelsArray()
-                  : null) ||
-                [];
-              model = msgs.find((item: any) => {
-                if (!item || !item.id) return false;
-                const ser = item.id._serialized || '';
-                const itemId = item.id.id || '';
-                return (
-                  itemId === rawId ||
-                  ser === msgId ||
-                  (rawId && ser.includes(rawId))
-                );
-              });
+                  statusChat.msgs?._models ||
+                  statusChat.msgs?.models ||
+                  statusChat.msgs
+              );
+              model = msgs.find(matchesStatusId);
             }
           }
 
@@ -1218,26 +1244,29 @@ export async function reactMessage(req: Request, res: Response) {
             (window as any).Store.Msg.models
           ) {
             const models = (window as any).Store.Msg.models;
-            model = models.find((item: any) => {
-              if (!item || !item.id) return false;
-              const ser = item.id._serialized || '';
-              const itemId = item.id.id || '';
-              return (
-                itemId === rawId ||
-                ser === msgId ||
-                (rawId && ser.includes(rawId))
-              );
-            });
+            model = asModels(models).find(matchesStatusId);
           }
-          if (!model) return false;
+          if (!model) {
+            return {
+              ok: false,
+              detail: `message-not-found; models=${statusModels.length}`,
+            };
+          }
           const result = await WPP.chat.sendReactionToMessage(model, reaction);
-          return result !== false;
+          const sendMsgResult = String(result?.sendMsgResult ?? '');
+          const rejected = /error|fail/i.test(sendMsgResult);
+          return {
+            ok: result !== false && !rejected,
+            detail: sendMsgResult || 'reaction-call-returned',
+          };
         },
         { msgId, reaction }
       );
-      if (!ok) {
+      if (!outcome?.ok) {
         throw new Error(
-          `Status message not found in Store for reaction: ${msgId}`
+          `Status reaction failed for ${msgId}: ${
+            outcome?.detail || 'unknown browser result'
+          }`
         );
       }
     } else {

--- a/client/status_panel.py
+++ b/client/status_panel.py
@@ -649,6 +649,7 @@ class StatusPanel(wx.Panel):
 
         self._post_panel.SetSizer(post_sizer)
         self._post_panel.Hide()
+        self._post_panel.Disable()
         sizer.Add(self._post_panel, 0, wx.EXPAND | wx.ALL, 5)
 
         # ── Post media status panel (hidden) ──────────────────────────────
@@ -682,6 +683,7 @@ class StatusPanel(wx.Panel):
 
         self._media_post_panel.SetSizer(media_sizer)
         self._media_post_panel.Hide()
+        self._media_post_panel.Disable()
         sizer.Add(self._media_post_panel, 0, wx.EXPAND | wx.ALL, 5)
 
         self._selected_media_paths: list = []
@@ -693,24 +695,28 @@ class StatusPanel(wx.Panel):
         self._voice_status_lbl = wx.StaticText(self._voice_post_panel, label=i18n.t("voice_recording"))
         voice_sizer.Add(self._voice_status_lbl, 0, wx.ALL, 5)
 
-        voice_btn_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        # Match ConversationsPanel's recorder: one vertical action stack,
+        # with every recording shortcut exposed only inside the Audio flow.
+        # The old horizontal strip was both unlike the working conversation
+        # recorder and easy to spill across/narrow the Status UI.
+        voice_btn_sizer = wx.BoxSizer(wx.VERTICAL)
 
         self._voice_close_btn = wx.Button(self._voice_post_panel, label=i18n.t("discard_voice_message"))
         self._voice_close_btn.SetAccessible(AccessibleDiscardVoiceMessage())
         self._voice_close_btn.Bind(wx.EVT_BUTTON, self._on_close_voice_panel)
         self._voice_close_btn.Hide()
-        voice_btn_sizer.Add(self._voice_close_btn, 0, wx.RIGHT, 5)
+        voice_btn_sizer.Add(self._voice_close_btn, 0, wx.LEFT | wx.BOTTOM, 5)
 
         self._voice_start_btn = wx.Button(self._voice_post_panel, label=i18n.t("record_voice_message"))
         self._voice_start_btn.SetAccessible(AccessibleRecordVoiceMessage("Ctrl+R"))
         self._voice_start_btn.Bind(wx.EVT_BUTTON, self._on_record_voice_button)
-        voice_btn_sizer.Add(self._voice_start_btn, 0, wx.RIGHT, 5)
+        voice_btn_sizer.Add(self._voice_start_btn, 0, wx.LEFT | wx.BOTTOM, 5)
 
         self._voice_pause_btn = wx.Button(self._voice_post_panel, label=i18n.t("pause_recording"))
         self._voice_pause_btn.SetAccessible(AccessiblePauseResumeRecording())
         self._voice_pause_btn.Bind(wx.EVT_BUTTON, self._toggle_pause_voice_recording)
         self._voice_pause_btn.Hide()
-        voice_btn_sizer.Add(self._voice_pause_btn, 0, wx.RIGHT, 5)
+        voice_btn_sizer.Add(self._voice_pause_btn, 0, wx.LEFT | wx.BOTTOM, 5)
 
         self._voice_play_btn = wx.Button(
             self._voice_post_panel, label=i18n.t("play_recorded_audio")
@@ -718,7 +724,7 @@ class StatusPanel(wx.Panel):
         self._voice_play_btn.SetAccessible(AccessiblePlayRecordedAudio())
         self._voice_play_btn.Bind(wx.EVT_BUTTON, self._toggle_play_recorded_audio)
         self._voice_play_btn.Hide()
-        voice_btn_sizer.Add(self._voice_play_btn, 0, wx.RIGHT, 5)
+        voice_btn_sizer.Add(self._voice_play_btn, 0, wx.LEFT | wx.BOTTOM, 5)
         self._recorded_audio_timer = wx.Timer(self._voice_play_btn)
         self._voice_play_btn.Bind(
             wx.EVT_TIMER, self._on_recorded_audio_timer, self._recorded_audio_timer
@@ -728,12 +734,13 @@ class StatusPanel(wx.Panel):
         self._voice_send_btn.SetAccessible(AccessibleSendVoiceMessage())
         self._voice_send_btn.Bind(wx.EVT_BUTTON, self._on_send_voice_status)
         self._voice_send_btn.Hide()
-        voice_btn_sizer.Add(self._voice_send_btn, 0, wx.RIGHT, 5)
+        voice_btn_sizer.Add(self._voice_send_btn, 0, wx.LEFT | wx.BOTTOM, 5)
 
         voice_sizer.Add(voice_btn_sizer, 0, wx.ALL, 5)
 
         self._voice_post_panel.SetSizer(voice_sizer)
         self._voice_post_panel.Hide()
+        self._voice_post_panel.Disable()
         sizer.Add(self._voice_post_panel, 0, wx.EXPAND | wx.ALL, 5)
 
         # Recording state — same shape as ConversationsPanel's own voice-
@@ -1867,9 +1874,16 @@ class StatusPanel(wx.Panel):
         self._leave_status_composer()
 
     def _hide_post_panels(self):
-        self._post_panel.Hide()
-        self._media_post_panel.Hide()
-        self._voice_post_panel.Hide()
+        # Disable as well as hide, so controls from the two inactive choices
+        # cannot remain keyboard-focusable or exposed as enabled actions in
+        # the Windows/MSAA accessibility tree while another composer is open.
+        for panel in (
+            self._post_panel,
+            self._media_post_panel,
+            self._voice_post_panel,
+        ):
+            panel.Disable()
+            panel.Hide()
 
     def _is_status_composer_open(self) -> bool:
         return any(
@@ -1899,6 +1913,7 @@ class StatusPanel(wx.Panel):
             self._status_list,
         ):
             widget.Hide()
+        panel.Enable()
         panel.Show()
         self.Layout()
 
@@ -1935,21 +1950,25 @@ class StatusPanel(wx.Panel):
         self._voice_pause_btn.Hide()
         self._voice_play_btn.Hide()
         self._voice_send_btn.Hide()
-        self._voice_close_btn.Hide()
+        # Audio is a self-contained flow. Before capture starts this is the
+        # Close action; once recording starts _on_stream_opened relabels the
+        # same control to Discard, exactly like the conversation recorder.
+        self._voice_close_btn.SetLabel(i18n.t("close"))
+        self._voice_close_btn.Show()
 
         self._voice_start_btn.SetFocus()
 
     def _on_ctrl_r_shortcut(self, event):
         """Ctrl+R shortcut handler for status panel.
-        If voice post panel is shown: start recording if idle, or send if recording."""
+        It belongs only to the Audio composer selected from Add Status: start
+        if idle, or send if recording. It must not open Audio from the clean
+        Status browser, otherwise audio controls leak outside their option."""
         if self._voice_post_panel.IsShown():
             if not self._is_recording:
                 if not self._recording_starting:
                     self._start_voice_recording()
             else:
                 self._on_send_voice_status(None)
-        else:
-            self._on_choose_voice_status(None)
 
     def _on_ctrl_shift_p_shortcut(self, event):
         """Ctrl+Shift+P shortcut handler to pause/resume voice recording."""

--- a/client/status_panel.py
+++ b/client/status_panel.py
@@ -4,12 +4,14 @@ import mimetypes
 import os
 import tempfile
 import threading
+import wave
 import wx
 import requests
+import sound_lib.stream as sl_stream
 from ui.accessible import (
     AccessibleStatusPrev, AccessibleStatusNext, AccessibleStatusCopyText, AccessibleSaveAs,
     AccessibleRecordVoiceMessage, AccessibleDiscardVoiceMessage, AccessiblePauseResumeRecording,
-    AccessibleSendVoiceMessage,
+    AccessibleSendVoiceMessage, AccessiblePlayRecordedAudio,
 )
 from core.api_client import api_get, api_post, redact_api_url
 from core.utils import format_number, get_downloads_folder, normalize_line_separators
@@ -710,6 +712,18 @@ class StatusPanel(wx.Panel):
         self._voice_pause_btn.Hide()
         voice_btn_sizer.Add(self._voice_pause_btn, 0, wx.RIGHT, 5)
 
+        self._voice_play_btn = wx.Button(
+            self._voice_post_panel, label=i18n.t("play_recorded_audio")
+        )
+        self._voice_play_btn.SetAccessible(AccessiblePlayRecordedAudio())
+        self._voice_play_btn.Bind(wx.EVT_BUTTON, self._toggle_play_recorded_audio)
+        self._voice_play_btn.Hide()
+        voice_btn_sizer.Add(self._voice_play_btn, 0, wx.RIGHT, 5)
+        self._recorded_audio_timer = wx.Timer(self._voice_play_btn)
+        self._voice_play_btn.Bind(
+            wx.EVT_TIMER, self._on_recorded_audio_timer, self._recorded_audio_timer
+        )
+
         self._voice_send_btn = wx.Button(self._voice_post_panel, label=i18n.t("send_voice_message"))
         self._voice_send_btn.SetAccessible(AccessibleSendVoiceMessage())
         self._voice_send_btn.Bind(wx.EVT_BUTTON, self._on_send_voice_status)
@@ -733,6 +747,8 @@ class StatusPanel(wx.Panel):
         self._recording_channels = 1
         self._recording_paused  = False
         self._is_recording      = False
+        self._recorded_audio_sound = None
+        self._recorded_audio_temp_path = None
         # True while a background thread is opening the PyAudio input stream.
         # pa.open() (and find_input_device_index()'s device enumeration) can
         # block for seconds negotiating with the driver, and this used to run
@@ -754,6 +770,7 @@ class StatusPanel(wx.Panel):
         self.ID_CTRL_C        = wx.NewIdRef()
         self.ID_CTRL_SHIFT_S  = wx.NewIdRef()
         self.ID_CTRL_R        = wx.NewIdRef()
+        self.ID_CTRL_P        = wx.NewIdRef()
         self.ID_CTRL_SHIFT_P  = wx.NewIdRef()
         self.ID_CTRL_SHIFT_D  = wx.NewIdRef()
         self.ID_F5            = wx.NewIdRef()
@@ -765,6 +782,7 @@ class StatusPanel(wx.Panel):
             (wx.ACCEL_NORMAL,                  wx.WXK_F5,     self.ID_F5),
             (wx.ACCEL_CTRL,                    ord("C"),      self.ID_CTRL_C),
             (wx.ACCEL_CTRL,                    ord("R"),      self.ID_CTRL_R),
+            (wx.ACCEL_CTRL,                    ord("P"),      self.ID_CTRL_P),
             (wx.ACCEL_CTRL | wx.ACCEL_SHIFT,   ord("P"),      self.ID_CTRL_SHIFT_P),
             (wx.ACCEL_CTRL | wx.ACCEL_SHIFT,   ord("D"),      self.ID_CTRL_SHIFT_D),
             (wx.ACCEL_CTRL,                    ord("."),      self.ID_CTRL_PERIOD),
@@ -780,6 +798,7 @@ class StatusPanel(wx.Panel):
         self.Bind(wx.EVT_MENU, self._on_copy_status_text,     id=self.ID_CTRL_C)
         self.Bind(wx.EVT_MENU, self._on_save_status_media,    id=self.ID_CTRL_SHIFT_S)
         self.Bind(wx.EVT_MENU, self._on_ctrl_r_shortcut,      id=self.ID_CTRL_R)
+        self.Bind(wx.EVT_MENU, self._on_ctrl_p_shortcut,      id=self.ID_CTRL_P)
         self.Bind(wx.EVT_MENU, self._on_ctrl_shift_p_shortcut,id=self.ID_CTRL_SHIFT_P)
         self.Bind(wx.EVT_MENU, self._on_ctrl_shift_d_shortcut,id=self.ID_CTRL_SHIFT_D)
         self.Bind(wx.EVT_MENU, self._on_refresh_status_btn,   id=self.ID_F5)
@@ -1429,12 +1448,9 @@ class StatusPanel(wx.Panel):
 
     # ── Like / unlike status ─────────────────────────────────────────────────
 
-    # Cap on how many liked-status ids settings.json keeps — a like is
-    # never removed from this list (there's no reliable "unlike" signal to
-    # remove it on either — see _on_unlike_status_attempted()), so without
-    # a cap it would grow forever. Keeping the most RECENT ones is what
-    # matters: an old status has long since expired, so nobody will ever
-    # ask "was this one liked?" again anyway.
+    # Cap on how many liked-status ids settings.json keeps. Keeping the most
+    # recent ones is what matters: an old status has long since expired, so
+    # nobody will ever ask "was this one liked?" again anyway.
     _MAX_REMEMBERED_LIKES = 500
 
     def _is_status_liked(self, status_id: str) -> bool:
@@ -1445,11 +1461,9 @@ class StatusPanel(wx.Panel):
         liked before restarting used to always show "Curtir" again with
         no way to tell it had already been done. Persisted in
         settings.json (settings["status_panel"]["liked_status_ids"]) so it
-        survives a restart — a like has no message-side trace to detect
-        it from instead (see _on_like_status()'s own docstring on why it's
-        sent as a plain, unquoted message: WPPConnect can't resolve a
-        status as a quote target any more than it can resolve one as a
-        reaction target).
+        survives a restart. Native status reactions are not stored as normal
+        private-chat messages, so there is no message-history row to infer this
+        state from after relaunching WinZapp.
         """
         if status_id in self._liked_statuses:
             return self._liked_statuses[status_id]
@@ -1457,39 +1471,13 @@ class StatusPanel(wx.Panel):
         return bool(status_id) and status_id in remembered
 
     def _on_like_status(self, event):
-        """"Like" the currently displayed status.
+        """Toggle the native heart reaction on the displayed status.
 
-        WhatsApp Web's own Store never indexes another person's status
-        message (confirmed live: neither the general Store.Msg collection
-        nor StatusV3Store — the latter is only populated once the Status
-        tab is actually rendered in the page, which never happens in
-        WPPConnect's headless session), and wa-js has no purpose-built
-        "react to a status" API. WPP.chat.sendReactionToMessage() always
-        needs an existing MsgModel instance to skip its own
-        getMessageById() lookup — passing a plain id/key just gets
-        stringified back into exactly that same failing lookup.
-
-        This is also how a "like" on a status genuinely behaves on the
-        wire in the real WhatsApp protocol: it lands in your DM history
-        with the poster, not as a public reaction — so sending it as a
-        normal message (the emoji as the body) to the poster's own chat
-        is a faithful equivalent, not just a workaround, and reuses
-        send_text_message()'s already-proven send path instead of the
-        status@broadcast reaction endpoint.
-
-        Deliberately sent WITHOUT quoting the status: WPPConnect's
-        send-reply endpoint needs to resolve the quoted message id the
-        same way the (broken) native reaction lookup does — a status is
-        never indexed anywhere WPPConnect can find it from inside the
-        poster's own chat either, so quoting it always failed server-side
-        and silently fell back to a plain send anyway (confirmed live:
-        "Não foi possível citar a mensagem original"), just after an
-        extra round trip and a confusing notice for something that was
-        never going to work.
-
-        There is no reliable way to *unsend* it afterwards (deleting it
-        would need to reach into the recipient's own chat), so once liked
-        the button only reports that state — see _on_unlike_status_attempted().
+        This must go through ``react-message`` with a status@broadcast key.
+        Sending a literal heart with ``send_text_message`` creates an ordinary
+        private message, which is observably different from WhatsApp's Status
+        Like button. The patched Node route resolves the status in the
+        poster's StatusV3Model, just as the status-reply route does.
         """
         if self._selected_contact_idx < 0:
             return
@@ -1503,10 +1491,7 @@ class StatusPanel(wx.Panel):
         if not status_id:
             return
 
-        is_liked = self._liked_statuses.get(status_id, False)
-        if is_liked:
-            self._on_unlike_status_attempted()
-            return
+        is_liked = self._is_status_liked(status_id)
 
         sender_jid = (
             status_key.get("participant", "")
@@ -1515,15 +1500,25 @@ class StatusPanel(wx.Panel):
         if not sender_jid:
             return
 
+        # API-normalized statuses normally already carry both fields. The
+        # fallbacks keep WebSocket-cache records and older stored records just
+        # as reactable without mutating the status displayed by the panel.
+        reaction_key = dict(status_key)
+        reaction_key["remoteJid"] = "status@broadcast"
+        if not reaction_key.get("participant"):
+            reaction_key["participant"] = sender_jid
+
         mw = self.main_window
 
         def _do_like():
             try:
-                ok = bool(mw.send_text_message(sender_jid, "❤️"))
+                ok = bool(mw.send_reaction(
+                    "status@broadcast", reaction_key, "" if is_liked else "❤️"
+                ))
             except Exception:
                 ok = False
             if ok:
-                wx.CallAfter(self._on_like_sent, status_id)
+                wx.CallAfter(self._on_like_sent, status_id, not is_liked)
             else:
                 wx.CallAfter(
                     wx.MessageBox,
@@ -1534,29 +1529,30 @@ class StatusPanel(wx.Panel):
 
         threading.Thread(target=_do_like, daemon=True).start()
 
-    def _on_like_sent(self, status_id: str):
-        self._liked_statuses[status_id] = True
+    def _on_like_sent(self, status_id: str, liked: bool = True):
+        self._liked_statuses[status_id] = liked
 
         mw = self.main_window
         section = mw.settings.setdefault("status_panel", {})
         remembered = section.setdefault("liked_status_ids", [])
-        if status_id not in remembered:
+        settings_changed = False
+        if liked and status_id not in remembered:
             remembered.append(status_id)
             if len(remembered) > self._MAX_REMEMBERED_LIKES:
                 del remembered[:len(remembered) - self._MAX_REMEMBERED_LIKES]
+            settings_changed = True
+        elif not liked and status_id in remembered:
+            remembered.remove(status_id)
+            settings_changed = True
+        if settings_changed:
             mw.save_settings()
 
         # The status shown may have changed while the send was in flight
         # (Ctrl+Left/Right) — only touch the button if it's still this one.
         if (self._current_status or {}).get("key", {}).get("id") == status_id:
-            self._like_btn.SetLabel(mw.i18n.t("status_unlike"))
-
-    def _on_unlike_status_attempted(self):
-        wx.MessageBox(
-            self.main_window.i18n.t("status_unlike_unsupported"),
-            self.main_window.app_name,
-            wx.OK | wx.ICON_INFORMATION,
-        )
+            self._like_btn.SetLabel(
+                mw.i18n.t("status_unlike") if liked else mw.i18n.t("status_like")
+            )
 
     # ── Play/pause video status (in-app: audio via BASS, frames via ffmpeg) ──
     #
@@ -1888,6 +1884,7 @@ class StatusPanel(wx.Panel):
         self._is_recording = False
         self._recording_paused = False
         self._recording_frames = []
+        self._stop_recorded_audio_preview()
         self._stop_recording_stream()
 
         i18n = self.main_window.i18n
@@ -1895,6 +1892,7 @@ class StatusPanel(wx.Panel):
         self._voice_start_btn.SetLabel(i18n.t("record_voice_message"))
         self._voice_start_btn.Show()
         self._voice_pause_btn.Hide()
+        self._voice_play_btn.Hide()
         self._voice_send_btn.Hide()
         self._voice_close_btn.Hide()
 
@@ -1918,6 +1916,15 @@ class StatusPanel(wx.Panel):
         """Ctrl+Shift+P shortcut handler to pause/resume voice recording."""
         if self._voice_post_panel.IsShown() and self._is_recording:
             self._toggle_pause_voice_recording(event)
+
+    def _on_ctrl_p_shortcut(self, event):
+        """Ctrl+P plays/stops the paused recording, matching conversations."""
+        if (
+            self._voice_post_panel.IsShown()
+            and self._is_recording
+            and self._recording_paused
+        ):
+            self._toggle_play_recorded_audio(event)
 
     def _on_ctrl_shift_d_shortcut(self, event):
         """Ctrl+Shift+D shortcut handler to discard voice recording/panel."""
@@ -2087,9 +2094,74 @@ class StatusPanel(wx.Panel):
         if self._recording_paused:
             self._voice_pause_btn.SetLabel(i18n.t("resume_recording"))
             self._voice_status_lbl.SetLabel(i18n.t("recording_paused"))
+            self._voice_play_btn.Show()
         else:
+            self._stop_recorded_audio_preview()
+            self._voice_play_btn.Hide()
             self._voice_pause_btn.SetLabel(i18n.t("pause_recording"))
             self._voice_status_lbl.SetLabel(i18n.t("recording_in_progress"))
+        self.Layout()
+
+    def _toggle_play_recorded_audio(self, event):
+        """Play or stop the stable snapshot captured before the pause."""
+        if not self._is_recording or not self._recording_paused:
+            return
+        if self._recorded_audio_sound is not None:
+            self._stop_recorded_audio_preview()
+            return
+        if not self._recording_frames:
+            return
+
+        try:
+            tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+            tmp.close()
+            with wave.open(tmp.name, "wb") as wf:
+                wf.setnchannels(self._recording_channels)
+                wf.setsampwidth(2)  # capture is always 16-bit PCM
+                wf.setframerate(self._recording_rate)
+                wf.writeframes(b"".join(self._recording_frames))
+            self._recorded_audio_temp_path = tmp.name
+            sound = sl_stream.FileStream(file=tmp.name)
+            sound.play()
+        except Exception as exc:
+            logging.warning("[status audio] Failed to preview recording: %s", exc)
+            self._cleanup_recorded_audio_temp_file()
+            return
+
+        self._recorded_audio_sound = sound
+        self._voice_play_btn.SetLabel(
+            self.main_window.i18n.t("stop_recorded_audio_playback")
+        )
+        self._recorded_audio_timer.Start(300)
+
+    def _on_recorded_audio_timer(self, event):
+        if (
+            self._recorded_audio_sound is None
+            or not self._recorded_audio_sound.is_playing
+        ):
+            self._stop_recorded_audio_preview()
+
+    def _stop_recorded_audio_preview(self):
+        self._recorded_audio_timer.Stop()
+        if self._recorded_audio_sound is not None:
+            try:
+                self._recorded_audio_sound.stop()
+            except Exception:
+                pass
+            self._recorded_audio_sound = None
+        self._cleanup_recorded_audio_temp_file()
+        if hasattr(self, "_voice_play_btn"):
+            self._voice_play_btn.SetLabel(
+                self.main_window.i18n.t("play_recorded_audio")
+            )
+
+    def _cleanup_recorded_audio_temp_file(self):
+        if self._recorded_audio_temp_path is not None:
+            try:
+                os.unlink(self._recorded_audio_temp_path)
+            except Exception:
+                pass
+            self._recorded_audio_temp_path = None
 
     def _stop_recording_stream(self):
         if self._recording_stream is not None:
@@ -2111,6 +2183,7 @@ class StatusPanel(wx.Panel):
                 self.main_window.voicemsg_discard_sound.play()
             except Exception:
                 pass
+        self._stop_recorded_audio_preview()
         self._stop_recording_stream()
         self._recording_frames = []
         self._is_recording = False
@@ -2120,12 +2193,17 @@ class StatusPanel(wx.Panel):
         self._status_list.SetFocus()
 
     def _on_send_voice_status(self, event):
+        if not self._is_recording:
+            return
         if hasattr(self.main_window, "voicemsg_send_sound"):
             try:
                 self.main_window.voicemsg_send_sound.play()
             except Exception:
                 pass
+        self._stop_recorded_audio_preview()
         self._stop_recording_stream()
+        self._is_recording = False
+        self._recording_paused = False
         self._voice_post_panel.Hide()
         self.Layout()
         self._status_list.SetFocus()
@@ -2139,7 +2217,6 @@ class StatusPanel(wx.Panel):
         fd, temp_wav = tempfile.mkstemp(suffix=".wav")
         os.close(fd)
         try:
-            import wave
             with wave.open(temp_wav, "wb") as wf:
                 wf.setnchannels(self._recording_channels)
                 wf.setsampwidth(self._recording_pa.get_sample_size(pyaudio.paInt16))

--- a/client/status_panel.py
+++ b/client/status_panel.py
@@ -809,10 +809,17 @@ class StatusPanel(wx.Panel):
         self.on_show()
 
     def _on_escape(self, event):
-        """Esc closes the open status viewer and returns focus to the list.
+        """Esc closes the composer/viewer and returns focus to the list.
         Also called directly (event=None) from _on_next_status() when the
         last status of a contact is exhausted — see its own comment."""
-        if self._viewer_panel.IsShown():
+        if self._is_status_composer_open():
+            if self._voice_post_panel.IsShown():
+                self._on_close_voice_panel(event)
+            elif self._media_post_panel.IsShown():
+                self._on_close_media_panel(event)
+            else:
+                self._on_close_post_panel(event)
+        elif self._viewer_panel.IsShown():
             self._selected_contact_idx = -1
             self._viewer_panel.Hide()
             self._video_player.stop()
@@ -1815,11 +1822,9 @@ class StatusPanel(wx.Panel):
         menu.Destroy()
 
     def _on_choose_text_status(self, event):
-        self._hide_post_panels()
-        self._post_panel.Show()
+        self._enter_status_composer(self._post_panel)
         self._post_text_field.SetValue("")
         self._caption_field.SetValue("")
-        self.Layout()
         self._post_text_field.SetFocus()
 
     def _on_open_post_emoji_picker(self, event):
@@ -1847,39 +1852,75 @@ class StatusPanel(wx.Panel):
         if dlg.ShowModal() == wx.ID_OK:
             self._selected_media_paths = dlg.GetPaths()
             dlg.Destroy()
-            self._hide_post_panels()
-            self._media_post_panel.Show()
+            self._enter_status_composer(self._media_post_panel)
             self._media_caption_field.SetValue("")
             self._rebuild_media_attachment_list()
-            self.Layout()
             self._media_caption_field.SetFocus()
         else:
             dlg.Destroy()
 
     def _on_close_post_panel(self, event):
-        self._post_panel.Hide()
-        self.Layout()
-        self._status_list.SetFocus()
+        self._leave_status_composer()
 
     def _on_close_media_panel(self, event):
         self._selected_media_paths = []
-        self._media_post_panel.Hide()
-        self.Layout()
-        self._status_list.SetFocus()
+        self._leave_status_composer()
 
     def _hide_post_panels(self):
         self._post_panel.Hide()
         self._media_post_panel.Hide()
         self._voice_post_panel.Hide()
 
+    def _is_status_composer_open(self) -> bool:
+        return any(
+            panel.IsShown()
+            for panel in (
+                self._post_panel,
+                self._media_post_panel,
+                self._voice_post_panel,
+            )
+        )
+
+    def _enter_status_composer(self, panel):
+        """Show only the selected Add Status flow.
+
+        The status browser and every other composer are deliberately hidden:
+        recording controls and their shortcuts belong to Audio, attachment
+        controls belong to Media, and text controls belong to Text. Keeping
+        them beside the status list made the main screen needlessly crowded.
+        """
+        self._hide_post_panels()
+        self._viewer_panel.Hide()
+        self._video_player.stop()
+        for widget in (
+            self._add_status_btn,
+            self._refresh_status_btn,
+            self._list_label,
+            self._status_list,
+        ):
+            widget.Hide()
+        panel.Show()
+        self.Layout()
+
+    def _leave_status_composer(self):
+        """Return from any Add Status flow to the clean status browser."""
+        self._hide_post_panels()
+        for widget in (
+            self._add_status_btn,
+            self._refresh_status_btn,
+            self._list_label,
+            self._status_list,
+        ):
+            widget.Show()
+        self.Layout()
+        self._status_list.SetFocus()
+
     # ── Record & post voice status ───────────────────────────────────────────
 
     def _on_choose_voice_status(self, event):
         """Open the voice status post panel in prepared state (NOT recording yet).
         User can click Record or press Ctrl+R to start recording."""
-        self._hide_post_panels()
-        self._viewer_panel.Hide()
-        self._video_player.stop()
+        self._enter_status_composer(self._voice_post_panel)
 
         self._is_recording = False
         self._recording_paused = False
@@ -1896,8 +1937,6 @@ class StatusPanel(wx.Panel):
         self._voice_send_btn.Hide()
         self._voice_close_btn.Hide()
 
-        self._voice_post_panel.Show()
-        self.Layout()
         self._voice_start_btn.SetFocus()
 
     def _on_ctrl_r_shortcut(self, event):
@@ -2188,9 +2227,7 @@ class StatusPanel(wx.Panel):
         self._recording_frames = []
         self._is_recording = False
         self._recording_paused = False
-        self._voice_post_panel.Hide()
-        self.Layout()
-        self._status_list.SetFocus()
+        self._leave_status_composer()
 
     def _on_send_voice_status(self, event):
         if not self._is_recording:
@@ -2204,9 +2241,7 @@ class StatusPanel(wx.Panel):
         self._stop_recording_stream()
         self._is_recording = False
         self._recording_paused = False
-        self._voice_post_panel.Hide()
-        self.Layout()
-        self._status_list.SetFocus()
+        self._leave_status_composer()
 
         if not self._recording_frames:
             return
@@ -2389,10 +2424,7 @@ class StatusPanel(wx.Panel):
             )
 
     def _on_status_sent(self):
-        self._post_panel.Hide()
-        self._media_post_panel.Hide()
-        self.Layout()
-        self._status_list.SetFocus()
+        self._leave_status_composer()
         self.main_window.output(self.main_window.i18n.t("status_posted"))
         threading.Thread(target=self._load_statuses, daemon=True).start()
 

--- a/tests/test_status_panel.py
+++ b/tests/test_status_panel.py
@@ -60,6 +60,7 @@ class _FakeI18n:
 class _FakeWidget:
     def __init__(self):
         self.shown = False
+        self.enabled = True
         self.label = ""
 
     def Show(self, show=True):
@@ -70,6 +71,12 @@ class _FakeWidget:
 
     def IsShown(self):
         return self.shown
+
+    def Enable(self, enable=True):
+        self.enabled = bool(enable)
+
+    def Disable(self):
+        self.enabled = False
 
     def SetLabel(self, text):
         self.label = text
@@ -1427,6 +1434,15 @@ class TestStatusComposerKeepsTheMainScreenClean:
         assert stub._list_label.shown is False
         assert stub._status_list.shown is False
         assert stub._video_player.stop_calls == 1
+        assert selected_panel.enabled is True
+        assert all(
+            panel.enabled is (panel is selected_panel)
+            for panel in (
+                stub._post_panel,
+                stub._media_post_panel,
+                stub._voice_post_panel,
+            )
+        )
 
     def test_closing_a_composer_restores_the_status_browser(self):
         stub = _Stub()

--- a/tests/test_status_panel.py
+++ b/tests/test_status_panel.py
@@ -98,7 +98,8 @@ class _FakeTextCtrl(_FakeWidget):
 
 
 class _FakeMainWindow:
-    def __init__(self, contact_names=None, send_text_result=True, settings=None):
+    def __init__(self, contact_names=None, send_text_result=True,
+                 send_reaction_result=True, settings=None):
         self.i18n = _FakeI18n()
         self.outputs = []
         self._contact_names = contact_names or {}
@@ -107,6 +108,8 @@ class _FakeMainWindow:
         self.app_name = "WinZapp"
         self._send_text_result = send_text_result
         self.send_text_calls = []
+        self._send_reaction_result = send_reaction_result
+        self.send_reaction_calls = []
         self.settings = settings if settings is not None else {}
         self.save_settings_calls = 0
 
@@ -119,6 +122,10 @@ class _FakeMainWindow:
     def send_text_message(self, remote_jid, text, quoted=None):
         self.send_text_calls.append((remote_jid, text, quoted))
         return self._send_text_result
+
+    def send_reaction(self, remote_jid, msg_key, emoji):
+        self.send_reaction_calls.append((remote_jid, msg_key, emoji))
+        return self._send_reaction_result
 
     def save_settings(self):
         self.save_settings_calls += 1
@@ -205,7 +212,6 @@ class _Stub:
     _is_status_liked             = StatusPanel._is_status_liked
     _on_like_status              = StatusPanel._on_like_status
     _on_like_sent                = StatusPanel._on_like_sent
-    _on_unlike_status_attempted  = StatusPanel._on_unlike_status_attempted
     _parse_statuses              = StatusPanel._parse_statuses
     _latest_ts                   = staticmethod(StatusPanel._latest_ts)
     _on_next_status               = StatusPanel._on_next_status
@@ -223,9 +229,11 @@ class _Stub:
     _status_row_text              = StatusPanel._status_row_text
     _update_focused_status_row_text = StatusPanel._update_focused_status_row_text
 
-    def __init__(self, contact_names=None, send_text_result=True, settings=None):
+    def __init__(self, contact_names=None, send_text_result=True,
+                 send_reaction_result=True, settings=None):
         self.main_window = _FakeMainWindow(
-            contact_names=contact_names, send_text_result=send_text_result, settings=settings,
+            contact_names=contact_names, send_text_result=send_text_result,
+            send_reaction_result=send_reaction_result, settings=settings,
         )
         self._status_contacts      = []
         self._status_row_contact   = {}
@@ -953,18 +961,11 @@ def _run_threads_synchronously(monkeypatch):
     monkeypatch.setattr(status_panel_module.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
 
 
-class TestLikeStatusSendsAPlainEmojiMessage:
-    """_on_like_status() no longer uses send_reaction() (WhatsApp Web's
-    Store never indexes another person's status — see the method's own
-    docstring) — it sends the like emoji as a normal message to the
-    poster instead, deliberately WITHOUT quoting the status: WPPConnect's
-    send-reply endpoint can't resolve a status as a quote target any more
-    than the reaction endpoint could resolve it as a reaction target, so
-    quoting it always failed server-side and silently fell back to a
-    plain send anyway (reported live as "Não foi possível citar a
-    mensagem original")."""
+class TestLikeStatusUsesTheNativeStatusReaction:
+    """The Status Like button is a reaction to status@broadcast, never a
+    literal heart sent into the poster's private conversation."""
 
-    def test_sends_heart_emoji_without_quoting(self, monkeypatch):
+    def test_sends_heart_through_reaction_endpoint_not_private_message(self, monkeypatch):
         _run_threads_synchronously(monkeypatch)
         status = _text_status("oi")
         entry = _entry("poster@s.whatsapp.net", [status])
@@ -976,14 +977,22 @@ class TestLikeStatusSendsAPlainEmojiMessage:
 
         stub._on_like_status(None)
 
-        assert stub.main_window.send_text_calls == [
-            ("poster@s.whatsapp.net", "❤️", None)
-        ]
+        assert stub.main_window.send_text_calls == []
+        assert stub.main_window.send_reaction_calls == [(
+            "status@broadcast",
+            {
+                "fromMe": False,
+                "id": "s1",
+                "remoteJid": "status@broadcast",
+                "participant": "poster@s.whatsapp.net",
+            },
+            "❤️",
+        )]
 
     def test_marks_liked_persists_to_settings_and_updates_button_label_on_success(self, monkeypatch):
         _run_threads_synchronously(monkeypatch)
         status = _text_status("oi")
-        stub = _Stub(send_text_result=True)
+        stub = _Stub(send_reaction_result=True)
         stub._status_contacts = [_entry("poster@s.whatsapp.net", [status])]
         stub._selected_contact_idx = 0
         stub._current_status_idx = 0
@@ -1002,7 +1011,7 @@ class TestLikeStatusSendsAPlainEmojiMessage:
         calls = []
         monkeypatch.setattr(wx, "MessageBox", lambda *a, **kw: calls.append(a))
         status = _text_status("oi")
-        stub = _Stub(send_text_result=False)
+        stub = _Stub(send_reaction_result=False)
         stub._status_contacts = [_entry("poster@s.whatsapp.net", [status])]
         stub._selected_contact_idx = 0
         stub._current_status_idx = 0
@@ -1014,10 +1023,8 @@ class TestLikeStatusSendsAPlainEmojiMessage:
         assert len(calls) == 1
         assert stub.main_window.save_settings_calls == 0
 
-    def test_clicking_like_again_shows_unlike_unsupported_message_instead_of_resending(self, monkeypatch):
+    def test_clicking_again_removes_the_native_reaction(self, monkeypatch):
         _run_threads_synchronously(monkeypatch)
-        calls = []
-        monkeypatch.setattr(wx, "MessageBox", lambda *a, **kw: calls.append(a))
         status = _text_status("oi")
         status_id = status["key"]["id"]
         stub = _Stub()
@@ -1030,7 +1037,24 @@ class TestLikeStatusSendsAPlainEmojiMessage:
         stub._on_like_status(None)
 
         assert stub.main_window.send_text_calls == []
-        assert len(calls) == 1
+        assert stub.main_window.send_reaction_calls[0][2] == ""
+        assert stub._liked_statuses[status_id] is False
+        assert stub._like_btn.label == "Curtir"
+
+    def test_unlike_removes_the_persisted_status_id(self, monkeypatch):
+        _run_threads_synchronously(monkeypatch)
+        status = _text_status("oi")
+        status_id = status["key"]["id"]
+        stub = _Stub(settings={"status_panel": {"liked_status_ids": [status_id]}})
+        stub._status_contacts = [_entry("poster@s.whatsapp.net", [status])]
+        stub._selected_contact_idx = 0
+        stub._current_status_idx = 0
+        stub._current_status = status
+
+        stub._on_like_status(None)
+
+        assert status_id not in stub.main_window.settings["status_panel"]["liked_status_ids"]
+        assert stub.main_window.save_settings_calls == 1
 
 
 class TestIsStatusLikedRemembersAcrossSessions:

--- a/tests/test_status_panel.py
+++ b/tests/test_status_panel.py
@@ -154,6 +154,7 @@ class _FakeVideoPlayer:
 class _FakeStatusList:
     def __init__(self, focused=-1):
         self._focused = focused
+        self.shown = True
         self.select_calls = []
         self.items = []
         self.focus_calls = []
@@ -166,6 +167,15 @@ class _FakeStatusList:
 
     def SetFocus(self):
         pass
+
+    def Show(self, show=True):
+        self.shown = bool(show)
+
+    def Hide(self):
+        self.shown = False
+
+    def IsShown(self):
+        return self.shown
 
     def Append(self, row):
         self.items.append(row[0])
@@ -217,6 +227,12 @@ class _Stub:
     _on_next_status               = StatusPanel._on_next_status
     _on_prev_status                = StatusPanel._on_prev_status
     _on_escape                    = StatusPanel._on_escape
+    _hide_post_panels             = StatusPanel._hide_post_panels
+    _is_status_composer_open      = StatusPanel._is_status_composer_open
+    _enter_status_composer        = StatusPanel._enter_status_composer
+    _leave_status_composer        = StatusPanel._leave_status_composer
+    _on_close_post_panel          = StatusPanel._on_close_post_panel
+    _on_close_media_panel         = StatusPanel._on_close_media_panel
     _MAX_REMEMBERED_LIKES         = StatusPanel._MAX_REMEMBERED_LIKES
     _on_send_status_reply         = StatusPanel._on_send_status_reply
     _send_status_reply_bg         = StatusPanel._send_status_reply_bg
@@ -248,6 +264,12 @@ class _Stub:
         self._video_download_status_id  = None
         self._video_player = _FakeVideoPlayer()
         self._status_list = _FakeStatusList()
+        self._add_status_btn = _FakeWidget()
+        self._refresh_status_btn = _FakeWidget()
+        self._list_label = _FakeWidget()
+        self._add_status_btn.Show()
+        self._refresh_status_btn.Show()
+        self._list_label.Show()
         self.my_status_dialog_calls = 0
 
         self._status_content_label = _FakeWidget()
@@ -260,6 +282,10 @@ class _Stub:
         self._reply_field          = _FakeTextCtrl()
         self._reply_send_btn       = _FakeWidget()
         self._viewer_panel         = _FakeWidget()
+        self._post_panel           = _FakeWidget()
+        self._media_post_panel     = _FakeWidget()
+        self._voice_post_panel     = _FakeWidget()
+        self._selected_media_paths = []
 
     def _open_my_status_dialog(self):
         self.my_status_dialog_calls += 1
@@ -1372,6 +1398,56 @@ class TestEscapeClosesTheViewer:
         stub._on_escape(None)  # must not raise even with event=None
 
         assert stub._video_player.stop_calls == 0
+
+
+class TestStatusComposerKeepsTheMainScreenClean:
+    @pytest.mark.parametrize(
+        "panel_name",
+        ["_post_panel", "_media_post_panel", "_voice_post_panel"],
+    )
+    def test_only_the_selected_add_status_panel_is_visible(self, panel_name):
+        stub = _Stub()
+        stub._viewer_panel.Show()
+        selected_panel = getattr(stub, panel_name)
+
+        stub._enter_status_composer(selected_panel)
+
+        assert selected_panel.shown is True
+        assert sum(
+            panel.shown
+            for panel in (
+                stub._post_panel,
+                stub._media_post_panel,
+                stub._voice_post_panel,
+            )
+        ) == 1
+        assert stub._viewer_panel.shown is False
+        assert stub._add_status_btn.shown is False
+        assert stub._refresh_status_btn.shown is False
+        assert stub._list_label.shown is False
+        assert stub._status_list.shown is False
+        assert stub._video_player.stop_calls == 1
+
+    def test_closing_a_composer_restores_the_status_browser(self):
+        stub = _Stub()
+        stub._enter_status_composer(stub._post_panel)
+
+        stub._leave_status_composer()
+
+        assert stub._is_status_composer_open() is False
+        assert stub._add_status_btn.shown is True
+        assert stub._refresh_status_btn.shown is True
+        assert stub._list_label.shown is True
+        assert stub._status_list.shown is True
+
+    def test_escape_closes_the_active_composer_before_the_viewer(self):
+        stub = _Stub()
+        stub._enter_status_composer(stub._post_panel)
+
+        stub._on_escape(None)
+
+        assert stub._is_status_composer_open() is False
+        assert stub._status_list.shown is True
 
 
 class TestStatusReplyKeepsTheStatusQuote:

--- a/tests/test_status_reaction_transport.py
+++ b/tests/test_status_reaction_transport.py
@@ -27,4 +27,9 @@ def test_status_like_uses_targeted_status_reaction_transport():
     assert "status@broadcast" in status_branch
     assert "reactionParentKey: model.id" in status_branch
     assert "broadcastParticipants: [authorWid]" in status_branch
+    assert "crypto.getRandomValues(new Uint8Array(10))" in status_branch
+    assert "WPP.whatsapp.randomHex" not in status_branch
+    assert "[status-reaction] begin" in status_branch
+    assert "[status-reaction] accepted" in status_branch
+    assert "[status-reaction] failed" in status_branch
     assert "sendReactionToMessage(model, reaction)" not in status_branch

--- a/tests/test_status_reaction_transport.py
+++ b/tests/test_status_reaction_transport.py
@@ -1,8 +1,8 @@
 """Contract for native status likes in the WPPConnect patch.
 
-A status like is not a private text reply and cannot use the ordinary chat
-reaction helper: WhatsApp requires a reaction message through
-status@broadcast, targeted to the status author.
+A status like is not a private text reply or a status post. WhatsApp Web has a
+dedicated action that handles LID conversion and direct device fanout to the
+status author.
 """
 
 from pathlib import Path
@@ -23,11 +23,14 @@ def test_status_like_uses_targeted_status_reaction_transport():
     source = CONTROLLER.read_text(encoding="utf-8")
     status_branch = source[source.index("export async function reactMessage") :]
 
-    assert "WPP.chat.sendRawMessage(" in status_branch
-    assert "status@broadcast" in status_branch
-    assert "reactionParentKey: model.id" in status_branch
-    assert "broadcastParticipants: [authorWid]" in status_branch
-    assert "crypto.getRandomValues(new Uint8Array(10))" in status_branch
+    assert "WAWebSendStatusReactionAction" in status_branch
+    assert (
+        "statusReactionAction.sendStatusReaction(model, reaction || '')"
+        in status_branch
+    )
+    assert "WPP.chat.sendRawMessage(" not in status_branch
+    assert "broadcastParticipants: [authorWid]" not in status_branch
+    assert "crypto.getRandomValues(new Uint8Array(10))" not in status_branch
     assert "WPP.whatsapp.randomHex" not in status_branch
     assert "[status-reaction] begin" in status_branch
     assert "[status-reaction] accepted" in status_branch

--- a/tests/test_status_reaction_transport.py
+++ b/tests/test_status_reaction_transport.py
@@ -1,0 +1,30 @@
+"""Contract for native status likes in the WPPConnect patch.
+
+A status like is not a private text reply and cannot use the ordinary chat
+reaction helper: WhatsApp requires a reaction message through
+status@broadcast, targeted to the status author.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTROLLER = (
+    ROOT
+    / "client"
+    / "api_patches"
+    / "src"
+    / "controller"
+    / "deviceController.ts"
+)
+
+
+def test_status_like_uses_targeted_status_reaction_transport():
+    source = CONTROLLER.read_text(encoding="utf-8")
+    status_branch = source[source.index("export async function reactMessage") :]
+
+    assert "WPP.chat.sendRawMessage(" in status_branch
+    assert "status@broadcast" in status_branch
+    assert "reactionParentKey: model.id" in status_branch
+    assert "broadcastParticipants: [authorWid]" in status_branch
+    assert "sendReactionToMessage(model, reaction)" not in status_branch

--- a/tests/test_status_voice.py
+++ b/tests/test_status_voice.py
@@ -53,6 +53,9 @@ class _FakeWidget:
     def Hide(self):
         self.shown = False
 
+    def IsShown(self):
+        return self.shown
+
 
 class _FakeVideoPlayer:
     """Opening a post panel stops any status video that was playing."""
@@ -88,6 +91,18 @@ class _FakeButton(_FakeLabel):
         pass
 
 
+class _FakeTimer:
+    def __init__(self):
+        self.started = []
+        self.stop_calls = 0
+
+    def Start(self, milliseconds):
+        self.started.append(milliseconds)
+
+    def Stop(self):
+        self.stop_calls += 1
+
+
 class _FakeMainWindow:
     def __init__(self, convert_result="converted.ogg"):
         self.i18n = _FakeI18n()
@@ -114,6 +129,8 @@ class _Stub:
     _send_media_status_bg     = StatusPanel._send_media_status_bg
     _send_all_media_statuses_bg = StatusPanel._send_all_media_statuses_bg
     _send_status_voice_bg     = StatusPanel._send_status_voice_bg
+    _stop_recorded_audio_preview = StatusPanel._stop_recorded_audio_preview
+    _cleanup_recorded_audio_temp_file = StatusPanel._cleanup_recorded_audio_temp_file
 
     def __init__(self, convert_result="converted.ogg"):
         self.main_window = _FakeMainWindow(convert_result=convert_result)
@@ -134,11 +151,17 @@ class _Stub:
         self._voice_status_lbl = _FakeLabel()
         self._voice_start_btn = _FakeButton()
         self._voice_pause_btn = _FakeButton()
+        self._voice_play_btn = _FakeButton()
         self._voice_send_btn = _FakeButton()
         self._voice_close_btn = _FakeButton()
         self._recording_pa = None
         self._recording_stream = None
         self._recording_frames = []
+        self._recording_rate = 48000
+        self._recording_channels = 1
+        self._recorded_audio_sound = None
+        self._recorded_audio_temp_path = None
+        self._recorded_audio_timer = _FakeTimer()
         self.status_sent_calls = 0
         self.voice_calls = []
         self.media_calls = []
@@ -395,6 +418,96 @@ class TestChooseVoiceStatusDegradesGracefullyWithoutPyaudio:
 
         assert stub.main_window.output_calls == []
         assert stub._recording_stream is None
+
+
+class _FakePreviewSound:
+    def __init__(self, path):
+        self.path = path
+        self.is_playing = False
+        self.stop_calls = 0
+
+    def play(self):
+        self.is_playing = True
+
+    def stop(self):
+        self.stop_calls += 1
+        self.is_playing = False
+
+
+class _PreviewStub(_Stub):
+    _toggle_pause_voice_recording = StatusPanel._toggle_pause_voice_recording
+    _toggle_play_recorded_audio = StatusPanel._toggle_play_recorded_audio
+    _on_recorded_audio_timer = StatusPanel._on_recorded_audio_timer
+    _on_ctrl_p_shortcut = StatusPanel._on_ctrl_p_shortcut
+
+    def __init__(self):
+        super().__init__()
+        self._voice_post_panel.Show()
+        self._is_recording = True
+        self._recording_frames = [b"\x00\x00" * 400]
+
+
+class TestVoiceStatusPausedRecordingPreview:
+    def test_pause_reveals_the_same_preview_control_as_conversations(self):
+        stub = _PreviewStub()
+
+        stub._toggle_pause_voice_recording(None)
+
+        assert stub._recording_paused is True
+        assert stub._voice_pause_btn.label == "resume_recording"
+        assert stub._voice_play_btn.shown is True
+
+    def test_play_and_stop_use_a_temporary_wav_and_clean_it_up(self, monkeypatch):
+        opened = []
+
+        def _file_stream(file):
+            sound = _FakePreviewSound(file)
+            opened.append(sound)
+            return sound
+
+        monkeypatch.setattr(status_panel_module.sl_stream, "FileStream", _file_stream)
+        stub = _PreviewStub()
+        stub._recording_paused = True
+
+        stub._toggle_play_recorded_audio(None)
+
+        temp_path = stub._recorded_audio_temp_path
+        assert os.path.isfile(temp_path)
+        assert opened[0].is_playing is True
+        assert stub._voice_play_btn.label == "stop_recorded_audio_playback"
+        assert stub._recorded_audio_timer.started == [300]
+
+        stub._toggle_play_recorded_audio(None)
+
+        assert opened[0].stop_calls == 1
+        assert stub._recorded_audio_sound is None
+        assert stub._recorded_audio_temp_path is None
+        assert not os.path.exists(temp_path)
+        assert stub._voice_play_btn.label == "play_recorded_audio"
+
+    def test_resuming_stops_preview_and_hides_its_button(self, monkeypatch):
+        sound = _FakePreviewSound("snapshot.wav")
+        sound.play()
+        stub = _PreviewStub()
+        stub._recording_paused = True
+        stub._recorded_audio_sound = sound
+
+        stub._toggle_pause_voice_recording(None)
+
+        assert sound.stop_calls == 1
+        assert stub._recording_paused is False
+        assert stub._voice_play_btn.shown is False
+
+    def test_ctrl_p_uses_the_preview_only_while_paused(self):
+        calls = []
+        stub = _PreviewStub()
+        stub._toggle_play_recorded_audio = lambda event: calls.append(event)
+
+        stub._on_ctrl_p_shortcut("not-paused")
+        stub._recording_paused = True
+        stub._on_ctrl_p_shortcut("paused")
+
+        assert calls == ["paused"]
 
 
 class _FakeStream:

--- a/tests/test_status_voice.py
+++ b/tests/test_status_voice.py
@@ -125,6 +125,9 @@ class _FakeMainWindow:
 class _Stub:
     _on_choose_voice_status   = StatusPanel._on_choose_voice_status
     _hide_post_panels         = StatusPanel._hide_post_panels
+    _is_status_composer_open  = StatusPanel._is_status_composer_open
+    _enter_status_composer    = StatusPanel._enter_status_composer
+    _leave_status_composer    = StatusPanel._leave_status_composer
     _start_voice_recording    = StatusPanel._start_voice_recording
     _send_media_status_bg     = StatusPanel._send_media_status_bg
     _send_all_media_statuses_bg = StatusPanel._send_all_media_statuses_bg
@@ -137,6 +140,17 @@ class _Stub:
         self._post_panel = _FakeWidget()
         self._media_post_panel = _FakeWidget()
         self._voice_post_panel = _FakeWidget()
+        self._add_status_btn = _FakeWidget()
+        self._refresh_status_btn = _FakeWidget()
+        self._list_label = _FakeWidget()
+        self._status_list = _FakeButton()
+        for widget in (
+            self._add_status_btn,
+            self._refresh_status_btn,
+            self._list_label,
+            self._status_list,
+        ):
+            widget.Show()
         # Opening a post panel now also hides the status viewer and stops the
         # in-app video player alongside the other panels; without these the
         # method under test dies on an AttributeError before reaching anything

--- a/tests/test_status_voice.py
+++ b/tests/test_status_voice.py
@@ -46,6 +46,7 @@ class _FakeI18n:
 class _FakeWidget:
     def __init__(self):
         self.shown = False
+        self.enabled = True
 
     def Show(self, show=True):
         self.shown = bool(show)
@@ -55,6 +56,12 @@ class _FakeWidget:
 
     def IsShown(self):
         return self.shown
+
+    def Enable(self, enable=True):
+        self.enabled = bool(enable)
+
+    def Disable(self):
+        self.enabled = False
 
 
 class _FakeVideoPlayer:
@@ -124,6 +131,7 @@ class _FakeMainWindow:
 
 class _Stub:
     _on_choose_voice_status   = StatusPanel._on_choose_voice_status
+    _on_ctrl_r_shortcut       = StatusPanel._on_ctrl_r_shortcut
     _hide_post_panels         = StatusPanel._hide_post_panels
     _is_status_composer_open  = StatusPanel._is_status_composer_open
     _enter_status_composer    = StatusPanel._enter_status_composer
@@ -432,6 +440,29 @@ class TestChooseVoiceStatusDegradesGracefullyWithoutPyaudio:
 
         assert stub.main_window.output_calls == []
         assert stub._recording_stream is None
+
+    def test_audio_composer_has_close_and_record_without_other_ui(self):
+        stub = _Stub()
+
+        stub._on_choose_voice_status(None)
+
+        assert stub._voice_post_panel.shown is True
+        assert stub._voice_post_panel.enabled is True
+        assert stub._voice_close_btn.shown is True
+        assert stub._voice_close_btn.label == "close"
+        assert stub._voice_start_btn.shown is True
+        assert stub._post_panel.enabled is False
+        assert stub._media_post_panel.enabled is False
+
+    def test_ctrl_r_does_not_open_audio_outside_the_audio_option(self):
+        stub = _Stub()
+        reached = []
+        stub._start_voice_recording = lambda: reached.append(True)
+
+        stub._on_ctrl_r_shortcut(None)
+
+        assert reached == []
+        assert stub._voice_post_panel.shown is False
 
 
 class _FakePreviewSound:


### PR DESCRIPTION
## Resumo

- mantém os painéis de composição do status ocultos e desabilitados até a opção correspondente ser escolhida
- aproxima a interface de gravação de voz do fluxo já usado nas conversas, incluindo ações e atalhos no contexto correto
- envia o coração do status pela ação nativa de reação do WhatsApp Web, sem convertê-lo em mensagem privada
- registra início, sucesso e falha do transporte para facilitar diagnósticos futuros

## Validação

- `npm run build`
- testes focados da interface de status: 123 aprovados
- `pytest tests/test_status_reaction_transport.py -q`: 1 aprovado após a correção final
- `git diff --check`

## Observação

A reação de status agora usa `WAWebSendStatusReactionAction`, responsável pela conversão LID/número e pelo envio direto aos dispositivos do autor do status.