### PR TITLE
fix(leitura): sincroniza estado entre dispositivos

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -726,6 +726,23 @@ def unread_after_history_sync(
     return max(baseline, max(0, int(local_unread or 0)) + inferred)
 
 
+def reconcile_snapshot_unread(
+    server_unread: int,
+    local_unread: int,
+    incoming_timestamp: int,
+    local_timestamp: int,
+    unsynced: bool = False,
+) -> int:
+    """Merge an authoritative chat snapshot without losing newer live arrivals."""
+    server_unread = max(0, int(server_unread or 0))
+    local_unread = max(0, int(local_unread or 0))
+    if server_unread >= local_unread:
+        return server_unread
+    if unsynced or int(incoming_timestamp or 0) < int(local_timestamp or 0):
+        return local_unread
+    return server_unread
+
+
 def history_gap_detected(fetched: list, local_records: list, page_size: int) -> bool:
     """True when a freshly fetched page cannot be joined onto stored history.
 
@@ -10679,14 +10696,22 @@ class MainWindow(wx.Frame):
                                 if not name:
                                     name = self._fill_group_name(jid)
                             chat["name"] = name
-                        # If chat exists in self.chats (passed in), preserve any higher unreadCount
+                        # A snapshot can legitimately lower the count after the
+                        # chat was read on another device. Preserve local only
+                        # when its activity is newer than this snapshot.
                         if hasattr(self, "chats") and jid in self.chats:
                             local_unread = int(self.chats[jid].get("unreadCount") or 0)
                             server_unread = int(chat.get("unreadCount") or 0)
-                            if local_unread > server_unread:
-                                chat["unreadCount"] = local_unread
+                            chat["unreadCount"] = reconcile_snapshot_unread(
+                                server_unread,
+                                local_unread,
+                                chat.get("t", 0),
+                                self.chats[jid].get("t", 0),
+                                bool(self.chats[jid].get("_unread_count_unsynced")),
+                            )
                         chats[jid] = chat
                     else:
+                        local_activity_t = int(chats[jid].get("t", 0) or 0)
                         for k, v in chat.items():
                             if k in ("messages", "remoteJid"):
                                 continue
@@ -10725,7 +10750,14 @@ class MainWindow(wx.Frame):
                                 # a few seconds stale relative to that. Same guard as
                                 # on_chat_unread_update()'s live-event path.
                                 _cp = getattr(self, "conversations_panel", None)
-                                if jid == getattr(_cp, "_last_open_jid", ""):
+                                open_now = (
+                                    _cp is not None
+                                    and _cp.conversation is not None
+                                    and self._normalize_jid(
+                                        _cp.conversation.get("remoteJid", "")
+                                    ) == jid
+                                )
+                                if open_now:
                                     v = 0
                                 elif server_val < local_val:
                                     # WPPConnect's list-chats snapshot lagging behind
@@ -10737,7 +10769,23 @@ class MainWindow(wx.Frame):
                                     # next live message's toast notification announced
                                     # "1 unread" right after the reset, even though
                                     # several messages had already piled up before it.
-                                    continue
+                                    merged = reconcile_snapshot_unread(
+                                        server_val,
+                                        local_val,
+                                        chat.get("t", 0),
+                                        local_activity_t,
+                                        bool(chats[jid].get("_unread_count_unsynced")),
+                                    )
+                                    if merged == local_val:
+                                        continue
+                                    v = merged
+                                    if merged == 0:
+                                        removed_ack = getattr(
+                                            self, "_locally_read_at", {}
+                                        ).pop(jid, None)
+                                        getattr(self, "_new_since_read", {}).pop(jid, None)
+                                        if removed_ack is not None:
+                                            self._persist_locally_read_at()
                                 else:
                                     # A snapshot taken shortly after
                                     # mark_conversation_as_read() cleared this chat
@@ -17775,32 +17823,83 @@ class MainWindow(wx.Frame):
             return api_post(url, json=payload, headers=headers, timeout=10)
 
         def _do_api():
+            success = False
             try:
-                resp = _send_seen(target_phone, is_lid_target)
-                if not resp.ok:
-                    logging.warning("[mark_as_read] API response %s for %s: %s",
-                                     resp.status_code, target_phone, resp.text[:200])
-                    # If it failed, try the alternate format (LID <-> phone) as fallback
-                    fallback_phone = remote_jid
-                    if fallback_phone.endswith("@lid"):
-                        phone_jid = getattr(self, "_lid_to_phone", {}).get(fallback_phone, "")
-                        if phone_jid: fallback_phone = phone_jid
-                    else:
-                        alt_lid = getattr(self, "_phone_to_lid", {}).get(self._normalize_jid(fallback_phone), "")
-                        if alt_lid: fallback_phone = alt_lid
+                fallback_phone = remote_jid
+                if fallback_phone.endswith("@lid"):
+                    fallback_phone = getattr(self, "_lid_to_phone", {}).get(
+                        fallback_phone, fallback_phone
+                    )
+                else:
+                    fallback_phone = getattr(self, "_phone_to_lid", {}).get(
+                        self._normalize_jid(fallback_phone), fallback_phone
+                    )
+                if fallback_phone.endswith("@s.whatsapp.net"):
+                    fallback_phone = fallback_phone.rsplit("@", 1)[0] + "@c.us"
 
-                    if fallback_phone.endswith("@s.whatsapp.net"):
-                        fallback_phone = fallback_phone.rsplit("@", 1)[0] + "@c.us"
+                targets = [(target_phone, is_lid_target)]
+                if fallback_phone != target_phone:
+                    targets.append((fallback_phone, fallback_phone.endswith("@lid")))
 
-                    if fallback_phone != target_phone:
-                        logging.info("[mark_as_read] Retrying /send-seen using fallback JID: %s", fallback_phone)
-                        resp2 = _send_seen(fallback_phone, fallback_phone.endswith("@lid"))
-                        if not resp2.ok:
-                            logging.warning("[mark_as_read] Fallback /send-seen also failed %s for %s: %s",
-                                             resp2.status_code, fallback_phone, resp2.text[:200])
-            except Exception as exc:
-                logging.warning("[mark_as_read] Request failed for %s: %s", target_phone, exc)
+                for attempt in range(3):
+                    for phone, is_lid in targets:
+                        try:
+                            resp = _send_seen(phone, is_lid)
+                        except Exception as exc:
+                            logging.warning(
+                                "[mark_as_read] Request failed for %s (attempt %s): %s",
+                                phone, attempt + 1, exc,
+                            )
+                            continue
+                        if resp.ok:
+                            success = True
+                            return
+                        logging.warning(
+                            "[mark_as_read] API response %s for %s (attempt %s): %s",
+                            resp.status_code, phone, attempt + 1, resp.text[:200],
+                        )
+                    if attempt < 2:
+                        time.sleep(attempt + 1)
+            except Exception:
+                logging.exception("[mark_as_read] Unexpected send-seen failure")
+            finally:
+                if not success:
+                    wx.CallAfter(
+                        self._restore_unread_after_send_seen_failure,
+                        remote_jid,
+                        unread,
+                        int(chat.get("t", 0) or 0),
+                    )
         threading.Thread(target=_do_api, daemon=True).start()
+
+    def _restore_unread_after_send_seen_failure(
+        self, remote_jid: str, previous_unread: int, read_timestamp: int
+    ):
+        """Undo an optimistic local read when WhatsApp rejected every attempt."""
+        normalized = self._normalize_jid(remote_jid)
+        chat = self.chats.get(normalized) or self.chats.get(remote_jid)
+        if chat is None:
+            return
+        marker = getattr(self, "_locally_read_at", {}).get(normalized)
+        if marker is None:
+            marker = getattr(self, "_locally_read_at", {}).get(remote_jid)
+        if (
+            marker != read_timestamp
+            or int(chat.get("t", 0) or 0) != read_timestamp
+            or int(chat.get("unreadCount") or 0) != 0
+            or max(
+                getattr(self, "_new_since_read", {}).get(normalized, 0),
+                getattr(self, "_new_since_read", {}).get(remote_jid, 0),
+            ) > 0
+        ):
+            return
+        chat["unreadCount"] = max(0, int(previous_unread or 0))
+        self._locally_read_at.pop(normalized, None)
+        self._locally_read_at.pop(remote_jid, None)
+        self._persist_locally_read_at()
+        self._schedule_save(dirty_jid=normalized)
+        self._refresh_chat_row_in_list(normalized)
+        self._schedule_set_chats()
 
     def mark_conversation_as_unread(self, remote_jid: str):
         chat = self.chats.get(remote_jid)

--- a/tests/test_get_remote_chats_persistence.py
+++ b/tests/test_get_remote_chats_persistence.py
@@ -154,6 +154,50 @@ class TestTheFullSaveIsOptional:
         assert stub._muted_chats
 
 
+class TestRemoteReadReconciliation:
+    JID = "5511900000001@s.whatsapp.net"
+
+    def _cached(self, *, archived=False, timestamp=1700000000):
+        return {
+            self.JID: {
+                "remoteJid": self.JID,
+                "t": timestamp,
+                "unreadCount": 4,
+                "archived": archived,
+                "messages": {"messages": {"records": []}},
+            }
+        }
+
+    @pytest.mark.parametrize("archived", [False, True])
+    def test_current_zero_from_phone_clears_normal_and_archived_chats(
+        self, post, archived
+    ):
+        cached = self._cached(archived=archived)
+        post["payload"] = [
+            _chat("5511900000001@c.us", unreadCount=0, archive=archived)
+        ]
+        stub = _make(cached)
+
+        result = stub.get_remote_chats(
+            dict(cached), persist_full=False, notify_errors=False
+        )
+
+        assert result[self.JID]["unreadCount"] == 0
+
+    def test_older_snapshot_does_not_erase_a_newer_live_arrival(self, post):
+        cached = self._cached(timestamp=1700000001)
+        post["payload"] = [
+            _chat("5511900000001@c.us", unreadCount=0, t=1700000000)
+        ]
+        stub = _make(cached)
+
+        result = stub.get_remote_chats(
+            dict(cached), persist_full=False, notify_errors=False
+        )
+
+        assert result[self.JID]["unreadCount"] == 4
+
+
 class TestTheSweepIsIndependentOfTheSave:
     """A phantom one-to-one entry — in the cache, echoed by the server, with
     no messages and no activity — is what the sweep exists to remove."""

--- a/tests/test_read_state_bidirectional_sync.py
+++ b/tests/test_read_state_bidirectional_sync.py
@@ -1,0 +1,87 @@
+"""Regression tests for read-state synchronization across linked devices."""
+
+from main import MainWindow, reconcile_snapshot_unread
+
+
+JID = "5511999999999@s.whatsapp.net"
+
+
+def test_current_remote_zero_clears_unread_from_phone_even_when_archived():
+    assert reconcile_snapshot_unread(0, 4, 2000, 2000) == 0
+
+
+def test_snapshot_older_than_a_live_arrival_cannot_clear_it():
+    assert reconcile_snapshot_unread(0, 1, 1000, 1001) == 1
+
+
+def test_unsynced_live_chat_keeps_its_local_count():
+    assert reconcile_snapshot_unread(0, 2, 2000, 2000, unsynced=True) == 2
+
+
+def test_higher_remote_count_is_always_accepted():
+    assert reconcile_snapshot_unread(5, 2, 2000, 1000) == 5
+
+
+class _RollbackStub:
+    _restore_unread_after_send_seen_failure = (
+        MainWindow._restore_unread_after_send_seen_failure
+    )
+    _normalize_jid = staticmethod(MainWindow._normalize_jid)
+
+    def __init__(self, *, archived=False):
+        self.chats = {
+            JID: {
+                "unreadCount": 0,
+                "t": 2000,
+                "archived": archived,
+            }
+        }
+        self._locally_read_at = {JID: 2000}
+        self._new_since_read = {JID: 0}
+        self.persisted = 0
+        self.saved = []
+        self.refreshed = []
+        self.list_refreshes = 0
+
+    def _persist_locally_read_at(self):
+        self.persisted += 1
+
+    def _schedule_save(self, dirty_jid=None):
+        self.saved.append(dirty_jid)
+
+    def _refresh_chat_row_in_list(self, jid):
+        self.refreshed.append(jid)
+
+    def _schedule_set_chats(self):
+        self.list_refreshes += 1
+
+
+def test_failed_send_seen_restores_normal_chat_unread_state():
+    stub = _RollbackStub()
+
+    stub._restore_unread_after_send_seen_failure(JID, 3, 2000)
+
+    assert stub.chats[JID]["unreadCount"] == 3
+    assert JID not in stub._locally_read_at
+    assert stub.saved == [JID]
+
+
+def test_failed_send_seen_restores_archived_chat_unread_state():
+    stub = _RollbackStub(archived=True)
+
+    stub._restore_unread_after_send_seen_failure(JID, 3, 2000)
+
+    assert stub.chats[JID]["unreadCount"] == 3
+    assert stub.chats[JID]["archived"] is True
+
+
+def test_failed_send_seen_does_not_overwrite_a_new_message():
+    stub = _RollbackStub()
+    stub.chats[JID]["unreadCount"] = 1
+    stub.chats[JID]["t"] = 2001
+    stub._new_since_read[JID] = 1
+
+    stub._restore_unread_after_send_seen_failure(JID, 3, 2000)
+
+    assert stub.chats[JID]["unreadCount"] == 1
+    assert stub._locally_read_at[JID] == 2000


### PR DESCRIPTION
## Resumo
- aceita contadores remotos menores quando o snapshot é atual, incluindo leituras feitas no celular com o WinZapp fechado
- preserva mensagens ao vivo quando o snapshot remoto é mais antigo
- usa a conversa realmente aberta em vez do último JID aberto
- repete /send-seen e restaura o estado local se todas as tentativas falharem
- cobre conversas normais e arquivadas

## Testes
- 70 testes direcionados passaram
- 3257 testes passaram com test_api_patches_in_sync.py ignorado
- a suíte completa teve 3325 aprovações e 4 falhas apenas porque client/api/ local contém patches compilados da PR #101; a branch não altera a API e um checkout limpo pula esses espelhos ausentes