### PR TITLE
fix: support WAV uploads and harden WPP updates

### DIFF
--- a/client/core/audio_transcode.py
+++ b/client/core/audio_transcode.py
@@ -5,6 +5,7 @@ import mimetypes
 import os
 import subprocess
 import sys
+import tempfile
 
 
 def transcode_audio_to_wav(ffmpeg: str, source_path: str) -> str | None:
@@ -59,28 +60,53 @@ def transcode_audio_to_wav(ffmpeg: str, source_path: str) -> str | None:
 def prepare_audio_for_whatsapp(ffmpeg: str, source_path: str) -> tuple[str, str] | None:
     """Return a WhatsApp-compatible audio path and MIME type.
 
-    WhatsApp accepts OGG audio through sendFile only when its stream is Opus.
-    Generic ``.ogg`` files may contain Vorbis, which WPPConnect rejects with
-    ``InvalidMediaCheckRepairFailedType``. Existing OGG/Opus files pass through.
+    WhatsApp accepts OGG audio through sendFile only when its stream is Opus,
+    while WAV reaches its media worker but is rejected after upload. Generic
+    ``.ogg`` files may also contain Vorbis, which WPPConnect rejects with
+    ``InvalidMediaCheckRepairFailedType``. Convert only those incompatible
+    inputs; formats already handled by WhatsApp (MP3, M4A, FLAC, etc.) keep
+    passing through unchanged.
     """
     mime = mimetypes.guess_type(source_path)[0] or "application/octet-stream"
-    if os.path.splitext(source_path)[1].lower() != ".ogg":
+    extension = os.path.splitext(source_path)[1].lower()
+    if extension not in {".ogg", ".wav", ".wave"}:
         return source_path, mime
 
-    try:
-        with open(source_path, "rb") as source:
-            header = source.read(4096)
-    except OSError:
-        return None
-    if b"OpusHead" in header:
-        return source_path, "audio/ogg; codecs=opus"
+    if extension == ".ogg":
+        try:
+            with open(source_path, "rb") as source:
+                header = source.read(4096)
+        except OSError:
+            return None
+        if b"OpusHead" in header:
+            return source_path, "audio/ogg; codecs=opus"
     if not ffmpeg or not os.path.isfile(ffmpeg):
         return None
 
-    output_path = source_path + ".opus.ogg"
+    try:
+        output_fd, output_path = tempfile.mkstemp(
+            prefix=os.path.basename(source_path) + ".",
+            suffix=".whatsapp.opus.ogg",
+        )
+        os.close(output_fd)
+    except OSError:
+        logging.exception("[send_media] could not create temporary Opus file")
+        return None
+
     creationflags = 0
     if sys.platform == "win32" and hasattr(subprocess, "CREATE_NO_WINDOW"):
         creationflags = subprocess.CREATE_NO_WINDOW
+    try:
+        source_size = os.path.getsize(source_path)
+    except OSError:
+        source_size = 0
+    timeout = max(120, min(1800, source_size // (512 * 1024)))
+    logging.info(
+        "[send_media] converting %s audio to OGG/Opus with %s (temporary output: %s)",
+        extension or "unknown",
+        ffmpeg,
+        output_path,
+    )
     try:
         result = subprocess.run(
             [
@@ -88,7 +114,7 @@ def prepare_audio_for_whatsapp(ffmpeg: str, source_path: str) -> tuple[str, str]
                 "-c:a", "libopus", "-b:a", "64k", output_path,
             ],
             capture_output=True,
-            timeout=120,
+            timeout=timeout,
             creationflags=creationflags,
         )
         if (
@@ -98,12 +124,12 @@ def prepare_audio_for_whatsapp(ffmpeg: str, source_path: str) -> tuple[str, str]
         ):
             return output_path, "audio/ogg; codecs=opus"
         logging.error(
-            "[send_media] OGG/Vorbis to OGG/Opus conversion failed (rc=%s): %s",
+            "[send_media] audio conversion to OGG/Opus failed (rc=%s): %s",
             result.returncode,
             (result.stderr or b"").decode("utf-8", errors="replace")[-800:],
         )
     except Exception:
-        logging.exception("[send_media] OGG/Vorbis to OGG/Opus conversion failed")
+        logging.exception("[send_media] audio conversion to OGG/Opus failed")
     try:
         os.unlink(output_path)
     except OSError:

--- a/client/core/wppconnect_sender_layer_patch.py
+++ b/client/core/wppconnect_sender_layer_patch.py
@@ -1,5 +1,5 @@
 """Shared source-text constant for patching @wppconnect-team/wppconnect's
-compiled sender.layer.js — two independent fixes to sendFile(), applied
+compiled sender.layer.js — three independent fixes to sendFile(), applied
 together since they touch the same method:
 
 3. The MediaGatingUtils.getUploadLimit() override below used to run on
@@ -16,8 +16,8 @@ together since they touch the same method:
    regularly. Fixed by setting a one-time flag
    (mediaGating.__winzappUploadLimitPatched) before wrapping, so the
    override installs exactly once per page load no matter how many
-   documents follow — see the guard added to PATCHED_SEND_FILE and
-   _BROWSER_DOCUMENT_LIMIT_PATCH below, and LEGACY_PATCHED_SEND_FILE_V2 /
+   attachments follow — see the guard added to PATCHED_SEND_FILE and
+   _BROWSER_ATTACHMENT_LIMIT_PATCH below, and LEGACY_PATCHED_SEND_FILE_V2 /
    ALL_PATCHES for how an already-patched (leaking) install on an existing
    user's machine gets migrated to the guarded version on the next
    setup_api.py run / app update.
@@ -61,7 +61,7 @@ together since they touch the same method:
    'auto-detect') is what tells it that, identically on both paths — so
    PATCHED_FILE_LOADING widens the gate to image/video/audio too.
 
-3. Raising WhatsApp Web's own client-side document ceiling to 1 GB, by
+3. Raising WhatsApp Web's own client-side attachment ceiling to 1 GB, by
    wrapping MediaGatingUtils.getUploadLimit inside the page. This runs in a
    per-send callback, so it MUST install itself only once: the guard that
    decides whether to wrap cannot be "does getUploadLimit exist", because a
@@ -325,6 +325,12 @@ PATCHED_SEND_FILE = (
     "        return sendResult;\n"
 )
 
+# The exact document-only upload-limit patch shipped before the browser-side
+# limit override caught up with PATCHED_FILE_LOADING's image/video/audio
+# support.  Keep the whole previous method so patch_sender_layer_source() can
+# migrate an already-patched node_modules on the next app start/update.
+LEGACY_PATCHED_SEND_FILE_V3 = PATCHED_SEND_FILE
+
 # The exact PATCHED_SEND_FILE text shipped before the
 # __winzappUploadLimitPatched guard existed — every install that already
 # ran setup_api.py/ApiSetupDialog against an earlier WinZapp build has
@@ -422,15 +428,6 @@ LEGACY_PATCHED_SEND_FILE_V2 = (
     "        return sendResult;\n"
 )
 
-ALL_PATCHES = (
-    (ORIGINAL_FILE_LOADING, PATCHED_FILE_LOADING),
-    (PATCHED_FILE_LOADING_V1, PATCHED_FILE_LOADING),
-    (ORIGINAL_SEND_FILE, PATCHED_SEND_FILE),
-    (LEGACY_PATCHED_SEND_FILE, PATCHED_SEND_FILE),
-    (LEGACY_PATCHED_SEND_FILE_V2, PATCHED_SEND_FILE),
-)
-
-
 #: The same override as _BROWSER_DOCUMENT_LIMIT_PATCH below, but WITHOUT the
 #: one-time `__winzappUploadLimitPatched` guard — i.e. the leaking version that
 #: re-wrapped getUploadLimit() on every single document send. Kept only as the
@@ -468,9 +465,110 @@ _BROWSER_DOCUMENT_LIMIT_PATCH = (
 )
 
 
+_BROWSER_ATTACHMENT_LIMIT_PATCH_V1 = (
+    "                    const mediaGating = WPP.whatsapp?.MediaGatingUtils;\n"
+    "                    if (['document', 'image', 'video', 'audio'].includes(options.type) && mediaGating?.getUploadLimit && !mediaGating.__winzappUploadLimitPatched) {\n"
+    "                        const getUploadLimit = mediaGating.getUploadLimit.bind(mediaGating);\n"
+    "                        mediaGating.getUploadLimit = (type, origin, isVcard) => ['document', 'image', 'video', 'audio'].includes(type)\n"
+    "                            ? Math.max(getUploadLimit(type, origin, isVcard), 1 * 1024 * 1024 * 1024)\n"
+    "                            : getUploadLimit(type, origin, isVcard);\n"
+    "                        mediaGating.__winzappUploadLimitPatched = true;\n"
+    "                    }\n"
+)
+
+
+_BROWSER_ATTACHMENT_LIMIT_PATCH_V2 = (
+    _BROWSER_ATTACHMENT_LIMIT_PATCH_V1
+    + "                    const mediaPrep = WPP.whatsapp?.MediaPrep;\n"
+    + "                    if (mediaPrep?.prepRawMedia && !mediaPrep.__winzappAudioTypePatched) {\n"
+    + "                        const prepRawMedia = mediaPrep.prepRawMedia.bind(mediaPrep);\n"
+    + "                        mediaPrep.prepRawMedia = (opaqueData, prepOptions = {}) => {\n"
+    + "                            const opaqueType = typeof opaqueData?.type === 'function'\n"
+    + "                                ? opaqueData.type()\n"
+    + "                                : opaqueData?.type;\n"
+    + "                            return prepRawMedia(opaqueData, String(opaqueType || '').startsWith('audio/')\n"
+    + "                                ? { ...prepOptions, isAudio: true }\n"
+    + "                                : prepOptions);\n"
+    + "                        };\n"
+    + "                        mediaPrep.__winzappAudioTypePatched = true;\n"
+    + "                    }\n"
+)
+
+
+_BROWSER_ATTACHMENT_LIMIT_PATCH_WITH_WAV_BYPASS = (
+    _BROWSER_ATTACHMENT_LIMIT_PATCH_V2
+    + "                    const mediaWorker = WPP.loader?.loadModule?.('WAWebSendMessageToMediaWorker');\n"
+    + "                    if (mediaWorker?.sendMessageToMediaWorker && !mediaWorker.__winzappWavPassthroughPatched) {\n"
+    + "                        const sendMessageToMediaWorker = mediaWorker.sendMessageToMediaWorker.bind(mediaWorker);\n"
+    + "                        mediaWorker.sendMessageToMediaWorker = async (message) => {\n"
+    + "                            const response = await sendMessageToMediaWorker(message);\n"
+    + "                            const file = message?.file;\n"
+    + "                            const wavMimes = ['audio/wav', 'audio/x-wav', 'audio/wave', 'audio/vnd.wave'];\n"
+    + "                            if (message?.type !== 'prep' || !wavMimes.includes(file?.type)\n"
+    + "                                || response?.type !== 'parsingError'\n"
+    + "                                || String(response?.error) !== 'File format unsupported') {\n"
+    + "                                return response;\n"
+    + "                            }\n"
+    + "                            const header = new Uint8Array(await file.slice(0, 12).arrayBuffer());\n"
+    + "                            const ascii = (offset) => String.fromCharCode(...header.subarray(offset, offset + 4));\n"
+    + "                            const riff = ascii(0);\n"
+    + "                            if (!['RIFF', 'RIFX', 'RF64'].includes(riff) || ascii(8) !== 'WAVE') {\n"
+    + "                                return response;\n"
+    + "                            }\n"
+    + "                            return {\n"
+    + "                                type: 'result',\n"
+    + "                                result: { type: 'audio/wav', file, isGif: false },\n"
+    + "                            };\n"
+    + "                        };\n"
+    + "                        mediaWorker.__winzappWavPassthroughPatched = true;\n"
+    + "                    }\n"
+)
+
+# WAV cannot be made into a valid WhatsApp audio message by bypassing the
+# browser's media worker: the upload completes, but WhatsApp rejects the
+# resulting message with ACK -1. Keep the old block above only to migrate
+# already-patched installations back to the supported MediaPrep path. WAV is
+# now converted to OGG/Opus before sendFile() is called.
+_BROWSER_ATTACHMENT_LIMIT_PATCH = _BROWSER_ATTACHMENT_LIMIT_PATCH_V2
+
+
 def _deepen(block: str) -> str:
     """The same block one nesting level further in (the chunked branch)."""
     return block.replace("                    ", "                        ")
+
+
+# Exact method briefly shipped with the native-WAV media-worker bypass. It is
+# a migration input only; patch_sender_layer_source() removes that bypass.
+LEGACY_PATCHED_SEND_FILE_V4 = LEGACY_PATCHED_SEND_FILE_V3.replace(
+    _deepen(_BROWSER_DOCUMENT_LIMIT_PATCH),
+    _deepen(_BROWSER_ATTACHMENT_LIMIT_PATCH_WITH_WAV_BYPASS),
+).replace(
+    _BROWSER_DOCUMENT_LIMIT_PATCH,
+    _BROWSER_ATTACHMENT_LIMIT_PATCH_WITH_WAV_BYPASS,
+)
+
+
+# Build the current method from the last shipped version so the two copies of
+# the page-side override cannot drift apart.  The legacy snapshot above stays
+# byte-for-byte exact for migration of existing installations.
+PATCHED_SEND_FILE = LEGACY_PATCHED_SEND_FILE_V3.replace(
+    _deepen(_BROWSER_DOCUMENT_LIMIT_PATCH),
+    _deepen(_BROWSER_ATTACHMENT_LIMIT_PATCH),
+).replace(
+    _BROWSER_DOCUMENT_LIMIT_PATCH,
+    _BROWSER_ATTACHMENT_LIMIT_PATCH,
+)
+
+
+ALL_PATCHES = (
+    (ORIGINAL_FILE_LOADING, PATCHED_FILE_LOADING),
+    (PATCHED_FILE_LOADING_V1, PATCHED_FILE_LOADING),
+    (ORIGINAL_SEND_FILE, PATCHED_SEND_FILE),
+    (LEGACY_PATCHED_SEND_FILE, PATCHED_SEND_FILE),
+    (LEGACY_PATCHED_SEND_FILE_V2, PATCHED_SEND_FILE),
+    (LEGACY_PATCHED_SEND_FILE_V3, PATCHED_SEND_FILE),
+    (LEGACY_PATCHED_SEND_FILE_V4, PATCHED_SEND_FILE),
+)
 
 
 def patch_sender_layer_source(source: str) -> str:
@@ -478,23 +576,58 @@ def patch_sender_layer_source(source: str) -> str:
     for original, patched in ALL_PATCHES:
         source = source.replace(original, patched)
 
-    # Unmarked -> marked, at both nesting depths the block appears at.
+    # Remove the failed native-WAV experiment even when it appears inside a
+    # source version that does not match the whole-method legacy snapshot.
     source = source.replace(
-        _deepen(_LEGACY_DOCUMENT_LIMIT_PATCH), _deepen(_BROWSER_DOCUMENT_LIMIT_PATCH)
+        _deepen(_BROWSER_ATTACHMENT_LIMIT_PATCH_WITH_WAV_BYPASS),
+        _deepen(_BROWSER_ATTACHMENT_LIMIT_PATCH),
     )
     source = source.replace(
-        _LEGACY_DOCUMENT_LIMIT_PATCH, _BROWSER_DOCUMENT_LIMIT_PATCH
+        _BROWSER_ATTACHMENT_LIMIT_PATCH_WITH_WAV_BYPASS,
+        _BROWSER_ATTACHMENT_LIMIT_PATCH,
+    )
+
+    # Document-only -> every attachment type, including already-guarded
+    # installations, at both nesting depths the block appears at.
+    source = source.replace(
+        _deepen(_BROWSER_DOCUMENT_LIMIT_PATCH),
+        _deepen(_BROWSER_ATTACHMENT_LIMIT_PATCH),
+    )
+    source = source.replace(
+        _BROWSER_DOCUMENT_LIMIT_PATCH,
+        _BROWSER_ATTACHMENT_LIMIT_PATCH,
+    )
+    # Generic 1 GB override shipped before WAV was explicitly marked as audio.
+    # The v2 block deliberately contains v1 as its prefix, so only run this
+    # migration when its own marker is absent; otherwise replacing that prefix
+    # would append the MediaPrep wrapper a second time on every startup.
+    if "__winzappAudioTypePatched" not in source:
+        source = source.replace(
+            _deepen(_BROWSER_ATTACHMENT_LIMIT_PATCH_V1),
+            _deepen(_BROWSER_ATTACHMENT_LIMIT_PATCH),
+        )
+        source = source.replace(
+            _BROWSER_ATTACHMENT_LIMIT_PATCH_V1,
+            _BROWSER_ATTACHMENT_LIMIT_PATCH,
+        )
+
+    # Unmarked document-only -> current guarded attachment override.
+    source = source.replace(
+        _deepen(_LEGACY_DOCUMENT_LIMIT_PATCH), _deepen(_BROWSER_ATTACHMENT_LIMIT_PATCH)
+    )
+    source = source.replace(
+        _LEGACY_DOCUMENT_LIMIT_PATCH, _BROWSER_ATTACHMENT_LIMIT_PATCH
     )
 
     if "WPP.whatsapp?.MediaGatingUtils" not in source:
         source = source.replace(
             "                    const result = await WPP.chat.sendFileMessage(to, file, {\n",
-            _deepen(_BROWSER_DOCUMENT_LIMIT_PATCH)
+            _deepen(_BROWSER_ATTACHMENT_LIMIT_PATCH)
             + "                        const result = await WPP.chat.sendFileMessage(to, file, {\n",
         )
         source = source.replace(
             "                    const result = await WPP.chat.sendFileMessage(to, base64, {\n",
-            _BROWSER_DOCUMENT_LIMIT_PATCH
+            _BROWSER_ATTACHMENT_LIMIT_PATCH
             + "                    const result = await WPP.chat.sendFileMessage(to, base64, {\n",
         )
 

--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -146,7 +146,7 @@
     "save_as_nothing_to_save": "This message has no file to save",
     "save_as_nothing_to_save_bulk": "None of the selected messages has a file to save",
     "all_files": "All files",
-    "audio_convert_failed": "Failed to convert audio. FFmpeg is missing or unavailable on this system.",
+    "audio_convert_failed": "Could not convert the audio to a format accepted by WhatsApp.",
     "downloading_progress": "downloading, {pct}% done",
     "uploading_progress": "uploading, {pct}% done",
     "discard_voice_message": "Discard voice message",

--- a/client/languages/es-ES.json
+++ b/client/languages/es-ES.json
@@ -146,7 +146,7 @@
     "save_as_nothing_to_save": "Este mensaje no tiene ningún archivo que guardar",
     "save_as_nothing_to_save_bulk": "Ninguno de los mensajes seleccionados tiene un archivo que guardar",
     "all_files": "Todos los archivos",
-    "audio_convert_failed": "Error al convertir el audio. FFmpeg no está disponible en este sistema.",
+    "audio_convert_failed": "No se pudo convertir el audio a un formato aceptado por WhatsApp.",
     "downloading_progress": "descargando, {pct}% completado",
     "uploading_progress": "enviando, {pct}% completado",
     "discard_voice_message": "Descartar mensaje de voz",

--- a/client/languages/pl.json
+++ b/client/languages/pl.json
@@ -146,7 +146,7 @@
     "save_as_nothing_to_save": "Ta wiadomość nie ma pliku do zapisania",
     "save_as_nothing_to_save_bulk": "Żadna z zaznaczonych wiadomości nie ma pliku do zapisania",
     "all_files": "Wszystkie pliki",
-    "audio_convert_failed": "Nie udało się przekonwertować audio. Brak FFmpeg lub jest on niedostępny w tym systemie.",
+    "audio_convert_failed": "Nie udało się przekonwertować dźwięku do formatu akceptowanego przez WhatsApp.",
     "downloading_progress": "pobieranie, ukończono {pct}%",
     "uploading_progress": "wysyłanie, ukończono {pct}%",
     "discard_voice_message": "Odrzuć wiadomość głosową",

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -146,7 +146,7 @@
     "save_as_nothing_to_save": "Esta mensagem não tem arquivo para salvar",
     "save_as_nothing_to_save_bulk": "Nenhuma das mensagens selecionadas tem arquivo para salvar",
     "all_files": "Todos os arquivos",
-    "audio_convert_failed": "Falha ao converter áudio. FFmpeg ausente ou indisponível no sistema.",
+    "audio_convert_failed": "Não foi possível converter o áudio para um formato aceito pelo WhatsApp.",
     "downloading_progress": "baixando, {pct}% concluído",
     "uploading_progress": "enviando, {pct}% concluído",
     "discard_voice_message": "Descartar mensagem de voz",

--- a/client/languages/pt-PT.json
+++ b/client/languages/pt-PT.json
@@ -146,7 +146,7 @@
     "save_as_nothing_to_save": "Esta mensagem não tem ficheiro para guardar",
     "save_as_nothing_to_save_bulk": "Nenhuma das mensagens selecionadas tem ficheiro para guardar",
     "all_files": "Todos os ficheiros",
-    "audio_convert_failed": "Falha ao converter áudio. FFmpeg ausente ou indisponível no sistema.",
+    "audio_convert_failed": "Não foi possível converter o áudio para um formato aceite pelo WhatsApp.",
     "downloading_progress": "a descarregar, {pct}% concluído",
     "uploading_progress": "a enviar, {pct}% concluído",
     "discard_voice_message": "Descartar mensagem de voz",

--- a/client/main.py
+++ b/client/main.py
@@ -20064,6 +20064,11 @@ class MainWindow(wx.Frame):
         except Exception as exc:
             logging.error("[send_media] failed to stat file %s: %s", file_path, exc)
             return False
+        MAX_FILE_SIZE = 1 * 1024 * 1024 * 1024
+        if file_size > MAX_FILE_SIZE:
+            err_msg = f"File size ({file_size / (1024*1024):.1f} MB) exceeds the 1 GB WhatsApp attachment limit."
+            logging.error("[send_media] %s", err_msg)
+            return {"ok": False, "error": err_msg, "retry": False}
         mime = mimetypes.guess_type(file_path)[0] or "application/octet-stream"
         filename = os.path.basename(file_path)
         upload_path = file_path
@@ -20074,7 +20079,7 @@ class MainWindow(wx.Frame):
             if prepared is None:
                 return {
                     "ok": False,
-                    "error": "Não foi possível converter o áudio OGG para Opus.",
+                    "error": self.i18n.t("media_audio_convert_failed"),
                     "retry": False,
                 }
             upload_path, mime = prepared
@@ -20125,13 +20130,18 @@ class MainWindow(wx.Frame):
             quoted_id = self._serialize_quoted_id(quoted, fallback_jid=remote_jid)
             if quoted_id:
                 data["quotedMessageId"] = quoted_id
-        # WPPConnect accepts documents up to 1 GB. Its WinZapp patch moves large
-        # payloads into Chromium in bounded chunks instead of one oversized CDP
-        # argument. Non-document media remains capped by the UI at 70 MB.
-        MAX_FILE_SIZE = 1 * 1024 * 1024 * 1024
+        # WPPConnect accepts attachments up to 1 GB. Its WinZapp patch moves
+        # large payloads into Chromium in bounded chunks instead of one
+        # oversized CDP argument, for document/image/video/audio alike.
         if file_size > MAX_FILE_SIZE:
-            err_msg = f"File size ({file_size / (1024*1024):.1f} MB) exceeds the 1 GB WhatsApp document limit."
+            err_msg = f"File size ({file_size / (1024*1024):.1f} MB) exceeds the 1 GB WhatsApp attachment limit."
             logging.error("[send_media] %s", err_msg)
+            for converted_path in (converted_audio_path, converted_video_path):
+                if converted_path:
+                    try:
+                        os.unlink(converted_path)
+                    except OSError:
+                        pass
             return {"ok": False, "error": err_msg, "retry": False}
         timeout = max(120, file_size // (100 * 1024))
         timeout = min(timeout, 1800)
@@ -20186,6 +20196,21 @@ class MainWindow(wx.Frame):
                     resp = resp[0]
                 msg_id = ""
                 if isinstance(resp, dict):
+                    raw_ack = resp.get("ack")
+                    try:
+                        ack = int(raw_ack) if raw_ack is not None else None
+                    except (TypeError, ValueError):
+                        ack = None
+                    if ack is not None and ack < 0:
+                        logging.error(
+                            "[send_media] WhatsApp rejected %s after upload (ack=%s)",
+                            filename, raw_ack,
+                        )
+                        return {
+                            "ok": False,
+                            "error": self.i18n.t("media_unsupported_error"),
+                            "retry": False,
+                        }
                     msg_id = resp.get("id") or resp.get("key", {}).get("id") or ""
                     if isinstance(msg_id, dict):
                         msg_id = msg_id.get("_serialized", "")

--- a/client/ui/dialogs/api_setup.py
+++ b/client/ui/dialogs/api_setup.py
@@ -269,6 +269,7 @@ class ApiSetupDialog(wx.Dialog):
 
         self._proc        = None   # active npm subprocess (for kill on cancel)
         self._cancelled   = False
+        self._finished    = False  # exactly one of success/error/cancel may win
         self._forced_tag  = forced_tag   # overrides .env WPPCONNECT_TAG_VERSION
 
         # Progress-bar state — see _STAGES_FULL/_STAGES_MODULES_ONLY and
@@ -1196,15 +1197,61 @@ class ApiSetupDialog(wx.Dialog):
 
     # ── Event handlers ────────────────────────────────────────────────────────
 
+    def _is_modal_active(self) -> bool:
+        """Whether this dialog still owns a running modal event loop.
+
+        Worker completion is delivered through ``wx.CallAfter``. A cancel or
+        close event can end ``ShowModal()`` after the worker queues that
+        callback but before the callback runs. Calling ``EndModal()`` in that
+        state triggers wxWidgets' ``IsRunning()`` assertion, so every terminal
+        path checks the actual dialog state instead of trusting the worker's
+        earlier ``_cancelled`` snapshot.
+        """
+        try:
+            return bool(self.IsModal())
+        except RuntimeError:
+            # The native wx object is already being destroyed.
+            return False
+
+    def _end_modal_safely(self, result: int) -> bool:
+        """End the modal loop once, ignoring callbacks that arrived too late."""
+        if not self._is_modal_active():
+            logging.info(
+                "[api_setup] ignoring late dialog completion result=%s; modal loop is no longer running",
+                result,
+            )
+            return False
+        try:
+            self.EndModal(result)
+            return True
+        except (RuntimeError, AssertionError):
+            # Defensive second check: a nested native dialog (the success/error
+            # MessageBox) can pump pending wx events before control returns here.
+            logging.info(
+                "[api_setup] modal loop ended before completion result=%s could be applied",
+                result,
+                exc_info=True,
+            )
+            return False
+
     def _on_cancel(self, _event=None):
-        if self._cancelled:
+        if self._cancelled or self._finished:
             return
         self._cancelled = True
+        self._finished = True
         self._timer.Stop()
         self._kill_proc_tree()
-        self.EndModal(wx.ID_CANCEL)
+        self._end_modal_safely(wx.ID_CANCEL)
 
     def _finish_success(self):
+        if self._cancelled or self._finished:
+            logging.info("[api_setup] ignoring late/duplicate success callback")
+            return
+        if not self._is_modal_active():
+            logging.info("[api_setup] ignoring success callback after modal loop ended")
+            self._finished = True
+            return
+        self._finished = True
         self._timer.Stop()
         self._trickling = False
         self._gauge.SetValue(100)
@@ -1214,12 +1261,20 @@ class ApiSetupDialog(wx.Dialog):
             wx.OK | wx.ICON_INFORMATION,
             self,
         )
-        self.EndModal(wx.ID_OK)
+        self._end_modal_safely(wx.ID_OK)
 
     def _finish_error(self, details: str = ""):
+        if self._cancelled or self._finished:
+            logging.info("[api_setup] ignoring late/duplicate error callback")
+            return
+        if not self._is_modal_active():
+            logging.info("[api_setup] ignoring error callback after modal loop ended")
+            self._finished = True
+            return
+        self._finished = True
         self._timer.Stop()
         msg = self._i18n.t("api_setup_error_generic")
         if details:
             msg = f"{msg}\n\n{details}"
         wx.MessageBox(msg, self._i18n.t("api_setup_error_title"), wx.OK | wx.ICON_ERROR, self)
-        self.EndModal(wx.ID_CANCEL)
+        self._end_modal_safely(wx.ID_CANCEL)

--- a/tests/test_api_setup_modal_lifecycle.py
+++ b/tests/test_api_setup_modal_lifecycle.py
@@ -1,0 +1,122 @@
+"""Regression tests for late WPPConnect setup/update callbacks.
+
+The setup worker reports completion with wx.CallAfter. Cancellation can end
+ShowModal() after the worker queued success but before that callback executes;
+the old callback then called EndModal() on a stopped loop and raised wxWidgets'
+``IsRunning(): Use ScheduleExit() on not running loop`` assertion.
+"""
+
+import pytest
+
+wx = pytest.importorskip("wx")
+
+from ui.dialogs import api_setup
+
+
+class _Timer:
+    def __init__(self):
+        self.stop_calls = 0
+
+    def Stop(self):
+        self.stop_calls += 1
+
+
+class _Gauge:
+    def __init__(self):
+        self.values = []
+
+    def SetValue(self, value):
+        self.values.append(value)
+
+
+class _I18n:
+    def t(self, key):
+        return key
+
+
+class _DialogStub:
+    _is_modal_active = api_setup.ApiSetupDialog._is_modal_active
+    _end_modal_safely = api_setup.ApiSetupDialog._end_modal_safely
+    _on_cancel = api_setup.ApiSetupDialog._on_cancel
+    _finish_success = api_setup.ApiSetupDialog._finish_success
+    _finish_error = api_setup.ApiSetupDialog._finish_error
+
+    def __init__(self, modal=True):
+        self._modal = modal
+        self._cancelled = False
+        self._finished = False
+        self._trickling = True
+        self._timer = _Timer()
+        self._gauge = _Gauge()
+        self._i18n = _I18n()
+        self.end_results = []
+        self.kill_calls = 0
+
+    def IsModal(self):
+        return self._modal
+
+    def EndModal(self, result):
+        if not self._modal:
+            raise AssertionError("EndModal called without a running modal loop")
+        self.end_results.append(result)
+        self._modal = False
+
+    def _kill_proc_tree(self):
+        self.kill_calls += 1
+
+
+def test_normal_success_closes_the_running_modal_once(monkeypatch):
+    boxes = []
+    monkeypatch.setattr(api_setup.wx, "MessageBox", lambda *args: boxes.append(args))
+    dialog = _DialogStub()
+
+    dialog._finish_success()
+    dialog._finish_success()
+
+    assert dialog.end_results == [wx.ID_OK]
+    assert len(boxes) == 1
+    assert dialog._gauge.values == [100]
+    assert dialog._timer.stop_calls == 1
+
+
+def test_queued_success_after_cancel_is_ignored(monkeypatch):
+    boxes = []
+    monkeypatch.setattr(api_setup.wx, "MessageBox", lambda *args: boxes.append(args))
+    dialog = _DialogStub()
+
+    dialog._on_cancel()
+    dialog._finish_success()
+
+    assert dialog.end_results == [wx.ID_CANCEL]
+    assert dialog.kill_calls == 1
+    assert boxes == []
+
+
+@pytest.mark.parametrize("callback", ["_finish_success", "_finish_error"])
+def test_completion_after_modal_loop_already_ended_is_a_noop(monkeypatch, callback):
+    boxes = []
+    monkeypatch.setattr(api_setup.wx, "MessageBox", lambda *args: boxes.append(args))
+    dialog = _DialogStub(modal=False)
+
+    if callback == "_finish_error":
+        dialog._finish_error("details")
+    else:
+        dialog._finish_success()
+
+    assert dialog.end_results == []
+    assert boxes == []
+    assert dialog._finished is True
+
+
+def test_normal_error_closes_once_and_late_cancel_does_nothing(monkeypatch):
+    boxes = []
+    monkeypatch.setattr(api_setup.wx, "MessageBox", lambda *args: boxes.append(args))
+    dialog = _DialogStub()
+
+    dialog._finish_error("npm failed")
+    dialog._on_cancel()
+
+    assert dialog.end_results == [wx.ID_CANCEL]
+    assert len(boxes) == 1
+    assert "npm failed" in boxes[0][0]
+    assert dialog.kill_calls == 0

--- a/tests/test_large_file_patch.py
+++ b/tests/test_large_file_patch.py
@@ -43,24 +43,10 @@ def test_sender_patch_migrates_intermediate_chunked_source():
 
 def test_sender_patch_migrates_the_previous_chunked_patch_to_1gb():
     previous = sender_patch.PATCHED_SEND_FILE.replace(
-        "                        const mediaGating = WPP.whatsapp?.MediaGatingUtils;\n"
-        "                        if (options.type === 'document' && mediaGating?.getUploadLimit && !mediaGating.__winzappUploadLimitPatched) {\n"
-        "                            const getUploadLimit = mediaGating.getUploadLimit.bind(mediaGating);\n"
-        "                            mediaGating.getUploadLimit = (type, origin, isVcard) => type === 'document'\n"
-        "                                ? Math.max(getUploadLimit(type, origin, isVcard), 1 * 1024 * 1024 * 1024)\n"
-        "                                : getUploadLimit(type, origin, isVcard);\n"
-        "                            mediaGating.__winzappUploadLimitPatched = true;\n"
-        "                        }\n",
+        sender_patch._deepen(sender_patch._BROWSER_ATTACHMENT_LIMIT_PATCH),
         "",
     ).replace(
-        "                    const mediaGating = WPP.whatsapp?.MediaGatingUtils;\n"
-        "                    if (options.type === 'document' && mediaGating?.getUploadLimit && !mediaGating.__winzappUploadLimitPatched) {\n"
-        "                        const getUploadLimit = mediaGating.getUploadLimit.bind(mediaGating);\n"
-        "                        mediaGating.getUploadLimit = (type, origin, isVcard) => type === 'document'\n"
-        "                            ? Math.max(getUploadLimit(type, origin, isVcard), 1 * 1024 * 1024 * 1024)\n"
-        "                            : getUploadLimit(type, origin, isVcard);\n"
-        "                        mediaGating.__winzappUploadLimitPatched = true;\n"
-        "                    }\n",
+        sender_patch._BROWSER_ATTACHMENT_LIMIT_PATCH,
         "",
     )
 
@@ -99,7 +85,74 @@ def test_sender_patch_guards_upload_limit_wrap_against_repeated_wrapping():
 
     assert patched.count("__winzappUploadLimitPatched = true") == 2
     assert patched.count("&& !mediaGating.__winzappUploadLimitPatched") == 2
-    assert "&& !mediaGating.__winzappUploadLimitPatched" in sender_patch._BROWSER_DOCUMENT_LIMIT_PATCH
+    assert "&& !mediaGating.__winzappUploadLimitPatched" in sender_patch._BROWSER_ATTACHMENT_LIMIT_PATCH
+
+
+def test_sender_patch_migrates_the_guarded_document_only_limit():
+    """Existing installs already carry the guarded document-only wrapper.
+    Updating must widen that exact source instead of treating it as current."""
+    migrated = sender_patch.patch_sender_layer_source(
+        sender_patch.LEGACY_PATCHED_SEND_FILE_V3
+    )
+
+    assert migrated == sender_patch.PATCHED_SEND_FILE
+    assert sender_patch._BROWSER_DOCUMENT_LIMIT_PATCH not in migrated
+    assert sender_patch._BROWSER_ATTACHMENT_LIMIT_PATCH in migrated
+
+
+def test_browser_upload_limit_covers_every_supported_attachment_type():
+    """The bounded transfer already accepts every media kind; its page-side
+    size gate must not leave audio at WhatsApp Web's default 16 MB ceiling."""
+    block = sender_patch._BROWSER_ATTACHMENT_LIMIT_PATCH
+
+    for kind in ("document", "image", "video", "audio"):
+        assert f"'{kind}'" in block
+    assert "includes(options.type)" in block
+    assert "includes(type)" in block
+    assert "type === 'document'" not in sender_patch.PATCHED_SEND_FILE
+
+
+def test_browser_media_prep_explicitly_marks_audio_mime_as_audio():
+    """WA-JS exposes MediaPrep's isAudio option but sendFileMessage leaves it
+    unset. Converted OGG/Opus must not depend on container auto-detection to
+    reach the audio path."""
+    block = sender_patch._BROWSER_ATTACHMENT_LIMIT_PATCH
+
+    assert "WPP.whatsapp?.MediaPrep" in block
+    assert "startsWith('audio/')" in block
+    assert "{ ...prepOptions, isAudio: true }" in block
+    assert "!mediaPrep.__winzappAudioTypePatched" in block
+    assert "mediaPrep.__winzappAudioTypePatched = true" in block
+
+
+def test_sender_patch_migrates_limit_only_block_to_explicit_audio_type():
+    old = sender_patch.PATCHED_SEND_FILE.replace(
+        sender_patch._BROWSER_ATTACHMENT_LIMIT_PATCH,
+        sender_patch._BROWSER_ATTACHMENT_LIMIT_PATCH_V1,
+    ).replace(
+        sender_patch._deepen(sender_patch._BROWSER_ATTACHMENT_LIMIT_PATCH),
+        sender_patch._deepen(sender_patch._BROWSER_ATTACHMENT_LIMIT_PATCH_V1),
+    )
+
+    assert sender_patch.patch_sender_layer_source(old) == sender_patch.PATCHED_SEND_FILE
+
+
+def test_browser_patch_does_not_bypass_whatsapps_wav_validation():
+    """A native WAV upload reaches HTTP 201 but WhatsApp rejects the message
+    with ACK -1, so WAV compatibility belongs in the Python transcoder."""
+    block = sender_patch._BROWSER_ATTACHMENT_LIMIT_PATCH
+
+    assert "WAWebSendMessageToMediaWorker" not in block
+    assert "__winzappWavPassthroughPatched" not in block
+
+
+def test_sender_patch_removes_the_failed_native_wav_bypass():
+    migrated = sender_patch.patch_sender_layer_source(
+        sender_patch.LEGACY_PATCHED_SEND_FILE_V4
+    )
+
+    assert migrated == sender_patch.PATCHED_SEND_FILE
+    assert "__winzappWavPassthroughPatched" not in migrated
 
 
 def test_large_documents_use_bounded_browser_transfers_and_a_1gb_browser_limit():
@@ -201,7 +254,7 @@ class TestTheUploadLimitOverrideInstallsItselfOnlyOnce:
     def test_the_injected_block_carries_the_marker_too(self):
         """The block injected into a node_modules that predates the override
         entirely is a separate constant from the two inline copies."""
-        head = sender_patch._BROWSER_DOCUMENT_LIMIT_PATCH
+        head = sender_patch._BROWSER_ATTACHMENT_LIMIT_PATCH
         assert "!mediaGating.__winzappUploadLimitPatched" in head
         assert "mediaGating.__winzappUploadLimitPatched = true;" in head
 

--- a/tests/test_ogg_audio_upload.py
+++ b/tests/test_ogg_audio_upload.py
@@ -1,4 +1,4 @@
-"""Regression tests for WhatsApp-compatible OGG attachment preparation."""
+"""Regression tests for WhatsApp-compatible audio preparation."""
 
 import os
 from types import SimpleNamespace
@@ -42,3 +42,59 @@ def test_ogg_vorbis_without_ffmpeg_fails_instead_of_uploading_bad_codec(tmp_path
     source.write_bytes(b"OggS" + b"\x01vorbis" + b"audio")
 
     assert prepare_audio_for_whatsapp("", str(source)) is None
+
+
+def test_wav_is_transcoded_to_opus(tmp_path, monkeypatch):
+    ffmpeg = tmp_path / "ffmpeg"
+    ffmpeg.write_bytes(b"binary")
+    source = tmp_path / "large-audio.wav"
+    source_bytes = b"RIFF" + b"pcm-audio" * 100
+    source.write_bytes(source_bytes)
+
+    seen_command = []
+    temp_kwargs = {}
+
+    def fake_mkstemp(**kwargs):
+        temp_kwargs.update(kwargs)
+        output = tmp_path / "writable-system-temp.whatsapp.opus.ogg"
+        return os.open(output, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600), str(output)
+
+    def fake_run(command, **kwargs):
+        seen_command.extend(command)
+        with open(command[-1], "wb") as target:
+            target.write(b"OggS" + b"OpusHead" + b"converted")
+        return SimpleNamespace(returncode=0, stderr=b"")
+
+    monkeypatch.setattr("core.audio_transcode.tempfile.mkstemp", fake_mkstemp)
+    monkeypatch.setattr("core.audio_transcode.subprocess.run", fake_run)
+
+    output, mime = prepare_audio_for_whatsapp(str(ffmpeg), str(source))
+
+    assert output.endswith(".whatsapp.opus.ogg")
+    assert mime == "audio/ogg; codecs=opus"
+    assert "libopus" in seen_command
+    assert str(source) in seen_command
+    assert "dir" not in temp_kwargs
+    assert source.read_bytes() == source_bytes
+
+
+def test_wav_without_ffmpeg_fails_instead_of_uploading_native_wav(tmp_path):
+    source = tmp_path / "large-audio.wav"
+    source.write_bytes(b"RIFF" + b"pcm-audio")
+
+    assert prepare_audio_for_whatsapp("", str(source)) is None
+
+
+def test_other_supported_audio_formats_still_pass_through(tmp_path, monkeypatch):
+    source = tmp_path / "music.mp3"
+    source.write_bytes(b"mp3 audio")
+    monkeypatch.setattr(
+        "core.audio_transcode.subprocess.run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("MP3 must not be transcoded")
+        ),
+    )
+
+    assert prepare_audio_for_whatsapp("missing-ffmpeg", str(source)) == (
+        str(source), "audio/mpeg",
+    )

--- a/tests/test_send_media_unsupported_error.py
+++ b/tests/test_send_media_unsupported_error.py
@@ -28,6 +28,8 @@ from main import MainWindow
 class _FakeI18n:
     def t(self, key):
         return {
+            "audio_convert_failed": "Failed to convert audio.",
+            "media_audio_convert_failed": "Could not convert audio for WhatsApp.",
             "media_unsupported_error": "the file appears to be corrupted or in a format WhatsApp cannot process",
         }.get(key, key)
 
@@ -75,6 +77,35 @@ def media_file(tmp_path):
 
 
 class TestMediaUnsupportedErrorStopsRetrying:
+    def test_negative_ack_is_failure_even_when_upload_returned_http_201(
+        self, media_file, monkeypatch
+    ):
+        import main
+
+        monkeypatch.setattr(
+            main.requests,
+            "post",
+            lambda *a, **k: _FakeResponse(
+                201,
+                {
+                    "response": {
+                        "ack": -1,
+                        "id": "true_5511999999999@c.us_REJECTED123",
+                    }
+                },
+            ),
+        )
+
+        result = _Stub().send_media_attachment(
+            "5511999999999@s.whatsapp.net", media_file, "video"
+        )
+
+        assert result == {
+            "ok": False,
+            "error": "the file appears to be corrupted or in a format WhatsApp cannot process",
+            "retry": False,
+        }
+
     def test_media_unsupported_error_is_not_retried_and_has_a_clear_message(self, media_file, monkeypatch):
         import main
 
@@ -128,3 +159,69 @@ class TestMediaUnsupportedErrorStopsRetrying:
 
         assert result["ok"] is False
         assert result["retry"] is False
+
+
+class TestConvertedAudioLifecycle:
+    def test_successful_upload_removes_only_the_converted_temporary_file(
+        self, tmp_path, monkeypatch
+    ):
+        import main
+        import core.audio_transcode as audio_transcode
+
+        source = tmp_path / "vorbis.ogg"
+        source_bytes = b"OggS" + b"original vorbis audio"
+        source.write_bytes(source_bytes)
+        converted = tmp_path / "vorbis.ogg.opus.ogg"
+        converted.write_bytes(b"OggS" + b"OpusHead" + b"converted audio")
+
+        monkeypatch.setattr(
+            audio_transcode,
+            "prepare_audio_for_whatsapp",
+            lambda ffmpeg, path: (str(converted), "audio/ogg; codecs=opus"),
+        )
+        monkeypatch.setattr(
+            main.requests,
+            "post",
+            lambda *args, **kwargs: _FakeResponse(
+                201, {"response": {"id": "true_5511999999999@c.us_AUDIO123"}}
+            ),
+        )
+
+        result = _Stub().send_media_attachment(
+            "5511999999999@s.whatsapp.net", str(source), "audio"
+        )
+
+        assert result == "AUDIO123"
+        assert source.read_bytes() == source_bytes
+        assert not converted.exists()
+
+    def test_conversion_failure_uses_the_localized_error_and_never_uploads(
+        self, tmp_path, monkeypatch
+    ):
+        import main
+        import core.audio_transcode as audio_transcode
+
+        source = tmp_path / "invalid.ogg"
+        source.write_bytes(b"OggS")
+        monkeypatch.setattr(
+            audio_transcode,
+            "prepare_audio_for_whatsapp",
+            lambda ffmpeg, path: None,
+        )
+        monkeypatch.setattr(
+            main.requests,
+            "post",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("a failed conversion must not be uploaded")
+            ),
+        )
+
+        result = _Stub().send_media_attachment(
+            "5511999999999@s.whatsapp.net", str(source), "audio"
+        )
+
+        assert result == {
+            "ok": False,
+            "error": "Could not convert audio for WhatsApp.",
+            "retry": False,
+        }


### PR DESCRIPTION
## Resumo

- converte arquivos WAV/WAVE e OGG sem Opus para OGG/Opus usando o FFmpeg empacotado
- grava a conversão em um diretório temporário gravável, inclusive quando a origem está em um diretório somente leitura
- mantém MP3, M4A, FLAC e OGG/Opus sem conversão
- amplia para 1 GB o limite do navegador para todos os anexos e trata ACK negativo como falha
- torna sucesso, erro e cancelamento do diálogo de atualização idempotentes, evitando a assertion `IsRunning()` do wxWidgets
- migra instalações que receberam o bypass WAV nativo rejeitado pelo WhatsApp

## Validação

- 3.632 testes passaram; 3 foram pulados
- conversão real validada com o FFmpeg empacotado e um WAV localizado em diretório somente leitura
- branch atualizada sobre a main no commit `64f1a474`
