### PR TITLE
fix(sync): corrige estados e metadados entre dispositivos

### DIFF
--- a/client/api_patches/src/controller/deviceController.ts
+++ b/client/api_patches/src/controller/deviceController.ts
@@ -2917,6 +2917,9 @@ export async function sendMute(req: Request, res: Response) {
             return { wid: chatId, isMuted: false, expiration: 0 };
           }
           const result = await WPP.chat.mute(chatId, { duration });
+          if (!result?.isMuted) {
+            throw new Error('WhatsApp did not confirm the mute operation');
+          }
           // The Wid instance does not survive serialization to Node.
           return {
             wid: String(result?.wid?._serialized ?? chatId),
@@ -2972,36 +2975,36 @@ export async function sendSeen(req: Request, res: Response) {
       }
      }
    */
-  const { phone } = req.body;
+  const { phone, unread = false } = req.body;
   const session = req.session;
 
   try {
     const results: any = [];
     const phoneList = Array.isArray(phone) ? phone : [phone];
     for (const contato of phoneList) {
-      // req.client.sendSeen() → WPP.chat.markIsRead() calls
-      // assertGetChat(chatId) first, which throws "Chat not found" for any
-      // chat WA-JS's in-browser Store hasn't already loaded — unlike
-      // getMessages() above (which calls WPP.chat.find(chatId) before
-      // touching Store for exactly this reason), sendSeen never did, so a
-      // chat the user hadn't actually opened inside this Chrome session
-      // recently (e.g. WinZapp itself just synced it via the REST API,
-      // without WA-JS's own Store ever "finding" it) silently failed to be
-      // marked read — reported live as some conversations staying unread
-      // both in WinZapp and on the phone even right after opening them.
-      // WPP.chat.find() loads/registers the chat in Store first so the
-      // subsequent markIsRead() has something to resolve.
-      await req.client.page.evaluate(async (chatId: string) => {
-        try {
-          if ((window as any).WPP?.chat?.find) {
-            await (window as any).WPP.chat.find(chatId);
+      // Use WA-JS directly for both states. WPPConnect exposes sendSeen(), but
+      // has no matching mark-unread wrapper, and its return value can resolve
+      // without proving that the browser operation succeeded.
+      const changed = await req.client.page.evaluate(
+        async ({ chatId, markUnread }: { chatId: string; markUnread: boolean }) => {
+          const WPP = (window as any).WPP;
+          if (!WPP?.chat) throw new Error('WA-JS chat API is unavailable');
+          if (WPP.chat.find) await WPP.chat.find(chatId);
+          const operation = markUnread
+            ? WPP.chat.markIsUnread
+            : WPP.chat.markIsRead;
+          if (typeof operation !== 'function') {
+            throw new Error(
+              markUnread ? 'markIsUnread is unavailable' : 'markIsRead is unavailable'
+            );
           }
-        } catch (e) {
-          // Ignore — markIsRead below still tries, and surfaces its own
-          // "Chat not found" if this genuinely doesn't exist.
-        }
-      }, contato);
-      results.push(await req.client.sendSeen(contato));
+          const result = await operation(chatId);
+          if (!result) throw new Error('WhatsApp did not confirm the read-state change');
+          return true;
+        },
+        { chatId: contato, markUnread: Boolean(unread) }
+      );
+      results.push(changed);
     }
     returnSucess(res, session, phone, results);
   } catch (error) {

--- a/client/api_patches/src/controller/deviceController.ts
+++ b/client/api_patches/src/controller/deviceController.ts
@@ -2989,6 +2989,22 @@ export async function sendSeen(req: Request, res: Response) {
         async ({ chatId, markUnread }: { chatId: string; markUnread: boolean }) => {
           const WPP = (window as any).WPP;
           if (!WPP?.chat) throw new Error('WA-JS chat API is unavailable');
+          // find() registers the chat in WA-JS's in-browser Store so the
+          // markIs*() call below has something to resolve: assertGetChat()
+          // throws "Chat not found" for any chat the Store hasn't loaded, and
+          // WinZapp routinely syncs chats over REST that this Chrome session
+          // never opened (reported as conversations staying unread on both the
+          // app and the phone right after being opened).
+          //
+          // This used to be wrapped in a try/catch that swallowed find()
+          // failures and let markIsRead() surface its own error. It is now
+          // deliberately unguarded: the caller needs a definite success or
+          // failure to decide whether to roll the local unread state back
+          // (_sync_conversation_read_state in client/main.py), and a find()
+          // that failed makes the following call's outcome untrustworthy
+          // rather than merely uninformative. A genuine transient failure
+          // surfaces as a normal error and is retried from the Python side —
+          // 3 attempts across both JID aliases, see _sync_conversation_read_state.
           if (WPP.chat.find) await WPP.chat.find(chatId);
           const operation = markUnread
             ? WPP.chat.markIsUnread

--- a/client/api_patches/src/util/createSessionUtil.ts
+++ b/client/api_patches/src/util/createSessionUtil.ts
@@ -1465,6 +1465,38 @@ export default class CreateSessionUtil {
     await client.onAnyMessage(async (message: any) => {
       message.session = client.session;
 
+      if (message.type === 'gp2' && message.subtype === 'subject') {
+        const serialized = (value: any) =>
+          value?._serialized || value?.id?._serialized || value || '';
+        const candidates = [message.chatId, message.from, message.to].map(serialized);
+        const groupId = candidates.find(
+          (value: any) => typeof value === 'string' && value.endsWith('@g.us')
+        );
+        if (groupId) {
+          let subject = message.body || message.subject || message.value || '';
+          if (!subject) {
+            try {
+              const chat: any = await client.getChatById(groupId);
+              subject =
+                chat?.groupMetadata?.subject ||
+                chat?.name ||
+                chat?.formattedTitle ||
+                '';
+            } catch (e: any) {
+              req.logger.warn(
+                `[group-subject] Failed to resolve ${groupId}: ${e?.message || e}`
+              );
+            }
+          }
+          if (subject) {
+            req.io.emit('groups.update', {
+              data: [{ id: groupId, subject }],
+              session: client.session,
+            });
+          }
+        }
+      }
+
       if (message.type === 'sticker') {
         download(message, client, req.logger);
       }

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -858,12 +858,16 @@ class WebSocketClient:
             for update in updates:
                 if not isinstance(update, dict):
                     continue
-                jid = update.get("id", "")
-                subject = update.get("subject")
+                jid = self._clean_jid(update.get("id") or update.get("remoteJid") or "")
+                subject = update.get("subject") or update.get("name") or ""
 
-                if jid and subject is not None:
-                    remote_jid = self.main_window._normalize_jid(self._clean_jid(jid))
-                    wx.CallAfter(self.main_window.on_group_subject_updated, remote_jid, subject)
+                if jid.endswith("@g.us") and isinstance(subject, str) and subject.strip():
+                    remote_jid = self.main_window._normalize_jid(jid)
+                    wx.CallAfter(
+                        self.main_window.on_group_subject_updated,
+                        remote_jid,
+                        subject.strip(),
+                    )
         except Exception:
             logging.exception("[WebSocketClient] on_groups_update error")
 
@@ -920,6 +924,10 @@ class WebSocketClient:
                     continue
                 unread = chat_update.get("unreadCount")
                 if unread is not None:
+                    try:
+                        unread = int(unread)
+                    except (TypeError, ValueError):
+                        continue
                     # What the chat held before this change, when the page was
                     # able to tell us (see createSessionUtil.ts's
                     # onUnreadCountChanged). It is what separates "the user
@@ -931,6 +939,15 @@ class WebSocketClient:
                         previous = int(previous) if previous is not None else None
                     except (TypeError, ValueError):
                         previous = None
+                    # WhatsApp uses -1 as a sentinel for a chat manually
+                    # marked unread. Downstream code works with badge counts,
+                    # where that state is one unread item. Normalize both the
+                    # new and previous values so a subsequent -1 -> 0 is also
+                    # recognized as a confirmed remote read.
+                    if unread < 0:
+                        unread = 1
+                    if previous is not None and previous < 0:
+                        previous = 1
                     # Logged on arrival, before any of MainWindow's guards can
                     # discard it: this is the only place that can tell "WhatsApp
                     # Web never emitted the event" apart from "it arrived and
@@ -943,7 +960,7 @@ class WebSocketClient:
                     )
                     wx.CallAfter(
                         self.main_window.on_chat_unread_update,
-                        jid, int(unread), previous,
+                        jid, unread, previous,
                     )
                 
                 archive = chat_update.get("archive") if chat_update.get("archive") is not None else chat_update.get("archived")
@@ -1793,8 +1810,15 @@ class WebSocketClient:
                 or media_data.get("size") or media_data.get("fileLength")
                 or 0
             )
+            # Like image/video, WPPConnect exposes the real caption in the
+            # top-level caption field. `body` may be binary thumbnail data and
+            # must not be used as a fallback.
+            doc_caption = wpp_msg.get("caption", "") or ""
+            if looks_like_binary_blob(doc_caption):
+                doc_caption = ""
             message_content = {
                 "documentMessage": {
+                    "caption": doc_caption,
                     "fileName": doc_file_name,
                     "fileLength": doc_file_length,
                     "url": wpp_msg.get("clientUrl", ""),

--- a/client/main.py
+++ b/client/main.py
@@ -11700,6 +11700,23 @@ class MainWindow(wx.Frame):
 
     def on_group_subject_updated(self, remote_jid: str, new_subject: str) -> None:
         """Handle a live group subject update emitted from a gp2 notification."""
+        # See _live_events_ready() — this is the third live funnel, gated for
+        # the same reasons as on_new_message()/on_historical_message().
+        #
+        # It went ungated for as long as nothing emitted 'groups.update' at
+        # all, which this method used to document about itself.  The gap
+        # stopped being theoretical once createSessionUtil.ts started emitting
+        # the event for gp2/subject notifications, which is why the gate lands
+        # together with that.
+        #
+        # A rename dropped here is recovered by the same gp2 notification
+        # arriving again through history backfill (on_historical_message →
+        # _apply_group_subject_change), not by the sync: nothing re-fetches
+        # /group-info for a group that already has a name, and list-chats
+        # serialises WhatsApp Web's own store, which can still be holding the
+        # old subject (see _apply_group_subject_change's docstring).
+        if not self._live_events_ready():
+            return
         if remote_jid not in self.chats:
             return
 

--- a/client/main.py
+++ b/client/main.py
@@ -10956,13 +10956,17 @@ class MainWindow(wx.Frame):
                     jid = self._normalize_jid(raw_jid)
                     if "muteExpiration" in chat:
                         mute_expiry = chat["muteExpiration"]
+                        mute_jids = self._mute_state_jids(jid)
                         if mute_expiry == -1 or (isinstance(mute_expiry, (int, float)) and mute_expiry > now):
-                            if self._muted_chats.get(jid) != int(mute_expiry):
-                                self._muted_chats[jid] = int(mute_expiry)
-                                db_changed = True
-                        elif jid in self._muted_chats:
-                            del self._muted_chats[jid]
-                            db_changed = True
+                            for mute_jid in mute_jids:
+                                if self._muted_chats.get(mute_jid) != int(mute_expiry):
+                                    self._muted_chats[mute_jid] = int(mute_expiry)
+                                    db_changed = True
+                        else:
+                            for mute_jid in mute_jids:
+                                if mute_jid in self._muted_chats:
+                                    del self._muted_chats[mute_jid]
+                                    db_changed = True
 
                     # ── Archive state: two-way sync ──────────────────────────
                     # This used to be add-only (normalize_chats() could put a
@@ -11682,17 +11686,20 @@ class MainWindow(wx.Frame):
         if hasattr(self, "conversations_panel"):
             wx.CallAfter(self.conversations_panel.update_conversation_name, jid, new_name)
 
-    def on_group_subject_updated(self, remote_jid: str, new_subject: str) -> None:
-        """
-        Handle a live group subject update received via the groups.update websocket event.
+    def _reconcile_group_info_name(self, jid: str, info: dict) -> None:
+        """Feed an authoritative /group-info name back into the chat list."""
+        if not isinstance(info, dict):
+            return
+        new_name = (info.get("subject") or info.get("name") or "").strip()
+        chat = self.chats.get(jid)
+        if not new_name or chat is None or chat.get("name") == new_name:
+            return
+        self._store_group_subject(jid, chat, new_name)
+        self._schedule_save(dirty_jid=jid)
+        wx.CallAfter(self._schedule_set_chats)
 
-        Note this path currently never fires: the Node layer emits no
-        'groups.update' Socket.IO event at all (WebSocketClient registers the
-        handler, but nothing on the server side sends it), so a rename only
-        reaches Python as the gp2 notification handled by
-        _apply_group_subject_change(). Kept wired for when that event does get
-        emitted — the work it does is the same either way.
-        """
+    def on_group_subject_updated(self, remote_jid: str, new_subject: str) -> None:
+        """Handle a live group subject update emitted from a gp2 notification."""
         if remote_jid not in self.chats:
             return
 
@@ -18411,6 +18418,19 @@ class MainWindow(wx.Frame):
         if unread == 0 and not force:
             return
 
+        self._sync_conversation_read_state(
+            remote_jid,
+            unread=False,
+            on_failure=lambda: wx.CallAfter(
+                self._restore_unread_after_send_seen_failure,
+                remote_jid,
+                unread,
+                int(chat.get("t", 0) or 0),
+            ),
+        )
+
+    def _sync_conversation_read_state(self, remote_jid: str, unread: bool, on_failure):
+        """Apply a read-state change remotely, trying the known JID aliases."""
         # Prefer @lid JID for WPPConnect if mapped
         target_phone = remote_jid
         if not target_phone.endswith("@lid"):
@@ -18426,7 +18446,11 @@ class MainWindow(wx.Frame):
         def _send_seen(phone: str, is_lid: bool) -> "requests.Response | None":
             url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/send-seen"
             headers = {"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"}
-            payload = {"phone": phone, "isGroup": phone.endswith("@g.us")}
+            payload = {
+                "phone": phone,
+                "isGroup": phone.endswith("@g.us"),
+                "unread": unread,
+            }
             if is_lid:
                 payload["isLid"] = True
             return api_post(url, json=payload, headers=headers, timeout=10)
@@ -18461,11 +18485,18 @@ class MainWindow(wx.Frame):
                             )
                             continue
                         if resp.ok:
-                            success = True
-                            return
+                            try:
+                                results = resp.json().get("response", {}).get("data")
+                            except (AttributeError, TypeError, ValueError):
+                                results = None
+                            if isinstance(results, list) and results and all(
+                                result is True for result in results
+                            ):
+                                success = True
+                                return
                         logging.warning(
-                            "[mark_as_read] API response %s for %s (attempt %s): %s",
-                            resp.status_code, phone, attempt + 1, resp.text[:200],
+                            "[read_state] API response %s for %s (unread=%s, attempt %s): %s",
+                            resp.status_code, phone, unread, attempt + 1, resp.text[:200],
                         )
                     if attempt < 2:
                         time.sleep(attempt + 1)
@@ -18473,12 +18504,7 @@ class MainWindow(wx.Frame):
                 logging.exception("[mark_as_read] Unexpected send-seen failure")
             finally:
                 if not success:
-                    wx.CallAfter(
-                        self._restore_unread_after_send_seen_failure,
-                        remote_jid,
-                        unread,
-                        int(chat.get("t", 0) or 0),
-                    )
+                    on_failure()
         threading.Thread(target=_do_api, daemon=True).start()
 
     def _restore_unread_after_send_seen_failure(
@@ -18513,9 +18539,42 @@ class MainWindow(wx.Frame):
     def mark_conversation_as_unread(self, remote_jid: str):
         chat = self.chats.get(remote_jid)
         if chat is not None:
+            previous_unread = int(chat.get("unreadCount") or 0)
+            timestamp = int(chat.get("t", 0) or 0)
             chat["unreadCount"] = 1
-            self._schedule_save()
+            if hasattr(self, "_locally_read_at"):
+                self._locally_read_at.pop(remote_jid, None)
+                self._persist_locally_read_at()
+            if hasattr(self, "_new_since_read"):
+                self._new_since_read.pop(remote_jid, None)
+            self._schedule_save(dirty_jid=remote_jid)
             wx.CallAfter(self.set_chats)
+            self._sync_conversation_read_state(
+                remote_jid,
+                unread=True,
+                on_failure=lambda: wx.CallAfter(
+                    self._restore_unread_after_mark_unread_failure,
+                    remote_jid,
+                    previous_unread,
+                    timestamp,
+                ),
+            )
+
+    def _restore_unread_after_mark_unread_failure(
+        self, remote_jid: str, previous_unread: int, timestamp: int
+    ):
+        """Undo an optimistic mark-unread if no newer state replaced it."""
+        chat = self.chats.get(remote_jid)
+        if (
+            chat is None
+            or int(chat.get("t", 0) or 0) != timestamp
+            or int(chat.get("unreadCount") or 0) != 1
+        ):
+            return
+        chat["unreadCount"] = max(0, previous_unread)
+        self._schedule_save(dirty_jid=remote_jid)
+        self._refresh_chat_row_in_list(remote_jid)
+        self._schedule_set_chats()
 
     # ── WPPConnect — profile / group info ─────────────────────────────────
     
@@ -19127,7 +19186,10 @@ class MainWindow(wx.Frame):
                 res_data = r.json() or {}
                 response = res_data.get("response") or {}
                 logging.info(f"[get_group_info] response type={type(response).__name__} keys={list(response.keys()) if isinstance(response, dict) else response}")
-                return response if isinstance(response, dict) else {}
+                if isinstance(response, dict):
+                    self._reconcile_group_info_name(jid, response)
+                    return response
+                return {}
         except Exception as e:
             logging.error(f"[get_group_info] error: {e}")
         return {}
@@ -19272,23 +19334,35 @@ class MainWindow(wx.Frame):
 
     # ── Mute ──────────────────────────────────────────────────────────────────
 
+    def _mute_state_jids(self, jid: str) -> set[str]:
+        """Return the canonical chat JID and any known phone/LID alias."""
+        normalized = self._normalize_jid(jid)
+        jids = {normalized}
+        if normalized.endswith("@lid"):
+            alternate = getattr(self, "_lid_to_phone", {}).get(normalized, "")
+        else:
+            alternate = getattr(self, "_phone_to_lid", {}).get(normalized, "")
+        if alternate:
+            jids.add(self._normalize_jid(alternate))
+        return jids
+
     def is_chat_muted(self, jid: str) -> bool:
-        expiry = self._muted_chats.get(jid)
-        if expiry is None:
-            return False
-        if expiry == -1:
-            return True  # permanent
-        return time.time() < expiry
+        for mute_jid in self._mute_state_jids(jid):
+            expiry = self._muted_chats.get(mute_jid)
+            if expiry == -1 or (expiry is not None and time.time() < expiry):
+                return True
+        return False
 
     def _apply_mute_state(self, jid: str, expiry):
         """Local-only half of mute/unmute: mutate _muted_chats, persist to
         DB metadata, and refresh the chat list. Split out from
         mute_chat()/unmute_chat() so _sync_mute_to_server() can call this
         again to roll back the optimistic change if WhatsApp rejects it."""
-        if expiry is None:
-            self._muted_chats.pop(jid, None)
-        else:
-            self._muted_chats[jid] = expiry
+        for mute_jid in self._mute_state_jids(jid):
+            if expiry is None:
+                self._muted_chats.pop(mute_jid, None)
+            else:
+                self._muted_chats[mute_jid] = expiry
         if hasattr(self, "db") and self.db is not None:
             self.db.set_metadata_json("muted_chats", self._muted_chats)
         self._schedule_set_chats()
@@ -19341,9 +19415,18 @@ class MainWindow(wx.Frame):
                     return api_post(url, json=payload, headers=headers, timeout=10)
 
                 def _accepted(resp) -> bool:
-                    return mute_response_accepted(
+                    accepted = mute_response_accepted(
                         bool(resp.ok), resp.text, duration_secs == 0
                     )
+                    if not accepted or not resp.ok:
+                        return accepted
+                    try:
+                        result = resp.json().get("response", {})
+                    except (AttributeError, TypeError, ValueError):
+                        return accepted
+                    if isinstance(result, dict) and "isMuted" in result:
+                        return bool(result["isMuted"]) is (duration_secs != 0)
+                    return accepted
 
                 # Prefer the @lid form when one is known — same preference
                 # delete_message_for_everyone()/forward_message() already

--- a/tests/test_get_remote_chats_persistence.py
+++ b/tests/test_get_remote_chats_persistence.py
@@ -46,6 +46,8 @@ class _DB:
 class _Stub:
     """Minimum surface get_remote_chats() actually reads on the happy path."""
 
+    _mute_state_jids = MainWindow._mute_state_jids
+
     def __init__(self, chats=None):
         self.wpp_server = "http://127.0.0.1"
         self.wpp_port = 6300

--- a/tests/test_group_rename.py
+++ b/tests/test_group_rename.py
@@ -27,18 +27,22 @@ import threading
 import pytest
 
 from main import MainWindow
+from core.websocket_client import WebSocketClient
 
 
 class _MainWindowStub:
     _apply_group_subject_change = MainWindow._apply_group_subject_change
     _resolve_subject_change_async = MainWindow._resolve_subject_change_async
     _store_group_subject = MainWindow._store_group_subject
+    on_group_subject_updated = MainWindow.on_group_subject_updated
+    _reconcile_group_info_name = MainWindow._reconcile_group_info_name
 
     def __init__(self, group_info_name=""):
         self._group_info_name = group_info_name
         self.group_info_calls = []
         self.saved = []
         self.set_chats_calls = 0
+        self.chats = {}
 
     # Collaborators the methods under test reach for.
     def _fill_group_name(self, jid):
@@ -204,3 +208,81 @@ class TestNotificationWithoutTheNewName:
 
         assert mw.group_info_calls == []
         assert chat["name"] == "Grupo Novo"
+
+
+def test_groups_update_renames_and_persists_the_known_group():
+    mw = _MainWindowStub()
+    chat = {"remoteJid": "123@g.us", "name": "Grupo Antigo"}
+    mw.chats["123@g.us"] = chat
+
+    mw.on_group_subject_updated("123@g.us", "Grupo Novo")
+
+    assert chat["name"] == "Grupo Novo"
+    assert mw.saved == ["123@g.us"]
+    assert mw.set_chats_calls == 1
+
+
+def test_group_info_name_is_fed_back_into_the_conversation_list(monkeypatch):
+    import main as main_module
+
+    monkeypatch.setattr(main_module.wx, "CallAfter", lambda fn, *args: fn(*args))
+    mw = _MainWindowStub()
+    chat = {"remoteJid": "123@g.us", "name": "Grupo Antigo"}
+    mw.chats["123@g.us"] = chat
+
+    mw._reconcile_group_info_name(
+        "123@g.us", {"subject": "Grupo Novo", "name": "Grupo Antigo"}
+    )
+
+    assert chat["name"] == "Grupo Novo"
+    assert mw._group_name_cache["123@g.us"] == "Grupo Novo"
+    assert mw.saved == ["123@g.us"]
+    assert mw.set_chats_calls == 1
+
+
+class _GroupUpdateMain:
+    _normalize_jid = staticmethod(MainWindow._normalize_jid)
+
+    def __init__(self):
+        self.updates = []
+
+    def on_group_subject_updated(self, jid, subject):
+        self.updates.append((jid, subject))
+
+
+class _WebSocketStub:
+    on_groups_update = WebSocketClient.on_groups_update
+    _belongs_to_this_session = WebSocketClient._belongs_to_this_session
+    _clean_jid = WebSocketClient._clean_jid
+
+    def __init__(self):
+        self.instance_name = "session"
+        self.main_window = _GroupUpdateMain()
+
+
+def test_groups_update_accepts_wid_ids_and_trims_the_subject(monkeypatch):
+    import core.websocket_client as websocket_module
+
+    monkeypatch.setattr(websocket_module.wx, "CallAfter", lambda fn, *args: fn(*args))
+    ws = _WebSocketStub()
+
+    ws.on_groups_update({
+        "session": "session",
+        "data": [{
+            "id": {"_serialized": "123@g.us"},
+            "subject": "  Grupo Novo  ",
+        }],
+    })
+
+    assert ws.main_window.updates == [("123@g.us", "Grupo Novo")]
+
+
+def test_node_emits_group_updates_from_subject_notifications():
+    source = (
+        __import__("pathlib").Path(__file__).parents[1]
+        / "client/api_patches/src/util/createSessionUtil.ts"
+    ).read_text(encoding="utf-8")
+
+    assert "message.type === 'gp2' && message.subtype === 'subject'" in source
+    assert "req.io.emit('groups.update'" in source
+    assert "await client.getChatById(groupId)" in source

--- a/tests/test_group_rename.py
+++ b/tests/test_group_rename.py
@@ -36,13 +36,23 @@ class _MainWindowStub:
     _store_group_subject = MainWindow._store_group_subject
     on_group_subject_updated = MainWindow.on_group_subject_updated
     _reconcile_group_info_name = MainWindow._reconcile_group_info_name
+    # The real gate, not a stand-in: on_group_subject_updated is a live-event
+    # funnel and the tests below assert it drops events the same way
+    # on_new_message does.  See tests/test_live_event_gate.py for the gate itself.
+    _live_events_ready = MainWindow._live_events_ready
 
-    def __init__(self, group_info_name=""):
+    def __init__(self, group_info_name="", live_events_ready=True):
         self._group_info_name = group_info_name
         self.group_info_calls = []
         self.saved = []
         self.set_chats_calls = 0
         self.chats = {}
+        # Default to "sync has started" so the tests that are about renaming
+        # don't all have to spell the gate's preconditions out.
+        self._ui_ready_event = threading.Event()
+        if live_events_ready:
+            self._ui_ready_event.set()
+        self._sync_ever_started = live_events_ready
 
     # Collaborators the methods under test reach for.
     def _fill_group_name(self, jid):
@@ -220,6 +230,61 @@ def test_groups_update_renames_and_persists_the_known_group():
     assert chat["name"] == "Grupo Novo"
     assert mw.saved == ["123@g.us"]
     assert mw.set_chats_calls == 1
+
+
+class TestTheRenameFunnelIsGatedLikeTheOtherTwo:
+    """on_group_subject_updated mutates self.chats and persists, so it needs
+    _live_events_ready() exactly like on_new_message/on_historical_message.
+
+    It went ungated for as long as nothing emitted 'groups.update' — the method
+    was documented as never firing.  Once createSessionUtil.ts began emitting
+    the event for gp2/subject notifications, a rename delivered over a reused
+    pairing socket could land before the sync that fetches the authoritative
+    name, renaming and persisting a chat that still held only its on-disk state.
+    """
+
+    def test_a_rename_arriving_before_any_sync_started_is_dropped(self):
+        mw = _MainWindowStub(live_events_ready=False)
+        chat = {"remoteJid": "123@g.us", "name": "Grupo Antigo"}
+        mw.chats["123@g.us"] = chat
+
+        mw.on_group_subject_updated("123@g.us", "Grupo Novo")
+
+        assert chat["name"] == "Grupo Antigo"
+        assert mw.saved == []
+        assert mw.set_chats_calls == 0
+
+    def test_a_rename_arriving_before_the_ui_exists_is_dropped(self):
+        mw = _MainWindowStub()
+        mw._ui_ready_event.clear()
+        chat = {"remoteJid": "123@g.us", "name": "Grupo Antigo"}
+        mw.chats["123@g.us"] = chat
+
+        mw.on_group_subject_updated("123@g.us", "Grupo Novo")
+
+        assert chat["name"] == "Grupo Antigo"
+        assert mw.saved == []
+        assert mw.set_chats_calls == 0
+
+    def test_the_gate_is_checked_before_self_chats_is_touched(self):
+        """The crash guard half: a socket reused from pairing can deliver this
+        before prepare_sync() has built self.chats at all, and `remote_jid not
+        in self.chats` would raise AttributeError rather than drop the event."""
+        mw = _MainWindowStub(live_events_ready=False)
+        del mw.chats
+
+        mw.on_group_subject_updated("123@g.us", "Grupo Novo")  # must not raise
+
+    def test_a_rename_once_the_sync_is_under_way_still_applies(self):
+        """The gate must not close the case it was never about."""
+        mw = _MainWindowStub()
+        chat = {"remoteJid": "123@g.us", "name": "Grupo Antigo"}
+        mw.chats["123@g.us"] = chat
+
+        mw.on_group_subject_updated("123@g.us", "Grupo Novo")
+
+        assert chat["name"] == "Grupo Novo"
+        assert mw.saved == ["123@g.us"]
 
 
 def test_group_info_name_is_fed_back_into_the_conversation_list(monkeypatch):

--- a/tests/test_locally_read_at_persisted.py
+++ b/tests/test_locally_read_at_persisted.py
@@ -56,6 +56,7 @@ class _FakeDB:
 
 class _Stub:
     mark_conversation_as_read = MainWindow.mark_conversation_as_read
+    _sync_conversation_read_state = MainWindow._sync_conversation_read_state
     _persist_locally_read_at = MainWindow._persist_locally_read_at
     _normalize_jid = staticmethod(MainWindow._normalize_jid)
     # on_chat_unread_update looks the chat up through this rather than

--- a/tests/test_mute.py
+++ b/tests/test_mute.py
@@ -24,6 +24,7 @@ both build it from ConversationsPanel.MUTE_PRESETS.
 import pytest
 
 from core.utils import mute_response_accepted
+from main import MainWindow
 from ui.conversations import ConversationsPanel
 
 # The exact body observed in the field, trimmed to what matters.
@@ -94,3 +95,61 @@ class TestMutePresets:
             for key, _ in ConversationsPanel.MUTE_PRESETS:
                 assert strings.get(key), f"{locale} is missing {key}"
             assert strings.get("mute_chat_menu_title"), locale
+
+
+class _MuteAliasStub:
+    _normalize_jid = staticmethod(MainWindow._normalize_jid)
+    _mute_state_jids = MainWindow._mute_state_jids
+    _apply_mute_state = MainWindow._apply_mute_state
+    is_chat_muted = MainWindow.is_chat_muted
+
+    def __init__(self):
+        self._muted_chats = {}
+        self._phone_to_lid = {
+            "5511999999999@s.whatsapp.net": "123456789@lid",
+        }
+        self._lid_to_phone = {
+            "123456789@lid": "5511999999999@s.whatsapp.net",
+        }
+        self.db = None
+        self.refreshes = 0
+
+    def _schedule_set_chats(self):
+        self.refreshes += 1
+
+
+def test_mute_state_is_shared_between_phone_and_lid_aliases():
+    stub = _MuteAliasStub()
+
+    stub._apply_mute_state("5511999999999@s.whatsapp.net", -1)
+
+    assert stub.is_chat_muted("5511999999999@s.whatsapp.net")
+    assert stub.is_chat_muted("123456789@lid")
+    assert set(stub._muted_chats) == {
+        "5511999999999@s.whatsapp.net",
+        "123456789@lid",
+    }
+
+
+def test_unmute_removes_both_phone_and_lid_aliases():
+    stub = _MuteAliasStub()
+    stub._muted_chats = {
+        "5511999999999@s.whatsapp.net": -1,
+        "123456789@lid": -1,
+    }
+
+    stub._apply_mute_state("123456789@lid", None)
+
+    assert stub._muted_chats == {}
+
+
+def test_node_controller_requires_whatsapp_to_confirm_the_mute():
+    source = (
+        __import__("pathlib").Path(__file__).parents[1]
+        / "client/api_patches/src/controller/deviceController.ts"
+    ).read_text(encoding="utf-8")
+    send_mute = source[source.index("export async function sendMute"):source.index("export async function sendSeen")]
+
+    assert "WPP.chat.mute(chatId, { duration })" in send_mute
+    assert "WPP.chat.unmute(chatId)" in send_mute
+    assert "if (!result?.isMuted)" in send_mute

--- a/tests/test_normalize_document_forward.py
+++ b/tests/test_normalize_document_forward.py
@@ -101,3 +101,31 @@ class TestDocumentNormalization:
         doc = result["message"]["documentMessage"]
         assert doc["fileName"] == "Document"
         assert doc["fileLength"] == 0
+
+    def test_plain_text_caption_is_preserved_for_the_recipient(self):
+        stub = _Stub()
+
+        result = stub._normalize_wpp_message(
+            _base_msg(filename="report.pdf", caption="Relatório mensal")
+        )
+
+        assert result["message"]["documentMessage"]["caption"] == "Relatório mensal"
+
+    def test_link_caption_is_preserved_as_ordinary_caption_text(self):
+        stub = _Stub()
+        caption = "Confira em https://example.com/documento"
+
+        result = stub._normalize_wpp_message(
+            _base_msg(filename="report.pdf", caption=caption)
+        )
+
+        assert result["message"]["documentMessage"]["caption"] == caption
+
+    def test_document_body_is_not_mistaken_for_a_caption(self):
+        stub = _Stub()
+
+        result = stub._normalize_wpp_message(
+            _base_msg(filename="report.pdf", body="A" * 5000)
+        )
+
+        assert result["message"]["documentMessage"]["caption"] == ""

--- a/tests/test_read_state_bidirectional_sync.py
+++ b/tests/test_read_state_bidirectional_sync.py
@@ -27,6 +27,9 @@ class _RollbackStub:
         MainWindow._restore_unread_after_send_seen_failure
     )
     _normalize_jid = staticmethod(MainWindow._normalize_jid)
+    _restore_unread_after_mark_unread_failure = (
+        MainWindow._restore_unread_after_mark_unread_failure
+    )
 
     def __init__(self, *, archived=False):
         self.chats = {
@@ -85,3 +88,64 @@ def test_failed_send_seen_does_not_overwrite_a_new_message():
 
     assert stub.chats[JID]["unreadCount"] == 1
     assert stub._locally_read_at[JID] == 2000
+
+
+class _MarkUnreadStub(_RollbackStub):
+    mark_conversation_as_unread = MainWindow.mark_conversation_as_unread
+
+    def __init__(self):
+        super().__init__()
+        self.chats[JID]["unreadCount"] = 0
+        self.remote_changes = []
+        self.set_chats_calls = 0
+
+    def set_chats(self):
+        self.set_chats_calls += 1
+
+    def _sync_conversation_read_state(self, jid, unread, on_failure):
+        self.remote_changes.append((jid, unread, on_failure))
+
+
+def test_mark_unread_clears_stale_read_ack_and_syncs_to_whatsapp(monkeypatch):
+    monkeypatch.setattr("main.wx.CallAfter", lambda fn, *args: fn(*args))
+    stub = _MarkUnreadStub()
+
+    stub.mark_conversation_as_unread(JID)
+
+    assert stub.chats[JID]["unreadCount"] == 1
+    assert JID not in stub._locally_read_at
+    assert stub.remote_changes[0][:2] == (JID, True)
+    assert stub.saved == [JID]
+
+
+def test_failed_remote_mark_unread_rolls_back_if_chat_did_not_change():
+    stub = _MarkUnreadStub()
+    stub.chats[JID]["unreadCount"] = 1
+
+    stub._restore_unread_after_mark_unread_failure(JID, 0, 2000)
+
+    assert stub.chats[JID]["unreadCount"] == 0
+    assert stub.saved == [JID]
+
+
+def test_failed_remote_mark_unread_does_not_overwrite_new_activity():
+    stub = _MarkUnreadStub()
+    stub.chats[JID].update(unreadCount=2, t=2001)
+
+    stub._restore_unread_after_mark_unread_failure(JID, 0, 2000)
+
+    assert stub.chats[JID]["unreadCount"] == 2
+    assert stub.saved == []
+
+
+def test_node_read_state_endpoint_supports_both_states_and_checks_result():
+    source = (
+        __import__("pathlib").Path(__file__).parents[1]
+        / "client/api_patches/src/controller/deviceController.ts"
+    ).read_text(encoding="utf-8")
+
+    send_seen = source[source.index("export async function sendSeen"):]
+    assert "WPP.chat.markIsUnread" in send_seen
+    assert "WPP.chat.markIsRead" in send_seen
+    assert "if (!result) throw new Error" in send_seen
+    assert "markUnread: Boolean(unread)" in send_seen

--- a/tests/test_websocket_notes_live_events.py
+++ b/tests/test_websocket_notes_live_events.py
@@ -17,9 +17,13 @@ from core.websocket_client import WebSocketClient, ack_to_status
 class _FakeMainWindow:
     def __init__(self):
         self.live_event_calls = 0
+        self.unread_updates = []
 
     def _note_live_wpp_event(self):
         self.live_event_calls += 1
+
+    def on_chat_unread_update(self, *args):
+        self.unread_updates.append(args)
 
 
 class _Stub:
@@ -64,6 +68,30 @@ class TestLiveEventNoting:
         stub.on_chats_update({"session": "someone-elses-session", "data": []})
 
         assert stub.main_window.live_event_calls == 0
+
+    def test_manual_unread_sentinel_is_normalized_for_both_transitions(self, monkeypatch):
+        monkeypatch.setattr("core.websocket_client.wx.CallAfter", lambda fn, *args: fn(*args))
+        stub = _Stub()
+
+        stub.on_chats_update({
+            "data": [{
+                "remoteJid": "1@s.whatsapp.net",
+                "unreadCount": -1,
+                "previousUnreadCount": 0,
+            }]
+        })
+        stub.on_chats_update({
+            "data": [{
+                "remoteJid": "1@s.whatsapp.net",
+                "unreadCount": 0,
+                "previousUnreadCount": -1,
+            }]
+        })
+
+        assert stub.main_window.unread_updates == [
+            ("1@s.whatsapp.net", 1, 0),
+            ("1@s.whatsapp.net", 0, 1),
+        ]
 
     def test_ack_to_status_still_works_untouched(self):
         # Sanity: the import path used above still resolves correctly.


### PR DESCRIPTION
## Resumo

- sincroniza marcar como lida e não lida entre WinZapp e WhatsApp, incluindo o sentinela manual de não lida
- propaga e reconcilia renomeações de grupos recebidas pelo Socket.IO e pelo endpoint de informações do grupo
- preserva legendas de documentos sem interpretar conteúdo binário como texto
- sincroniza silenciar e reativar com confirmação do WhatsApp e aliases de telefone/LID
- faz rollback de alterações otimistas quando o servidor não confirma a operação

## Validação

- 3650 passed na suíte completa do pytest
- 
pm run build concluído no servidor WPPConnect
- 	ests/test_api_patches_in_sync.py incluído na execução direcionada (108 passed)

## Observações

A pasta local não rastreada client/sounds/New/ não faz parte deste PR.