### PR TITLE
Fix memory leak in outgoing message tracking

### DIFF
--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -2227,7 +2227,7 @@ class ConversationsPanel(wx.Panel):
         reply — the quote never actually reached the recipient.
         """
         self._hide_media_transfer_gauge()
-        tracked = self._outgoing_virtual_messages.get(local_id)
+        tracked = self._outgoing_virtual_messages.pop(local_id, None)
         if tracked is not None:
             tracked["_local_pending"] = False
             if real_id and isinstance(real_id, str):
@@ -2319,6 +2319,7 @@ class ConversationsPanel(wx.Panel):
     def _mark_message_failed(self, local_id: str):
         """Mark a virtual pending message as permanently failed (exhausted retries)."""
         self._hide_media_transfer_gauge()
+        self._outgoing_virtual_messages.pop(local_id, None)
         for i, msg in enumerate(self._sorted_messages):
             if msg.get("_local_id") == local_id:
                 msg["_local_pending"] = False
@@ -2338,6 +2339,7 @@ class ConversationsPanel(wx.Panel):
         stops meaning anything.
         """
         self._hide_media_transfer_gauge()
+        self._outgoing_virtual_messages.pop(local_id, None)
         for i, msg in enumerate(self._sorted_messages):
             if msg.get("_local_id") == local_id:
                 msg["_local_pending"]     = False
@@ -9831,6 +9833,7 @@ class ConversationsPanel(wx.Panel):
             # dialog had selected, cancel the queued/in-flight upload and apply
             # a local deletion; asking the API for "everyone" here can only fail.
             self.main_window.message_queue.cancel(pending_local_id)
+            self._outgoing_virtual_messages.pop(pending_local_id, None)
             self._media_upload_progress.pop(pending_local_id, None)
             self._media_transfer_started.discard(pending_local_id)
             self._hide_media_transfer_gauge()

--- a/tests/test_outgoing_virtual_message_cleanup.py
+++ b/tests/test_outgoing_virtual_message_cleanup.py
@@ -1,0 +1,113 @@
+"""Tests for the _outgoing_virtual_messages memory leak fix.
+
+Reported live: WinZapp's memory usage kept growing the longer the app ran.
+ConversationsPanel._outgoing_virtual_messages indexes every outgoing virtual
+message by its local_id (added in _register_pending_message, right when the
+composer hands a new message to MessageQueue) so navigate_to_conversation()
+can restore a still-pending bubble when the user reopens a conversation
+before the DB has caught up. But nothing ever removed an entry once the
+message was resolved — sent, permanently failed, left unconfirmed after a
+timeout, or cancelled by the user while still in flight — so the dict grew
+by one entry, forever, for every single message ever sent in the process's
+lifetime.
+
+The lookup is only ever consulted for rows that are still `_local_pending`
+(see navigate_to_conversation()), and the WebSocket-echo reconciliation in
+MainWindow.on_new_message() matches pending sends by scanning
+_sorted_messages/records directly (by message type), never through this
+dict — so removing a resolved entry here cannot break either mechanism.
+
+Same test-stub approach as tests/test_quote_lost_drops_reply_header.py:
+ConversationsPanel is a wx.Panel and can't be instantiated without a running
+wx.App, so its methods are exercised via __new__() against a minimal stub.
+"""
+
+from ui.conversations import ConversationsPanel
+
+
+class _FakeList:
+    def SetItemText(self, index, text):
+        pass
+
+    def RefreshItem(self, index):
+        pass
+
+
+class _FakeMainWindow:
+    def _schedule_save(self, dirty_jid=None):
+        pass
+
+    def _schedule_set_chats(self):
+        pass
+
+
+def _make_panel(msg):
+    panel = ConversationsPanel.__new__(ConversationsPanel)
+    panel._sorted_messages = [msg]
+    panel._played_sent_local_ids = set()
+    panel._outgoing_virtual_messages = {"loc-1": msg}
+    panel._media_upload_progress = {}
+    panel._media_transfer_started = set()
+    panel._hide_media_transfer_gauge = lambda: None
+    panel.messages_list = _FakeList()
+    panel.conversation = {"remoteJid": "j@c.us"}
+    panel.main_window = _FakeMainWindow()
+    panel._render_message_line = lambda m, **kw: "RENDERED:" + str(m.get("_local_id"))
+    return panel
+
+
+def _make_msg(**overrides):
+    msg = {
+        "_local_id": "loc-1",
+        "_local_pending": True,
+        "key": {"id": "loc-1", "fromMe": True, "remoteJid": "j@c.us"},
+        "messageType": "conversation",
+        "message": {"conversation": "teste"},
+        "messageTimestamp": 1,
+        "pushName": "",
+    }
+    msg.update(overrides)
+    return msg
+
+
+class TestMarkMessageSentClearsTheIndex:
+    def test_pops_the_local_id_once_sent(self):
+        msg = _make_msg()
+        panel = _make_panel(msg)
+
+        ConversationsPanel._mark_message_sent(panel, "loc-1", real_id="REAL")
+
+        assert "loc-1" not in panel._outgoing_virtual_messages
+
+    def test_message_row_is_still_updated_in_place(self):
+        """The dict was only an index — the message dict itself must keep
+        living inside _sorted_messages exactly as before."""
+        msg = _make_msg()
+        panel = _make_panel(msg)
+
+        ConversationsPanel._mark_message_sent(panel, "loc-1", real_id="REAL")
+
+        assert msg["_local_pending"] is False
+        assert msg["key"]["id"] == "REAL"
+
+
+class TestMarkMessageFailedClearsTheIndex:
+    def test_pops_the_local_id_once_failed(self):
+        msg = _make_msg()
+        panel = _make_panel(msg)
+
+        ConversationsPanel._mark_message_failed(panel, "loc-1")
+
+        assert "loc-1" not in panel._outgoing_virtual_messages
+        assert msg["_send_failed"] is True
+
+
+class TestMarkMessageUnconfirmedClearsTheIndex:
+    def test_pops_the_local_id_once_unconfirmed(self):
+        msg = _make_msg()
+        panel = _make_panel(msg)
+
+        ConversationsPanel._mark_message_unconfirmed(panel, "loc-1")
+
+        assert "loc-1" not in panel._outgoing_virtual_messages
+        assert msg["_send_unconfirmed"] is True


### PR DESCRIPTION
## What was wrong

Every message you send from WinZapp gets tracked in a small internal dictionary while it's on its way out, so the app can find it again and update it once it's sent. Nobody ever removed it from that dictionary afterwards, though.

So the dictionary just kept growing, one entry per message, for as long as the app stayed open. It never came back down, no matter whether the window was active or just sitting in the background.

## What changed

I added a cleanup step at every point where a message's outcome becomes final: sent, permanently failed, left unconfirmed after a timeout, or cancelled by the user while it was still sending. The entry is removed from the dictionary right there.

The message itself doesn't change at all and still shows up in the chat exactly as before. Only the extra lookup entry gets cleared once it's no longer needed.

## Why this is safe

That dictionary exists for one reason: restoring a "still sending" bubble if you reopen a conversation before it's confirmed. Once a message is resolved, nothing ever reads it from there again, so removing it at that point can't break anything.

## Testing

I added a small test file covering all four cleanup points. I also ran the full test suite, and everything else still passes.
