### PR TITLE
fix(contatos): filtra nova conversa e estabiliza sincronização

### DIFF
--- a/client/api_patches/src/middleware/statusConnection.ts
+++ b/client/api_patches/src/middleware/statusConnection.ts
@@ -16,7 +16,16 @@
 
 import { NextFunction, Request, Response } from 'express';
 
+import { SessionNotReadyError } from '../errors/domain';
 import { contactToArray } from '../util/functions';
+
+function disconnected(res: Response) {
+  return res.status(404).json({
+    response: null,
+    status: 'Disconnected',
+    message: 'A sessão do WhatsApp não está ativa.',
+  });
+}
 
 export default async function statusConnection(
   req: Request,
@@ -30,7 +39,10 @@ export default async function statusConnection(
         req.path.endsWith('/typing') ||
         req.path.endsWith('/recording') ||
         req.path.endsWith('/send-seen');
-      if (!skipsConnectionProbe) await req.client.isConnected();
+      if (!skipsConnectionProbe) {
+        const connected = await req.client.isConnected();
+        if (connected !== true) return disconnected(res);
+      }
 
       const localArr = contactToArray(
         req.body.phone || [],
@@ -88,19 +100,19 @@ export default async function statusConnection(
       }
       req.body.phone = localArr;
     } else {
-      return res.status(404).json({
-        response: null,
-        status: 'Disconnected',
-        message: 'A sessão do WhatsApp não está ativa.',
-      });
+      return disconnected(res);
     }
     next();
   } catch (error) {
-    req.logger.error(error);
-    res.status(404).json({
-      response: null,
-      status: 'Disconnected',
-      message: 'A sessão do WhatsApp não está ativa.',
-    });
+    const detail = String((error as any)?.message || error || '');
+    if (/WAPI is not defined|Execution context was destroyed/i.test(detail)) {
+      next(new SessionNotReadyError(detail));
+      return;
+    }
+    if (/Target closed|not connected|Session (closed|not active)/i.test(detail)) {
+      disconnected(res);
+      return;
+    }
+    next(error);
   }
 }

--- a/client/api_patches/src/routes/index.ts
+++ b/client/api_patches/src/routes/index.ts
@@ -954,7 +954,12 @@ routes.get(
   verifyToken,
   MiscController.takeScreenshot
 );
-routes.post('/api/:session/set-limit', MiscController.setLimit);
+routes.post(
+  '/api/:session/set-limit',
+  verifyToken,
+  statusConnection,
+  MiscController.setLimit
+);
 
 //Communitys
 routes.post(

--- a/client/api_patches/src/util/createSessionUtil.ts
+++ b/client/api_patches/src/util/createSessionUtil.ts
@@ -1423,9 +1423,21 @@ export default class CreateSessionUtil {
     // MainWindow.on_new_message() (client/main.py's _apply_possible_edit())
     // that was already built for exactly this — it just never received a
     // live edit event to actually detect until now.
-    await client.onMessageEdit(async (chat: any, id: string, message: any) => {
+    await client.onMessageEdit(async (eventOrChat: any, _id: string, legacyMessage: any) => {
+      // Current WPPConnect emits one { chat, id, msg } object even though its
+      // public type still declares the legacy three-argument callback.
+      const message = legacyMessage ?? eventOrChat?.msg;
+      if (!message || typeof message !== 'object') {
+        req.logger.warn(
+          `[${client.session}] onMessageEdit emitted without a serialized message`
+        );
+        return;
+      }
       message.session = client.session;
-      req.io.emit('received-message', { response: message });
+      req.io.emit('received-message', {
+        response: message,
+        session: client.session,
+      });
       callWebHook(client, req, 'onmessageedit', message);
     });
 

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -136,6 +136,40 @@ class WebSocketClient:
 
         # Debounce timer for on_disconnect() — see that method.
         self._disconnect_timer = None
+        self._locally_sent_reaction_ids = {}
+
+    def _consume_own_reaction_echo(self, msg):
+        """True only for an echo of a reaction just sent by WinZapp."""
+        reaction = (msg.get("message") or {}).get("reactionMessage") or {}
+        signature = (str((reaction.get("key") or {}).get("id", "")),
+                     (reaction.get("text") or "").strip())
+        reaction_id = str((msg.get("key") or {}).get("id", ""))
+        now = time.monotonic()
+        local_ids = getattr(self, "_locally_sent_reaction_ids", None)
+        if local_ids is None:
+            local_ids = self._locally_sent_reaction_ids = {}
+        self._locally_sent_reaction_ids = {
+            event_id: created_at
+            for event_id, created_at in local_ids.items()
+            if now - created_at <= 60
+        }
+        if reaction_id and reaction_id in self._locally_sent_reaction_ids:
+            return True
+        pending = getattr(self.main_window, "_pending_own_reactions", None)
+        lock = getattr(self.main_window, "_pending_own_reactions_lock", None)
+        if pending is None or lock is None:
+            return False
+        with lock:
+            created_at = pending.get(signature)
+            if created_at is None:
+                return False
+            if now - created_at > 60:
+                pending.pop(signature, None)
+                return False
+            pending.pop(signature, None)
+            if reaction_id:
+                self._locally_sent_reaction_ids[reaction_id] = now
+            return True
 
     def _clean_jid(self, jid_val):
         if not jid_val:
@@ -782,10 +816,11 @@ class WebSocketClient:
             # We distinguish the two cases via _own_sent_ids, which is populated
             # by MessageQueue immediately after the API returns the real message ID.
             if msg.get("key", {}).get("fromMe", False):
-                # Own reactions are applied optimistically in _on_own_reaction_sent;
-                # suppress the WebSocket echo so the reaction count isn't doubled.
                 if msg.get("messageType") == "reactionMessage":
-                    return
+                    # fromMe also covers reactions made on linked devices. Only
+                    # suppress one that matches a reaction WinZapp just sent.
+                    if self._consume_own_reaction_echo(msg):
+                        return
                 msg_id = msg.get("key", {}).get("id", "")
                 _lock = getattr(self.main_window, "_own_sent_ids_lock", None)
                 if _lock is not None:
@@ -1406,15 +1441,13 @@ class WebSocketClient:
             reactor_from_me, r_chat, reaction_id, reactor_participant = _split(
                 reaction_serialized or ""
             )
-            if reactor_from_me:
-                return  # own reaction — applied optimistically, ignore the echo
             if not chat_jid:
                 chat_jid = r_chat
 
             normalized = {
                 "key": {
                     "remoteJid": chat_jid,
-                    "fromMe": False,
+                    "fromMe": reactor_from_me,
                     "id": reaction_id,
                 },
                 "pushName": "",
@@ -1433,6 +1466,8 @@ class WebSocketClient:
             }
             if reactor_participant:
                 normalized["key"]["participant"] = reactor_participant
+            if reactor_from_me and self._consume_own_reaction_echo(normalized):
+                return
             wx.CallAfter(self.main_window.on_new_message, normalized)
         except Exception:
             logging.exception("[WebSocketClient] on_wpp_reaction error")

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -1222,23 +1222,11 @@ class WebSocketClient:
             logging.exception("[WebSocketClient] Failed to fetch host device JID")
 
     def _set_wpp_limits(self):
-        """Push raised file-size limits into WhatsApp Web via the setLimit API.
+        """Raise WhatsApp Web's effective document file-size limit to 1 GB.
 
-        WPPConnect documented defaults:
-          maxMediaSize — 70 MB  (images, videos, audio)
-          maxFileSize  — 1 GB   (documents)
-
-        maxMediaSize now matches maxFileSize: the 70 MB ceiling only ever
-        existed because non-document sends had no way to move a large file
-        into Chromium without building one giant in-memory base64 string
-        and passing it as a single CDP argument. Now that sender.layer.js's
-        bounded/chunked transfer covers image/video/audio too (see
-        core/wppconnect_sender_layer_patch.py), there is no longer a reason
-        for WhatsApp Web's own client-side guard to reject a large media
-        send before WinZapp ever gets a chance to use that path — matches
-        the single client-side cap every attachment type now shares
-        (ui/conversations.py's _MAX_ATTACHMENT_BYTES; the separate, lower
-        _MAX_MEDIA_BYTES it replaced no longer exists).
+        WA-JS 4.6 marks maxMediaSize as deprecated and its implementation is
+        a no-op that rejects values above 70 MB. Media limits now come from
+        WhatsApp's MediaGatingUtils, so only maxFileSize remains meaningful.
         """
         mw = self.main_window
         url = f"{mw.wpp_server}:{mw.wpp_port}/api/{mw.token}/set-limit"
@@ -1246,20 +1234,15 @@ class WebSocketClient:
             "Authorization": f"Bearer {mw.token}",
             "Content-Type": "application/json",
         }
-        limits = [
-            ("maxMediaSize", 1 * 1024 * 1024 * 1024),  # 1 GB
-            ("maxFileSize",  1 * 1024 * 1024 * 1024),  # 1 GB
-        ]
-        for limit_type, value in limits:
-            try:
-                api_post(
-                    url,
-                    json={"type": limit_type, "value": value},
-                    headers=headers,
-                    timeout=10,
-                )
-            except Exception:
-                pass
+        try:
+            api_post(
+                url,
+                json={"type": "maxFileSize", "value": 1 * 1024 * 1024 * 1024},
+                headers=headers,
+                timeout=10,
+            )
+        except Exception:
+            pass
 
     def on_wpp_status_find(self, data):
         try:

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -1106,7 +1106,6 @@ class WebSocketClient:
                             "pushName": push,
                             "profilePicUrl": contact.get("profilePicUrl") or "",
                             "type": "contact",
-                            "isSaved": True,
                         }
                         self.main_window.contacts[jid] = entry
                         updated = True

--- a/client/main.py
+++ b/client/main.py
@@ -1161,6 +1161,11 @@ class MainWindow(wx.Frame):
         # corresponding WebSocket echo event can be processed.
         self._own_sent_ids: set = set()
         self._own_sent_ids_lock = threading.Lock()
+        # Reactions made by WinZapp are rendered optimistically. Keep their
+        # target/emoji briefly so the WebSocket client suppresses only that
+        # echo, not a fromMe reaction made on the phone or another device.
+        self._pending_own_reactions: dict = {}
+        self._pending_own_reactions_lock = threading.Lock()
         # Consecutive failed network probes (see check_whatsapp_reachable).
         self._offline_probe_strikes = 0
         # Consecutive not-yet-connected results from _set_wa_connected() this
@@ -15862,6 +15867,13 @@ class MainWindow(wx.Frame):
             "msgId": self._serialize_msg_id(remote_jid, msg_key),
             "reaction": emoji
         }
+        reaction_signature = (str(msg_key.get("id", "")), emoji)
+        with self._pending_own_reactions_lock:
+            now = time.monotonic()
+            for key, created_at in list(self._pending_own_reactions.items()):
+                if now - created_at > 60:
+                    self._pending_own_reactions.pop(key, None)
+            self._pending_own_reactions[reaction_signature] = now
         try:
             response = api_post(url, json=payload, headers=headers, timeout=15)
             if response.status_code not in (200, 201):
@@ -15872,10 +15884,14 @@ class MainWindow(wx.Frame):
                 # longer than the old truncation allowed.
                 logging.error("[send_reaction] HTTP %s: %s",
                               response.status_code, response.text[:1500])
+                with self._pending_own_reactions_lock:
+                    self._pending_own_reactions.pop(reaction_signature, None)
                 return False
             return True
         except Exception as exc:
             logging.error("[send_reaction] exception: %s", exc)
+            with self._pending_own_reactions_lock:
+                self._pending_own_reactions.pop(reaction_signature, None)
             return False
 
     def pin_message(self, remote_jid: str, msg_key: dict, pin: bool = True) -> bool:

--- a/client/main.py
+++ b/client/main.py
@@ -16150,7 +16150,13 @@ class MainWindow(wx.Frame):
                 self._schedule_set_chats()
 
 
-    def _resolve_jid_name(self, jid_norm: str, chat_jid_norm: str = "") -> str:
+    def _resolve_jid_name(
+        self,
+        jid_norm: str,
+        chat_jid_norm: str = "",
+        *,
+        resolve_missing: bool = True,
+    ) -> str:
         """Return the best display name for a participant JID (contact lookup + fallback).
 
         chat_jid_norm: the group this participant belongs to, when known —
@@ -16241,11 +16247,12 @@ class MainWindow(wx.Frame):
             # group is opened) shows the real name instead of the
             # placeholder forever. resolve_lid_jids_via_api dedupes
             # concurrent/repeat requests for the same jid internally.
-            threading.Thread(
-                target=self.resolve_lid_jids_via_api,
-                args=([jid_norm],),
-                daemon=True,
-            ).start()
+            if resolve_missing:
+                threading.Thread(
+                    target=self.resolve_lid_jids_via_api,
+                    args=([jid_norm],),
+                    daemon=True,
+                ).start()
             # `local` here is just the raw @lid digits, meaningless to a user
             # ("Fulano está digitando" showing a bare numeric ID instead of a
             # name/phone). A generic placeholder is far more useful than
@@ -16259,7 +16266,13 @@ class MainWindow(wx.Frame):
             return self.i18n.t("unnamed_participant")
         return format_number(jid_norm)
 
-    def _presence_label_for_chat(self, chat_jid_norm: str, is_group: bool) -> str:
+    def _presence_label_for_chat(
+        self,
+        chat_jid_norm: str,
+        is_group: bool,
+        *,
+        resolve_missing: bool = True,
+    ) -> str:
         """Return the typing/recording label to append to a chat-list row, or ''."""
         active = getattr(self, "_composing_chats", {}).get(chat_jid_norm, {})
         if not active:
@@ -16272,7 +16285,14 @@ class MainWindow(wx.Frame):
         else:
             return ""
         if is_group:
-            name = self._resolve_jid_name(participant_jid, chat_jid_norm)
+            if resolve_missing:
+                name = self._resolve_jid_name(participant_jid, chat_jid_norm)
+            else:
+                name = self._resolve_jid_name(
+                    participant_jid,
+                    chat_jid_norm,
+                    resolve_missing=False,
+                )
             if name:
                 return self.i18n.t("group_presence_indicator").format(
                     name=name, action=action_label
@@ -20356,7 +20376,9 @@ class MainWindow(wx.Frame):
                         name = "eu"
                     else:
                         if hasattr(self, "conversations_panel"):
-                            name = self.conversations_panel._get_participant_name(jid)
+                            name = self.conversations_panel._get_participant_name(
+                                jid, resolve_missing=False
+                            )
                         else:
                             name = ""
                     
@@ -20814,7 +20836,11 @@ class MainWindow(wx.Frame):
             text += f" {preview}"
         chat_jid_norm = self._normalize_jid(chat_jid) if chat_jid else ""
         if chat_jid_norm:
-            presence_label = self._presence_label_for_chat(chat_jid_norm, chat_jid_norm.endswith("@g.us"))
+            presence_label = self._presence_label_for_chat(
+                chat_jid_norm,
+                chat_jid_norm.endswith("@g.us"),
+                resolve_missing=False,
+            )
             if presence_label:
                 text += f" {presence_label}"
         if chat_jid_norm and self.is_chat_pinned(chat_jid_norm):

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -8380,7 +8380,13 @@ class ConversationsPanel(wx.Panel):
         self.conversation_panel.Layout()
         self.message_field.SetFocus()
 
-    def _get_participant_name(self, participant_jid: str, msg: dict | None = None) -> str:
+    def _get_participant_name(
+        self,
+        participant_jid: str,
+        msg: dict | None = None,
+        *,
+        resolve_missing: bool = True,
+    ) -> str:
         """Return a display name for a group participant."""
         mw = self.main_window
         if mw._is_self_jid(participant_jid):
@@ -8478,11 +8484,12 @@ class ConversationsPanel(wx.Panel):
         # same JID internally) so a LATER render of this same notification
         # (conversation reopened, history resynced, ...) shows the real
         # formatted phone number instead of the raw LID digits forever.
-        threading.Thread(
-            target=mw.resolve_lid_jids_via_api,
-            args=([participant_jid],),
-            daemon=True,
-        ).start()
+        if resolve_missing:
+            threading.Thread(
+                target=mw.resolve_lid_jids_via_api,
+                args=([participant_jid],),
+                daemon=True,
+            ).start()
         # No phone mapping for this @lid — return just the local part (strip "@lid")
         # so the display shows the raw identifier without the domain suffix.
         return participant_jid.rsplit("@", 1)[0]

--- a/client/ui/dialogs/new_conversation.py
+++ b/client/ui/dialogs/new_conversation.py
@@ -135,13 +135,6 @@ class NewConversationDialog(wx.Dialog):
 
         def _name_for_chat(chat):
             jid = chat.get("remoteJid", "")
-            if jid.endswith("@g.us"):
-                # Groups carry their name under name/subject/groupMetadata
-                # subject — not in the contact store — so resolve it there
-                # first, or a named group would fall through to its raw JID.
-                group_name = mw._group_name_from_chat_dict(chat)
-                if group_name:
-                    return group_name
             return (
                 mw._resolve_contact_name(chat)
                 or mw.find_name_through_messages(chat)
@@ -152,6 +145,8 @@ class NewConversationDialog(wx.Dialog):
 
         # ── Search existing chats ─────────────────────────────────────────────
         for jid, chat in mw.chats.items():
+            if not jid or jid.endswith(("@g.us", "@broadcast", "@newsletter")):
+                continue
             name = _name_for_chat(chat)
             if not self._name_is_usable(name):
                 continue
@@ -160,15 +155,32 @@ class NewConversationDialog(wx.Dialog):
                     seen.add(self._dedup_key(jid))
                     self._results.append((name, jid, chat))
 
-        # ── Search contacts not yet in chats ──────────────────────────────────
+        # contacts is also a name cache for group participants and other
+        # identities learned from events. Only WhatsApp contacts or contacts
+        # explicitly created in WinZapp belong in this picker.
         for jid, contact in mw.contacts.items():
-            if self._dedup_key(jid) in seen:
+            if not jid or jid.endswith(("@g.us", "@broadcast", "@newsletter")):
+                continue
+            is_saved_contact = (
+                contact.get("isMyContact") is True
+                or contact.get("isMe") is True
+                or (
+                    contact.get("isSaved") is True
+                    and bool((contact.get("name") or "").strip())
+                )
+            )
+            if not is_saved_contact:
+                continue
+            key = self._dedup_key(jid)
+            if jid.endswith("@lid") and key == jid.split("@", 1)[0]:
+                continue
+            if key in seen:
                 continue
             name = contact.get("name") or contact.get("pushName") or format_number(jid)
             if not self._name_is_usable(name):
                 continue
             if qlow in name.lower() or qlow in format_number(jid).lower():
-                seen.add(self._dedup_key(jid))
+                seen.add(key)
                 self._results.append((name, jid, None))
 
         # ── If query looks like a phone number, add direct option ─────────────
@@ -214,7 +226,10 @@ class NewConversationDialog(wx.Dialog):
         # Chats may be stored under either @c.us or @s.whatsapp.net depending on
         # which format WPPConnect used when the event arrived, so check both.
         norm_jid = mw._normalize_jid(jid)
-        existing = mw.chats.get(norm_jid) or mw.chats.get(jid)
+        get_chat = getattr(mw, "get_chat", None)
+        existing = get_chat(norm_jid) if get_chat is not None else None
+        if existing is None:
+            existing = mw.chats.get(norm_jid) or mw.chats.get(jid)
         if existing is None:
             chat["remoteJid"] = norm_jid
             mw.chats[norm_jid] = chat

--- a/tests/test_api_runtime_regressions.py
+++ b/tests/test_api_runtime_regressions.py
@@ -1,0 +1,45 @@
+"""Structural guards for runtime-only WPPConnect integration contracts."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _patch(relative_path):
+    return (ROOT / "client" / "api_patches" / relative_path).read_text(
+        encoding="utf-8"
+    )
+
+
+def test_message_edit_accepts_current_and_legacy_callback_shapes():
+    source = _patch("src/util/createSessionUtil.ts")
+
+    assert "legacyMessage ?? eventOrChat?.msg" in source
+    assert "onMessageEdit emitted without a serialized message" in source
+    assert "session: client.session" in source
+
+
+def test_status_probe_distinguishes_not_ready_from_disconnected():
+    source = _patch("src/middleware/statusConnection.ts")
+
+    assert "connected !== true" in source
+    assert "new SessionNotReadyError(detail)" in source
+    assert "WAPI is not defined" in source
+    assert "next(error)" in source
+
+
+def test_set_limit_route_authenticates_and_checks_connection():
+    source = _patch("src/routes/index.ts")
+    route = re.search(
+        r"routes\.post\(\s*'/api/:session/set-limit',(?P<body>.*?)\);",
+        source,
+        re.DOTALL,
+    )
+
+    assert route is not None
+    assert re.search(
+        r"verifyToken,\s*statusConnection,\s*MiscController\.setLimit",
+        route.group("body"),
+    )

--- a/tests/test_group_notification_lid_resolution.py
+++ b/tests/test_group_notification_lid_resolution.py
@@ -80,6 +80,17 @@ def test_unresolved_lid_triggers_a_background_resolution_call():
     assert mw.resolve_calls == [[LID]]
 
 
+def test_passive_render_of_unresolved_lid_does_not_create_a_thread():
+    mw = _FakeMainWindow()
+    panel = _PanelStub(mw)
+
+    result = panel._get_participant_name(LID, resolve_missing=False)
+
+    assert result == "123456789012345"
+    assert not mw._resolved_event.wait(timeout=0.1)
+    assert mw.resolve_calls == []
+
+
 def test_already_resolved_lid_does_not_trigger_a_call():
     mw = _FakeMainWindow()
     mw._lid_to_phone[LID] = "5511999999999@s.whatsapp.net"

--- a/tests/test_large_file_patch.py
+++ b/tests/test_large_file_patch.py
@@ -74,12 +74,16 @@ def test_media_and_document_ceilings_match():
     assert "70  * 1024 * 1024" not in conversations
 
 
-def test_wpp_media_size_limit_matches_the_document_ceiling():
+def test_wpp_only_sets_the_effective_file_size_limit():
     websocket_client = (ROOT / "client" / "core" / "websocket_client.py").read_text(
         encoding="utf-8"
     )
+    method = websocket_client.split("    def _set_wpp_limits(self):", 1)[1].split(
+        "    def ", 1
+    )[0]
 
-    assert '("maxMediaSize", 1 * 1024 * 1024 * 1024)' in websocket_client
+    assert '"type": "maxFileSize"' in method
+    assert '"type": "maxMediaSize"' not in method
 
 
 def test_sender_patch_widens_bounded_transfer_to_every_attachment_type():

--- a/tests/test_new_conversation_empty_list.py
+++ b/tests/test_new_conversation_empty_list.py
@@ -116,8 +116,14 @@ def _chat(jid, name):
     return {"remoteJid": jid, "name": name}
 
 
-def _contact(jid, name):
-    return {"id": jid, "remoteJid": jid, "name": name}
+def _contact(jid, name, **flags):
+    return {
+        "id": jid,
+        "remoteJid": jid,
+        "name": name,
+        "isMyContact": True,
+        **flags,
+    }
 
 
 class TestEmptyQueryListsEverything:
@@ -175,10 +181,7 @@ class TestEmptyQueryListsEverything:
 
         assert [n for n, _, _ in stub._results] == ["Zé"]
 
-    def test_named_group_shows_its_name_not_the_raw_jid(self):
-        """A group WITH a name (name/subject/groupMetadata.subject) must
-        appear under that name, sorted with the rest — not fall through to
-        its raw 18-digit id."""
+    def test_named_group_is_not_listed(self):
         jid = "120363000000000001@g.us"
         mw = _FakeMw(
             chats={
@@ -190,7 +193,61 @@ class TestEmptyQueryListsEverything:
 
         stub._do_search("")
 
-        assert [n for n, _, _ in stub._results] == ["Ana", "Família"]
+        assert [n for n, _, _ in stub._results] == ["Ana"]
+
+    def test_named_group_participant_is_not_listed_as_a_contact(self):
+        jid = "5511888888888@s.whatsapp.net"
+        contact = _contact(jid, "Participante")
+        contact.pop("isMyContact")
+        mw = _FakeMw(contacts={jid: contact})
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert stub._results == []
+
+    def test_private_chat_remains_available_as_a_recent_conversation(self):
+        jid = "5511888888888@s.whatsapp.net"
+        mw = _FakeMw(chats={jid: _chat(jid, "Conversa recente")})
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert [n for n, _, _ in stub._results] == ["Conversa recente"]
+
+    def test_locally_created_contact_is_listed(self):
+        jid = "5511777777777@s.whatsapp.net"
+        contact = _contact(jid, "Contato local", isSaved=True)
+        contact.pop("isMyContact")
+        mw = _FakeMw(contacts={jid: contact})
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert [n for n, _, _ in stub._results] == ["Contato local"]
+
+    def test_event_push_name_marked_saved_without_local_name_is_not_listed(self):
+        jid = "5511666666666@s.whatsapp.net"
+        contact = {
+            "remoteJid": jid,
+            "pushName": "Nome de evento",
+            "isSaved": True,
+        }
+        mw = _FakeMw(contacts={jid: contact})
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert stub._results == []
+
+    def test_unresolved_lid_contact_is_not_listed(self):
+        jid = "10000000000001@lid"
+        mw = _FakeMw(contacts={jid: _contact(jid, "LID sem telefone")})
+        stub = _Stub(mw)
+
+        stub._do_search("")
+
+        assert stub._results == []
 
     def test_contact_with_only_a_phone_number_is_filtered_out(self):
         mw = _FakeMw(

--- a/tests/test_phone_reaction_events.py
+++ b/tests/test_phone_reaction_events.py
@@ -1,0 +1,61 @@
+"""Own reactions from linked devices must not be mistaken for WinZapp echoes."""
+
+import threading
+import time
+
+from core.websocket_client import WebSocketClient
+
+
+class _MainWindow:
+    def __init__(self, pending=None):
+        self._pending_own_reactions = dict(pending or {})
+        self._pending_own_reactions_lock = threading.Lock()
+
+
+def _client(pending=None):
+    client = WebSocketClient.__new__(WebSocketClient)
+    client.main_window = _MainWindow(pending)
+    return client
+
+
+def _reaction(target_id="message-1", emoji="👍"):
+    return {
+        "key": {"fromMe": True, "id": "reaction-1"},
+        "messageType": "reactionMessage",
+        "message": {
+            "reactionMessage": {
+                "key": {"id": target_id},
+                "text": emoji,
+            }
+        },
+    }
+
+
+def test_reaction_from_phone_is_not_suppressed_without_a_local_send():
+    client = _client()
+
+    assert client._consume_own_reaction_echo(_reaction()) is False
+
+
+def test_matching_local_reaction_echo_is_suppressed_once():
+    signature = ("message-1", "👍")
+    client = _client({signature: time.monotonic()})
+
+    assert client._consume_own_reaction_echo(_reaction()) is True
+    # The same reaction may arrive through both received-message and the
+    # dedicated onreactionmessage event; both copies must stay suppressed.
+    assert client._consume_own_reaction_echo(_reaction()) is True
+
+
+def test_different_phone_reaction_is_not_suppressed():
+    client = _client({("message-1", "👍"): time.monotonic()})
+
+    assert client._consume_own_reaction_echo(_reaction(emoji="😂")) is False
+
+
+def test_expired_local_marker_does_not_hide_a_phone_reaction():
+    signature = ("message-1", "👍")
+    client = _client({signature: time.monotonic() - 61})
+
+    assert client._consume_own_reaction_echo(_reaction()) is False
+    assert signature not in client.main_window._pending_own_reactions


### PR DESCRIPTION
## Resumo

- limita Nova conversa a chats privados recentes e contatos realmente salvos, removendo grupos, participantes incidentais e duplicatas de JID
- aceita os dois formatos do evento onMessageEdit e trata prontidão transitória da WAPI sem fingir desconexão
- autentica a rota set-limit e evita criação de threads durante a renderização da lista de conversas

## Validação

- 3315 testes Python passaram
- 28 testes Node passaram
- setup_api.py recompilou a API TypeScript com sucesso
- validação ao vivo de pareamento, conexão, sincronização, mídia e encerramento limpo