### PR TITLE
Fix memory leak in document upload limit patch

### DIFF
--- a/client/core/wppconnect_sender_layer_patch.py
+++ b/client/core/wppconnect_sender_layer_patch.py
@@ -2,6 +2,26 @@
 compiled sender.layer.js — two independent fixes to sendFile(), applied
 together since they touch the same method:
 
+3. The MediaGatingUtils.getUploadLimit() override below used to run on
+   EVERY document send, unconditionally re-wrapping whatever function was
+   currently installed with a brand-new closure around it — with no check
+   for "already wrapped". mediaGating is WPP.whatsapp.MediaGatingUtils, a
+   singleton that lives for the whole WhatsApp Web page's lifetime (the
+   entire session, since the page is never reloaded on its own), so every
+   document a user sent added one more permanent link to a closure chain
+   nothing ever released: send 500 documents in one session and
+   getUploadLimit() is 500 closures deep, and none of it is reclaimed until
+   the page itself reloads. This is a real, unbounded, one-way memory leak
+   in the browser process for any WinZapp user who sends documents
+   regularly. Fixed by setting a one-time flag
+   (mediaGating.__winzappUploadLimitPatched) before wrapping, so the
+   override installs exactly once per page load no matter how many
+   documents follow — see the guard added to PATCHED_SEND_FILE and
+   _BROWSER_DOCUMENT_LIMIT_PATCH below, and LEGACY_PATCHED_SEND_FILE_V2 /
+   ALL_PATCHES for how an already-patched (leaking) install on an existing
+   user's machine gets migrated to the guarded version on the next
+   setup_api.py run / app update.
+
 1. sendFile() losing the real error when a send fails inside the browser
    page. Every video sent from WinZapp (message attachment AND status)
    used to fail with an opaque HTTP 500 whose logged "error" was just
@@ -227,6 +247,105 @@ PATCHED_SEND_FILE = (
     "                        const chunks = window.__winzappFileTransfers.get(id);\n"
     "                        const file = new File(chunks, options.filename || 'file', { type: mime });\n"
     "                        const mediaGating = WPP.whatsapp?.MediaGatingUtils;\n"
+    "                        if (options.type === 'document' && mediaGating?.getUploadLimit && !mediaGating.__winzappUploadLimitPatched) {\n"
+    "                            const getUploadLimit = mediaGating.getUploadLimit.bind(mediaGating);\n"
+    "                            mediaGating.getUploadLimit = (type, origin, isVcard) => type === 'document'\n"
+    "                                ? Math.max(getUploadLimit(type, origin, isVcard), 1 * 1024 * 1024 * 1024)\n"
+    "                                : getUploadLimit(type, origin, isVcard);\n"
+    "                            mediaGating.__winzappUploadLimitPatched = true;\n"
+    "                        }\n"
+    "                        const result = await WPP.chat.sendFileMessage(to, file, {\n"
+    "                            waitForAck: true,\n"
+    "                            ...options,\n"
+    "                        });\n"
+    "                        return { ack: result.ack, id: result.id };\n"
+    "                    }\n"
+    "                    catch (e) {\n"
+    "                        return {\n"
+    "                            __winzappSendFileError: true,\n"
+    "                            message: (e && e.message) || String(e),\n"
+    "                            name: (e && e.name) || 'Error',\n"
+    "                            stack: e && e.stack,\n"
+    "                        };\n"
+    "                    }\n"
+    "                }, { id: transferId, to, mime, options: options });\n"
+    "            }\n"
+    "            finally {\n"
+    "                await this.page.evaluate((id) => {\n"
+    "                    if (window.__winzappFileTransfers)\n"
+    "                        window.__winzappFileTransfers.delete(id);\n"
+    "                }, transferId).catch(() => undefined);\n"
+    "            }\n"
+    "        }\n"
+    "        else {\n"
+    "            sendResult = await (0, helpers_1.evaluateAndReturn)(this.page, async ({ to, base64, options }) => {\n"
+    "                try {\n"
+    "                    const mediaGating = WPP.whatsapp?.MediaGatingUtils;\n"
+    "                    if (options.type === 'document' && mediaGating?.getUploadLimit && !mediaGating.__winzappUploadLimitPatched) {\n"
+    "                        const getUploadLimit = mediaGating.getUploadLimit.bind(mediaGating);\n"
+    "                        mediaGating.getUploadLimit = (type, origin, isVcard) => type === 'document'\n"
+    "                            ? Math.max(getUploadLimit(type, origin, isVcard), 1 * 1024 * 1024 * 1024)\n"
+    "                            : getUploadLimit(type, origin, isVcard);\n"
+    "                        mediaGating.__winzappUploadLimitPatched = true;\n"
+    "                    }\n"
+    "                    const result = await WPP.chat.sendFileMessage(to, base64, {\n"
+    "                        waitForAck: true,\n"
+    "                        ...options,\n"
+    "                    });\n"
+    "                    return { ack: result.ack, id: result.id };\n"
+    "                }\n"
+    "                catch (e) {\n"
+    "                    return {\n"
+    "                        __winzappSendFileError: true,\n"
+    "                        message: (e && e.message) || String(e),\n"
+    "                        name: (e && e.name) || 'Error',\n"
+    "                        stack: e && e.stack,\n"
+    "                    };\n"
+    "                }\n"
+    "            }, { to, base64, options: options });\n"
+    "        }\n"
+    "        if (sendResult && sendResult.__winzappSendFileError) {\n"
+    "            const err = new Error(sendResult.message);\n"
+    "            err.name = sendResult.name;\n"
+    "            if (sendResult.stack)\n"
+    "                err.stack = sendResult.stack;\n"
+    "            throw err;\n"
+    "        }\n"
+    "        return sendResult;\n"
+)
+
+# The exact PATCHED_SEND_FILE text shipped before the
+# __winzappUploadLimitPatched guard existed — every install that already
+# ran setup_api.py/ApiSetupDialog against an earlier WinZapp build has
+# this verbatim text sitting in its node_modules right now, silently
+# leaking one closure per document sent. Kept only so ALL_PATCHES below
+# can find and migrate it forward; never touched otherwise.
+LEGACY_PATCHED_SEND_FILE_V2 = (
+    "        let sendResult;\n"
+    "        if (largeFilePath) {\n"
+    "            const transferId = `winzapp-${Date.now()}-${Math.random()}`;\n"
+    "            const mime = options.mimetype || 'application/octet-stream';\n"
+    "            await this.page.evaluate((id) => {\n"
+    "                window.__winzappFileTransfers = window.__winzappFileTransfers || new Map();\n"
+    "                window.__winzappFileTransfers.set(id, []);\n"
+    "            }, transferId);\n"
+    "            try {\n"
+    "                const stream = require('fs').createReadStream(largeFilePath, { highWaterMark: 3 * 1024 * 1024 });\n"
+    "                for await (const data of stream) {\n"
+    "                    const chunk = data.toString('base64');\n"
+    "                    await this.page.evaluate(({ id, chunk }) => {\n"
+    "                        const binary = atob(chunk);\n"
+    "                        const bytes = new Uint8Array(binary.length);\n"
+    "                        for (let i = 0; i < binary.length; i++)\n"
+    "                            bytes[i] = binary.charCodeAt(i);\n"
+    "                        window.__winzappFileTransfers.get(id).push(bytes);\n"
+    "                    }, { id: transferId, chunk });\n"
+    "                }\n"
+    "                sendResult = await (0, helpers_1.evaluateAndReturn)(this.page, async ({ id, to, mime, options }) => {\n"
+    "                    try {\n"
+    "                        const chunks = window.__winzappFileTransfers.get(id);\n"
+    "                        const file = new File(chunks, options.filename || 'file', { type: mime });\n"
+    "                        const mediaGating = WPP.whatsapp?.MediaGatingUtils;\n"
     "                        if (options.type === 'document' && mediaGating?.getUploadLimit) {\n"
     "                            const getUploadLimit = mediaGating.getUploadLimit.bind(mediaGating);\n"
     "                            mediaGating.getUploadLimit = (type, origin, isVcard) => type === 'document'\n"
@@ -297,16 +416,18 @@ ALL_PATCHES = (
     (PATCHED_FILE_LOADING_V1, PATCHED_FILE_LOADING),
     (ORIGINAL_SEND_FILE, PATCHED_SEND_FILE),
     (LEGACY_PATCHED_SEND_FILE, PATCHED_SEND_FILE),
+    (LEGACY_PATCHED_SEND_FILE_V2, PATCHED_SEND_FILE),
 )
 
 
 _BROWSER_DOCUMENT_LIMIT_PATCH = (
     "                    const mediaGating = WPP.whatsapp?.MediaGatingUtils;\n"
-    "                    if (options.type === 'document' && mediaGating?.getUploadLimit) {\n"
+    "                    if (options.type === 'document' && mediaGating?.getUploadLimit && !mediaGating.__winzappUploadLimitPatched) {\n"
     "                        const getUploadLimit = mediaGating.getUploadLimit.bind(mediaGating);\n"
     "                        mediaGating.getUploadLimit = (type, origin, isVcard) => type === 'document'\n"
     "                            ? Math.max(getUploadLimit(type, origin, isVcard), 1 * 1024 * 1024 * 1024)\n"
     "                            : getUploadLimit(type, origin, isVcard);\n"
+    "                        mediaGating.__winzappUploadLimitPatched = true;\n"
     "                    }\n"
 )
 

--- a/tests/test_large_file_patch.py
+++ b/tests/test_large_file_patch.py
@@ -44,20 +44,22 @@ def test_sender_patch_migrates_intermediate_chunked_source():
 def test_sender_patch_migrates_the_previous_chunked_patch_to_1gb():
     previous = sender_patch.PATCHED_SEND_FILE.replace(
         "                        const mediaGating = WPP.whatsapp?.MediaGatingUtils;\n"
-        "                        if (options.type === 'document' && mediaGating?.getUploadLimit) {\n"
+        "                        if (options.type === 'document' && mediaGating?.getUploadLimit && !mediaGating.__winzappUploadLimitPatched) {\n"
         "                            const getUploadLimit = mediaGating.getUploadLimit.bind(mediaGating);\n"
         "                            mediaGating.getUploadLimit = (type, origin, isVcard) => type === 'document'\n"
         "                                ? Math.max(getUploadLimit(type, origin, isVcard), 1 * 1024 * 1024 * 1024)\n"
         "                                : getUploadLimit(type, origin, isVcard);\n"
+        "                            mediaGating.__winzappUploadLimitPatched = true;\n"
         "                        }\n",
         "",
     ).replace(
         "                    const mediaGating = WPP.whatsapp?.MediaGatingUtils;\n"
-        "                    if (options.type === 'document' && mediaGating?.getUploadLimit) {\n"
+        "                    if (options.type === 'document' && mediaGating?.getUploadLimit && !mediaGating.__winzappUploadLimitPatched) {\n"
         "                        const getUploadLimit = mediaGating.getUploadLimit.bind(mediaGating);\n"
         "                        mediaGating.getUploadLimit = (type, origin, isVcard) => type === 'document'\n"
         "                            ? Math.max(getUploadLimit(type, origin, isVcard), 1 * 1024 * 1024 * 1024)\n"
         "                            : getUploadLimit(type, origin, isVcard);\n"
+        "                        mediaGating.__winzappUploadLimitPatched = true;\n"
         "                    }\n",
         "",
     )
@@ -66,6 +68,38 @@ def test_sender_patch_migrates_the_previous_chunked_patch_to_1gb():
 
     assert "WPP.whatsapp?.MediaGatingUtils" in migrated
     assert "1 * 1024 * 1024 * 1024" in migrated
+    assert "__winzappUploadLimitPatched" in migrated
+
+
+def test_sender_patch_migrates_the_leaking_unguarded_upload_limit_wrap():
+    """LEGACY_PATCHED_SEND_FILE_V2 is the exact text every existing install
+    already has on disk from before the __winzappUploadLimitPatched guard
+    existed. Without this migration, re-running setup_api.py on an
+    already-patched machine would leave the leak in place forever, since
+    none of the other ALL_PATCHES pairs match already-patched text."""
+    assert (
+        sender_patch.LEGACY_PATCHED_SEND_FILE_V2,
+        sender_patch.PATCHED_SEND_FILE,
+    ) in sender_patch.ALL_PATCHES
+    assert "__winzappUploadLimitPatched" not in sender_patch.LEGACY_PATCHED_SEND_FILE_V2
+
+    migrated = sender_patch.LEGACY_PATCHED_SEND_FILE_V2
+    for original, replacement in sender_patch.ALL_PATCHES:
+        migrated = migrated.replace(original, replacement)
+
+    assert migrated == sender_patch.PATCHED_SEND_FILE
+
+
+def test_sender_patch_guards_upload_limit_wrap_against_repeated_wrapping():
+    """The getUploadLimit() override must install at most once per page
+    load — re-wrapping it on every document send chains one more closure
+    onto a singleton (WPP.whatsapp.MediaGatingUtils) that lives for the
+    whole session, leaking memory in the browser process forever."""
+    patched = sender_patch.PATCHED_SEND_FILE
+
+    assert patched.count("__winzappUploadLimitPatched = true") == 2
+    assert patched.count("&& !mediaGating.__winzappUploadLimitPatched") == 2
+    assert "&& !mediaGating.__winzappUploadLimitPatched" in sender_patch._BROWSER_DOCUMENT_LIMIT_PATCH
 
 
 def test_large_documents_use_bounded_browser_transfers_and_a_1gb_browser_limit():


### PR DESCRIPTION
## What was wrong

WinZapp raises WhatsApp's own upload size limit for documents by wrapping one internal browser function with a small override. That override got reinstalled from scratch on every single document you sent, instead of just once.

The function it wraps lives on an object that stays alive for the whole session, so every document added one more layer on top of the last one. None of those layers ever went away, so a busy sitting of sending documents left a long chain of wrapped functions sitting in memory for nothing.

## What changed

I added a flag that gets set the first time the override installs. Every document after that just checks the flag and skips re-wrapping, since the
override is already there and still works fine.

Existing installs that already have the old, unguarded version sitting intheir node_modules get migrated to the fixed version automatically, the same way this file already handles older patch versions.

## Why this is safe

The override behaves exactly the same either way; it just doesn't get reapplied on top of itself anymore. The upload limit still gets raised for every document, from the very first one.

## Testing

I added tests covering the guard itself and the migration from the old unguarded version. I ran the related test files and the full suite, and everything passes except two pre-existing, unrelated clipboard test failures that also happen without this change.
