### PR TITLE
Restrict the account IPC pipe to the current user

### DIFF
--- a/client/ipc.py
+++ b/client/ipc.py
@@ -168,24 +168,62 @@ class IpcListener:
                 continue
             except OSError:
                 break
-            with conn:
-                self._handle_conn(conn)
+            # Handed off to its own thread for the same reason as the
+            # Windows pipe loop below: a "quit" reply waits here for up to
+            # 10s for released_predicate(), and handling it inline would
+            # stall accept() from picking up any other request (e.g. a
+            # concurrent "activate") for that whole window.
+            threading.Thread(target=self._handle_conn, args=(conn,), daemon=True).start()
         try:
             srv.close()
             os.unlink(path)
         except OSError:
             pass
 
+    @staticmethod
+    def _current_user_pipe_sa():  # pragma: no cover (Windows-only)
+        """SECURITY_ATTRIBUTES with a DACL granting access to this Windows
+        user's SID only — nobody else, not even other local administrators.
+
+        A bare ``win32security.SECURITY_ATTRIBUTES()`` (the previous code
+        here) has no security descriptor of its own, so ``CreateNamedPipe``
+        falls back to the default DACL for a kernel object created by this
+        process: verified directly against a real pipe, that default grants
+        full control to the current user AND to ``BUILTIN\\Administrators``
+        AND ``NT AUTHORITY\\SYSTEM`` — not "current user only" the way the
+        module docstring above has always claimed. Any other account able to
+        reach that pipe name (any local admin, not just this user) could send
+        it an "activate"/"quit" command for a WinZapp instance it does not
+        own. This SID-scoped DACL is what actually delivers on that claim.
+        """
+        import win32security
+        import win32api
+        import ntsecuritycon
+
+        token = win32security.OpenProcessToken(
+            win32api.GetCurrentProcess(), win32security.TOKEN_QUERY
+        )
+        user_sid, _ = win32security.GetTokenInformation(token, win32security.TokenUser)
+
+        dacl = win32security.ACL()
+        dacl.AddAccessAllowedAce(win32security.ACL_REVISION, ntsecuritycon.FILE_ALL_ACCESS, user_sid)
+
+        sd = win32security.SECURITY_DESCRIPTOR()
+        sd.SetSecurityDescriptorDacl(1, dacl, 0)
+
+        sa = win32security.SECURITY_ATTRIBUTES()
+        sa.SECURITY_DESCRIPTOR = sd
+        sa.bInheritHandle = False
+        return sa
+
     def _serve_windows(self) -> None:  # pragma: no cover (Windows-only)
         # Uses pywin32 named pipes with a current-user DACL. Protocol identical
         # to the AF_UNIX path. Imported lazily so non-Windows never needs it.
         import win32pipe
-        import win32file
         import pywintypes
-        import win32security
 
         name = _pipe_name(self.global_dir, self.account_id)
-        sa = win32security.SECURITY_ATTRIBUTES()  # default = current user token
+        sa = self._current_user_pipe_sa()
         self._ready.set()
         while not self._stop.is_set():
             try:
@@ -197,33 +235,55 @@ class IpcListener:
                     65536, 65536, 0, sa,
                 )
                 win32pipe.ConnectNamedPipe(handle, None)
-                data = win32file.ReadFile(handle, 65536)[1]
-                reply_lines = self._handle_message(data.decode("utf-8"))
-                for line in reply_lines:
-                    win32file.WriteFile(handle, (line + "\n").encode("utf-8"))
-                win32file.FlushFileBuffers(handle)
-                win32pipe.DisconnectNamedPipe(handle)
-                win32file.CloseHandle(handle)
             except pywintypes.error:
                 if self._stop.is_set():
                     break
                 time.sleep(0.05)
+                continue
+            # Handed off to its own thread so a slow reply — "quit" waits
+            # here for up to 10s for released_predicate() — can't stall this
+            # loop from accepting the next connection. Before this, a "quit"
+            # in flight made every other request (e.g. a concurrent
+            # "activate" from another account switching in) simply time out
+            # on the caller's side, since nothing was accepting it.
+            threading.Thread(
+                target=self._handle_pipe_connection, args=(handle,), daemon=True
+            ).start()
+
+    def _handle_pipe_connection(self, handle) -> None:  # pragma: no cover (Windows-only)
+        import win32pipe
+        import win32file
+        import pywintypes
+
+        try:
+            data = win32file.ReadFile(handle, 65536)[1]
+            reply_lines = self._handle_message(data.decode("utf-8"))
+            for line in reply_lines:
+                win32file.WriteFile(handle, (line + "\n").encode("utf-8"))
+            win32file.FlushFileBuffers(handle)
+            win32pipe.DisconnectNamedPipe(handle)
+            win32file.CloseHandle(handle)
+        except pywintypes.error:
+            pass
 
     # ── per-connection handling (shared logic) ───────────────────────────
     def _handle_conn(self, conn: socket.socket) -> None:
-        conn.settimeout(5.0)
-        buf = b""
-        try:
-            while b"\n" not in buf:
-                chunk = conn.recv(4096)
-                if not chunk:
-                    return
-                buf += chunk
-            line = buf.split(b"\n", 1)[0].decode("utf-8")
-            for reply in self._handle_message(line):
-                conn.sendall((reply + "\n").encode("utf-8"))
-        except (OSError, ValueError):
-            pass
+        # Runs on its own thread (see _serve_unix) — closes conn itself now
+        # that the accept loop no longer wraps the call in `with conn:`.
+        with conn:
+            conn.settimeout(5.0)
+            buf = b""
+            try:
+                while b"\n" not in buf:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        return
+                    buf += chunk
+                line = buf.split(b"\n", 1)[0].decode("utf-8")
+                for reply in self._handle_message(line):
+                    conn.sendall((reply + "\n").encode("utf-8"))
+            except (OSError, ValueError):
+                pass
 
     def _handle_message(self, line: str) -> list[str]:
         try:

--- a/client/ipc.py
+++ b/client/ipc.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import socket
 import sys
@@ -181,7 +182,7 @@ class IpcListener:
             pass
 
     @staticmethod
-    def _current_user_pipe_sa():  # pragma: no cover (Windows-only)
+    def _current_user_pipe_sa():
         """SECURITY_ATTRIBUTES with a DACL granting access to this Windows
         user's SID only — nobody else, not even other local administrators.
 
@@ -206,6 +207,12 @@ class IpcListener:
         user_sid, _ = win32security.GetTokenInformation(token, win32security.TokenUser)
 
         dacl = win32security.ACL()
+        # FILE_ALL_ACCESS rather than just read+write: every pipe instance
+        # after the first one is created against the SAME name and therefore
+        # against this DACL, and that needs FILE_CREATE_PIPE_INSTANCE (0x4) —
+        # granted here only because it sits inside FILE_ALL_ACCESS (0x1F01FF).
+        # A narrower read/write mask would serve exactly one connection and
+        # then fail the accept loop's next CreateNamedPipe with access denied.
         dacl.AddAccessAllowedAce(win32security.ACL_REVISION, ntsecuritycon.FILE_ALL_ACCESS, user_sid)
 
         sd = win32security.SECURITY_DESCRIPTOR()
@@ -217,15 +224,35 @@ class IpcListener:
         return sa
 
     def _serve_windows(self) -> None:  # pragma: no cover (Windows-only)
-        # Uses pywin32 named pipes with a current-user DACL. Protocol identical
-        # to the AF_UNIX path. Imported lazily so non-Windows never needs it.
+        # Protocol identical to the AF_UNIX path; imported lazily so
+        # non-Windows never needs pywin32.
         import win32pipe
+        import win32file
         import pywintypes
 
         name = _pipe_name(self.global_dir, self.account_id)
-        sa = self._current_user_pipe_sa()
+        try:
+            sa = self._current_user_pipe_sa()
+        except Exception:
+            # Fail closed — no fallback to a default-DACL pipe. But the failure
+            # has to be *visible*: this runs on the service thread, where an
+            # escaping exception goes to threading.excepthook -> stderr, which
+            # a PyInstaller --windowed build discards, and main.py's try/except
+            # around start() has already returned by then. All that would be
+            # left is "[ipc] listener started (ready=False)" with no reason,
+            # while account_launcher reads the resulting request_activate()
+            # False as "no process running" and launches a SECOND process for
+            # an account that is already running.
+            logging.exception("[ipc] pipe DACL build failed — listener not started")
+            return
         self._ready.set()
         while not self._stop.is_set():
+            # Bound to None first so the handler below can tell "CreateNamedPipe
+            # itself failed" from "this iteration's handle needs closing". A
+            # bare CloseHandle(handle) in the except would otherwise close the
+            # *previous* iteration's handle — which a live connection thread is
+            # still using — and kill a working connection.
+            handle = None
             try:
                 handle = win32pipe.CreateNamedPipe(
                     name,
@@ -236,6 +263,22 @@ class IpcListener:
                 )
                 win32pipe.ConnectNamedPipe(handle, None)
             except pywintypes.error:
+                # A client that connected and closed again before we reached
+                # ConnectNamedPipe raises ERROR_NO_DATA (232) here — routine,
+                # since request_activate()/request_quit() give up on their own
+                # deadline and quit_all_accounts() is explicitly best-effort
+                # about unresponsive peers. Without this close, every such
+                # give-up leaked a kernel handle and a pipe instance for the
+                # life of the process, and PIPE_UNLIMITED_INSTANCES means
+                # nothing ever caps that.
+                # (ERROR_PIPE_CONNECTED, 535 — client already waiting — is not
+                # an exception in pywin32; it returns normally and the read
+                # below works, so it never lands here.)
+                if handle is not None:
+                    try:
+                        win32file.CloseHandle(handle)
+                    except Exception:
+                        pass
                 if self._stop.is_set():
                     break
                 time.sleep(0.05)
@@ -250,21 +293,75 @@ class IpcListener:
                 target=self._handle_pipe_connection, args=(handle,), daemon=True
             ).start()
 
-    def _handle_pipe_connection(self, handle) -> None:  # pragma: no cover (Windows-only)
+    def _read_pipe_message(self, handle, timeout: float = 5.0) -> Optional[bytes]:
+        """Read one message from a connected pipe instance, or None if the
+        client sent nothing within `timeout` (mirrors the AF_UNIX side's
+        conn.settimeout(5.0)).
+
+        The pipe is PIPE_WAIT, so a bare ReadFile against a client that
+        connects and never writes blocks FOREVER. Polling PeekNamedPipe is the
+        cheapest way out that this transport can carry: overlapped I/O would
+        mean threading FILE_FLAG_OVERLAPPED plus an OVERLAPPED/event through
+        CreateNamedPipe, ConnectNamedPipe and every WriteFile in this file, and
+        PIPE_NOWAIT is documented as legacy-only and just turns ReadFile into
+        this same poll with worse semantics. Cancelling the read from a
+        watchdog thread was the other candidate and was rejected as tearing a
+        handle out from under a blocked syscall.
+        """
+        import win32pipe
+        import win32file
+
+        deadline = time.monotonic() + timeout
+        while True:
+            if win32pipe.PeekNamedPipe(handle, 0)[1] > 0:
+                return win32file.ReadFile(handle, 65536)[1]
+            if self._stop.is_set() or time.monotonic() >= deadline:
+                return None
+            time.sleep(0.01)
+
+    def _handle_pipe_connection(self, handle) -> None:
         import win32pipe
         import win32file
         import pywintypes
 
         try:
-            data = win32file.ReadFile(handle, 65536)[1]
-            reply_lines = self._handle_message(data.decode("utf-8"))
-            for line in reply_lines:
+            data = self._read_pipe_message(handle)
+            if data is None:
+                return
+            for line in self._handle_message(data.decode("utf-8")):
                 win32file.WriteFile(handle, (line + "\n").encode("utf-8"))
             win32file.FlushFileBuffers(handle)
-            win32pipe.DisconnectNamedPipe(handle)
-            win32file.CloseHandle(handle)
-        except pywintypes.error:
-            pass
+        except pywintypes.error as exc:
+            # The peer going away mid-exchange is a transport condition, not a
+            # fault, and it happens on an expected path: a "quit" reply waits up
+            # to 10s for released_predicate(), while the caller's own timeout is
+            # also 10s but starts earlier — so the client always closes first
+            # and our WriteFile/FlushFileBuffers always raises 109. Logging that
+            # as an ERROR traceback would send whoever reads log.log chasing a
+            # broken transport that isn't broken, and drown the ERROR that does
+            # matter — the file is the project's primary diagnostic and is
+            # truncated every launch.
+            logging.info("[ipc] pipe connection ended: winerror=%s %s",
+                         exc.winerror, exc.funcname)
+        except Exception:
+            # Deliberately broader than pywintypes.error: a client sending
+            # non-UTF-8 raises UnicodeDecodeError (a ValueError), which the
+            # AF_UNIX twin catches and this one used not to — leaving an
+            # unhandled exception on a connection thread AND, since the cleanup
+            # lived at the end of the same try, a leaked handle with it.
+            logging.exception("[ipc] pipe connection handler failed")
+        finally:
+            # Always: any error above used to leak the handle and its pipe
+            # instance. Closing an already-closed pywin32 handle is a no-op,
+            # so nothing here needs to know how far the exchange got.
+            try:
+                win32pipe.DisconnectNamedPipe(handle)
+            except Exception:
+                pass
+            try:
+                win32file.CloseHandle(handle)
+            except Exception:
+                pass
 
     # ── per-connection handling (shared logic) ───────────────────────────
     def _handle_conn(self, conn: socket.socket) -> None:

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -5,6 +5,7 @@ On Linux these exercise the AF_UNIX fallback transport + the shared protocol
 The Windows named-pipe transport shares the same protocol layer.
 """
 
+import sys
 import threading
 import time
 
@@ -125,3 +126,133 @@ def test_queue_before_window_then_flush(tmp_path):
         assert delivered == [("ready", "user")]
     finally:
         listener.stop()
+
+
+def test_a_concurrent_activate_is_not_blocked_by_an_in_flight_quit(tmp_path):
+    """Regression: handling "quit" used to happen inline in the accept loop,
+    including its up-to-10s wait for released_predicate() — so any other
+    request sent while a quit was in flight had nowhere to connect to until
+    that wait finished. Each connection is now handed to its own thread so
+    the accept loop is free to pick up the next one immediately."""
+    gd = _gd(tmp_path)
+    acc = "d" * 32
+    released = threading.Event()
+
+    def on_quit():
+        # Slow enough that an inline handler would clearly stall the next
+        # request; short enough to keep the test fast.
+        threading.Timer(1.5, released.set).start()
+
+    listener = ipc.IpcListener(
+        gd, acc, on_activate=lambda s: None, on_quit=on_quit,
+        released_predicate=lambda: released.is_set(),
+    )
+    listener.start()
+    try:
+        assert listener.wait_ready(2.0)
+
+        quit_result = {}
+
+        def _do_quit():
+            quit_result["ok"] = ipc.request_quit(gd, acc, timeout=5.0)
+
+        t = threading.Thread(target=_do_quit)
+        t.start()
+        time.sleep(0.3)  # let the quit request land and start its wait
+
+        start = time.monotonic()
+        ok = ipc.request_activate(gd, acc, source="user", timeout=2.0)
+        elapsed = time.monotonic() - start
+
+        assert ok is True
+        assert elapsed < 1.0, (
+            f"activate took {elapsed:.2f}s while a quit was in flight — "
+            "the accept loop was blocked instead of handling it concurrently"
+        )
+        t.join(timeout=5)
+        assert quit_result.get("ok") is True
+    finally:
+        listener.stop()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="named pipe DACL is Windows-only")
+class TestNamedPipeDacl:
+    """The module docstring has always claimed the named pipe is 'restricted
+    to the current user' — this actually creates a pipe with the real
+    SECURITY_ATTRIBUTES the listener builds and inspects the DACL Windows
+    attached to it, rather than trusting that the pywin32 calls did what the
+    comment says. A bare SECURITY_ATTRIBUTES() (the previous code) was
+    confirmed, by this same technique, to grant full control to the current
+    user AND BUILTIN\\Administrators AND NT AUTHORITY\\SYSTEM."""
+
+    def test_only_the_current_user_has_an_ace(self):
+        import win32pipe
+        import win32file
+        import win32security
+        import win32api
+
+        sa = ipc.IpcListener._current_user_pipe_sa()
+        name = r"\\.\pipe\wz_test_dacl_pytest"
+        handle = win32pipe.CreateNamedPipe(
+            name,
+            win32pipe.PIPE_ACCESS_DUPLEX,
+            win32pipe.PIPE_TYPE_MESSAGE | win32pipe.PIPE_READMODE_MESSAGE | win32pipe.PIPE_WAIT,
+            win32pipe.PIPE_UNLIMITED_INSTANCES,
+            65536, 65536, 0, sa,
+        )
+        try:
+            sd = win32security.GetSecurityInfo(
+                handle, win32security.SE_KERNEL_OBJECT,
+                win32security.DACL_SECURITY_INFORMATION,
+            )
+            dacl = sd.GetSecurityDescriptorDacl()
+            assert dacl is not None
+            assert dacl.GetAceCount() == 1
+
+            token = win32security.OpenProcessToken(
+                win32api.GetCurrentProcess(), win32security.TOKEN_QUERY
+            )
+            current_sid, _ = win32security.GetTokenInformation(token, win32security.TokenUser)
+            ace = dacl.GetAce(0)
+            assert ace[2] == current_sid
+        finally:
+            win32file.CloseHandle(handle)
+
+    def test_the_current_user_can_still_connect(self):
+        """The security lockdown must not lock out the very process that
+        creates the pipe."""
+        import win32pipe
+        import win32file
+        import pywintypes
+
+        sa = ipc.IpcListener._current_user_pipe_sa()
+        name = r"\\.\pipe\wz_test_dacl_connect_pytest"
+        handle = win32pipe.CreateNamedPipe(
+            name,
+            win32pipe.PIPE_ACCESS_DUPLEX,
+            win32pipe.PIPE_TYPE_MESSAGE | win32pipe.PIPE_READMODE_MESSAGE | win32pipe.PIPE_WAIT,
+            win32pipe.PIPE_UNLIMITED_INSTANCES,
+            65536, 65536, 0, sa,
+        )
+        connected = {}
+
+        def _client():
+            try:
+                h = win32file.CreateFile(
+                    name, win32file.GENERIC_READ | win32file.GENERIC_WRITE,
+                    0, None, win32file.OPEN_EXISTING, 0, None,
+                )
+                connected["ok"] = True
+                win32file.CloseHandle(h)
+            except pywintypes.error as exc:
+                connected["error"] = exc
+
+        t = threading.Thread(target=_client)
+        t.start()
+        try:
+            win32pipe.ConnectNamedPipe(handle, None)
+        finally:
+            t.join(timeout=5)
+            win32file.CloseHandle(handle)
+
+        assert connected.get("ok") is True, connected.get("error")

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -5,6 +5,8 @@ On Linux these exercise the AF_UNIX fallback transport + the shared protocol
 The Windows named-pipe transport shares the same protocol layer.
 """
 
+import logging
+import os
 import sys
 import threading
 import time
@@ -15,10 +17,33 @@ import ipc
 
 
 def _gd(tmp_path):
-    import os
     gd = str(tmp_path / "global")
     os.makedirs(gd, exist_ok=True)
     return gd
+
+
+def _test_pipe_name(tag):
+    """A pipe name unique to this process.
+
+    Pipe names are machine-global: with a fixed name, two pytest runs in
+    parallel — or a leftover instance from a run that was killed — create a
+    SECOND instance of the same name, and the client thread below can then
+    connect to the other process's instance, leaving ConnectNamedPipe here
+    hanging until the join timeout.
+    """
+    return r"\\.\pipe\wz_test_%s_%d" % (tag, os.getpid())
+
+
+def _create_test_pipe(name, sa):
+    import win32pipe
+
+    return win32pipe.CreateNamedPipe(
+        name,
+        win32pipe.PIPE_ACCESS_DUPLEX,
+        win32pipe.PIPE_TYPE_MESSAGE | win32pipe.PIPE_READMODE_MESSAGE | win32pipe.PIPE_WAIT,
+        win32pipe.PIPE_UNLIMITED_INSTANCES,
+        65536, 65536, 0, sa,
+    )
 
 
 def test_no_listener_returns_false(tmp_path):
@@ -137,8 +162,10 @@ def test_a_concurrent_activate_is_not_blocked_by_an_in_flight_quit(tmp_path):
     gd = _gd(tmp_path)
     acc = "d" * 32
     released = threading.Event()
+    quit_in_flight = threading.Event()
 
     def on_quit():
+        quit_in_flight.set()
         # Slow enough that an inline handler would clearly stall the next
         # request; short enough to keep the test fast.
         threading.Timer(1.5, released.set).start()
@@ -158,7 +185,12 @@ def test_a_concurrent_activate_is_not_blocked_by_an_in_flight_quit(tmp_path):
 
         t = threading.Thread(target=_do_quit)
         t.start()
-        time.sleep(0.3)  # let the quit request land and start its wait
+        # Wait for the quit to have actually reached the handler rather than
+        # sleeping a fixed amount: on a loaded CI runner request_quit's
+        # retry-connect can land after any such sleep, and the activate below
+        # would then be answered by an idle accept loop — passing without ever
+        # exercising the regression, silently.
+        assert quit_in_flight.wait(5.0)
 
         start = time.monotonic()
         ok = ipc.request_activate(gd, acc, source="user", timeout=2.0)
@@ -186,20 +218,13 @@ class TestNamedPipeDacl:
     user AND BUILTIN\\Administrators AND NT AUTHORITY\\SYSTEM."""
 
     def test_only_the_current_user_has_an_ace(self):
-        import win32pipe
         import win32file
         import win32security
         import win32api
+        import ntsecuritycon
 
         sa = ipc.IpcListener._current_user_pipe_sa()
-        name = r"\\.\pipe\wz_test_dacl_pytest"
-        handle = win32pipe.CreateNamedPipe(
-            name,
-            win32pipe.PIPE_ACCESS_DUPLEX,
-            win32pipe.PIPE_TYPE_MESSAGE | win32pipe.PIPE_READMODE_MESSAGE | win32pipe.PIPE_WAIT,
-            win32pipe.PIPE_UNLIMITED_INSTANCES,
-            65536, 65536, 0, sa,
-        )
+        handle = _create_test_pipe(_test_pipe_name("dacl"), sa)
         try:
             sd = win32security.GetSecurityInfo(
                 handle, win32security.SE_KERNEL_OBJECT,
@@ -213,8 +238,19 @@ class TestNamedPipeDacl:
                 win32api.GetCurrentProcess(), win32security.TOKEN_QUERY
             )
             current_sid, _ = win32security.GetTokenInformation(token, win32security.TokenUser)
-            ace = dacl.GetAce(0)
-            assert ace[2] == current_sid
+            (ace_type, _ace_flags), mask, sid = dacl.GetAce(0)
+            assert sid == current_sid
+            # The SID alone proves nothing about what it is granted: a single
+            # ACCESS_DENIED ACE for this same user would satisfy both the count
+            # and the SID check above, and lock the owner out of its own pipe.
+            assert ace_type == win32security.ACCESS_ALLOWED_ACE_TYPE
+            # And it must grant enough: read+write for the exchange itself,
+            # plus FILE_CREATE_PIPE_INSTANCE, without which every instance of
+            # this pipe after the first fails with access denied.
+            required = (ntsecuritycon.FILE_GENERIC_READ
+                        | ntsecuritycon.FILE_GENERIC_WRITE
+                        | ntsecuritycon.FILE_CREATE_PIPE_INSTANCE)
+            assert mask & required == required
         finally:
             win32file.CloseHandle(handle)
 
@@ -226,15 +262,10 @@ class TestNamedPipeDacl:
         import pywintypes
 
         sa = ipc.IpcListener._current_user_pipe_sa()
-        name = r"\\.\pipe\wz_test_dacl_connect_pytest"
-        handle = win32pipe.CreateNamedPipe(
-            name,
-            win32pipe.PIPE_ACCESS_DUPLEX,
-            win32pipe.PIPE_TYPE_MESSAGE | win32pipe.PIPE_READMODE_MESSAGE | win32pipe.PIPE_WAIT,
-            win32pipe.PIPE_UNLIMITED_INSTANCES,
-            65536, 65536, 0, sa,
-        )
+        name = _test_pipe_name("dacl_connect")
+        handle = _create_test_pipe(name, sa)
         connected = {}
+        server_done = threading.Event()
 
         def _client():
             try:
@@ -243,6 +274,12 @@ class TestNamedPipeDacl:
                     0, None, win32file.OPEN_EXISTING, 0, None,
                 )
                 connected["ok"] = True
+                # Hold the client end open until the server side is through its
+                # ConnectNamedPipe. Closing immediately made that call fail with
+                # ERROR_NO_DATA ("the pipe is being closed") whenever the client
+                # won the race — a flake, and one that reads exactly like the
+                # permissions failure this test exists to rule out.
+                server_done.wait(5)
                 win32file.CloseHandle(h)
             except pywintypes.error as exc:
                 connected["error"] = exc
@@ -252,7 +289,103 @@ class TestNamedPipeDacl:
         try:
             win32pipe.ConnectNamedPipe(handle, None)
         finally:
+            server_done.set()
             t.join(timeout=5)
             win32file.CloseHandle(handle)
 
         assert connected.get("ok") is True, connected.get("error")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="named pipe transport is Windows-only")
+class TestNamedPipeConnectionHandling:
+    """The per-connection half of the Windows transport, driven against a real
+    pipe. Every connection gets its own thread now, so a client that misbehaves
+    no longer merely stalls the accept loop — it costs a thread and a pipe
+    instance that must both be reclaimed."""
+
+    def test_a_client_that_never_writes_does_not_block_forever(self):
+        """Regression: the pipe is PIPE_WAIT, so ReadFile against a client that
+        connects and then says nothing blocked indefinitely — one such client
+        per connection, and thread/pipe-instance growth is unbounded. The
+        AF_UNIX twin has had conn.settimeout(5.0) for this all along."""
+        import win32pipe
+        import win32file
+        import pywintypes
+
+        listener = ipc.IpcListener(
+            "", "e" * 32, on_activate=lambda s: None, on_quit=lambda: None
+        )
+        name = _test_pipe_name("silent_client")
+        handle = _create_test_pipe(name, ipc.IpcListener._current_user_pipe_sa())
+        client = {}
+
+        def _client():
+            try:
+                client["h"] = win32file.CreateFile(
+                    name, win32file.GENERIC_READ | win32file.GENERIC_WRITE,
+                    0, None, win32file.OPEN_EXISTING, 0, None,
+                )
+            except pywintypes.error as exc:
+                client["error"] = exc
+
+        t = threading.Thread(target=_client)
+        t.start()
+        try:
+            win32pipe.ConnectNamedPipe(handle, None)
+            t.join(timeout=5)
+            assert client.get("h") is not None, client.get("error")
+
+            start = time.monotonic()
+            assert listener._read_pipe_message(handle, timeout=0.3) is None
+            assert time.monotonic() - start < 3.0
+        finally:
+            if client.get("h") is not None:
+                win32file.CloseHandle(client["h"])
+            win32file.CloseHandle(handle)
+
+    def test_a_non_utf8_message_is_logged_and_the_handle_released(self, caplog):
+        """Regression: data.decode("utf-8") raises UnicodeDecodeError, which the
+        old `except pywintypes.error` did not catch — the connection thread died
+        with an unhandled traceback (discarded entirely in a --windowed build)
+        and, because the cleanup sat at the end of that same try, leaked the
+        handle and its pipe instance with it."""
+        import win32pipe
+        import win32file
+        import pywintypes
+
+        listener = ipc.IpcListener(
+            "", "f" * 32, on_activate=lambda s: None, on_quit=lambda: None
+        )
+        name = _test_pipe_name("bad_utf8")
+        handle = _create_test_pipe(name, ipc.IpcListener._current_user_pipe_sa())
+        done = threading.Event()
+        client = {}
+
+        def _client():
+            try:
+                h = win32file.CreateFile(
+                    name, win32file.GENERIC_READ | win32file.GENERIC_WRITE,
+                    0, None, win32file.OPEN_EXISTING, 0, None,
+                )
+                win32file.WriteFile(h, b"\xff\xfe not utf-8\n")
+                # Hold the client end open until the server side is done, so
+                # the read under test can't race the buffer away.
+                done.wait(5)
+                win32file.CloseHandle(h)
+            except pywintypes.error as exc:
+                client["error"] = exc
+
+        t = threading.Thread(target=_client)
+        t.start()
+        try:
+            win32pipe.ConnectNamedPipe(handle, None)
+            with caplog.at_level(logging.ERROR):
+                listener._handle_pipe_connection(handle)  # must not raise
+            assert "pipe connection handler failed" in caplog.text
+            # pywin32 zeroes a PyHANDLE once it is closed — proof the finally
+            # ran rather than the handle leaking on the way out.
+            assert int(handle) == 0
+        finally:
+            done.set()
+            t.join(timeout=5)
+            assert client.get("error") is None


### PR DESCRIPTION
The named pipe used for switching between accounts and quitting them was documented as restricted to the current Windows user, but the code never actually applied that restriction. I confirmed directly that the default it fell back to instead grants full control to the current user, to the local Administrators group, and to SYSTEM, not to this user alone. The quit handler also blocked the pipe from accepting any other request for several seconds while it waited for shutdown, which could make an unrelated switch request hang. This change actually builds the security descriptor the docstring already claimed to set, and hands each connection to its own thread so the accept loop keeps serving other requests while a quit is still waiting. Everyday single user usage behaves exactly as before. I ran the existing IPC tests along with new ones that inspect the real security descriptor on an actual pipe and confirm a concurrent request no longer stalls behind a quit in progress.