### PR TITLE
Make database call timeouts and shutdown actually stop stale work

### DIFF
--- a/client/core/database_bridge.py
+++ b/client/core/database_bridge.py
@@ -60,9 +60,17 @@ class DatabaseBridgeClosed(RuntimeError):
 class DatabaseBridgeTimeout(RuntimeError):
     """Raised when a database call does not complete within its timeout.
 
-    This does NOT mean the underlying operation failed or was rolled back —
-    only that the calling thread stopped waiting for it. The operation may
-    still complete on the event-loop thread afterwards.
+    This does NOT mean the underlying operation failed or was rolled back.
+    _call() cancels the coroutine's future the moment the timeout fires,
+    which asyncio delivers at the coroutine's next await point: a call still
+    queued behind other work never gets to start at all, and one already
+    suspended waiting on something (a lock, an I/O op) is interrupted right
+    there — in both cases no stale write lands later for a caller that
+    already timed out and moved on (e.g. retried the same write). The one
+    case cancellation cannot reach is a coroutine actively executing
+    synchronous code with no await in between (e.g. mid-way through
+    encrypting a large payload) — Python cannot preempt that, so it keeps
+    running and may still complete in the background.
     """
 
 
@@ -81,12 +89,22 @@ class DatabaseBridge:
         self._db_path = Path(db_path)
         self._key = key
         self._closing = False
-        self._close_lock = threading.Lock()
+        # Guards _closing and _inflight together. They used to be checked/
+        # updated under two separate locks (a plain read of _closing in
+        # _call(), then a *different* lock around incrementing _inflight in
+        # _call_unchecked()) — a caller could read _closing as False, and
+        # before it got as far as incrementing _inflight, close() could set
+        # _closing, see _inflight still at 0 (nothing counted yet) and treat
+        # everything as already drained, stop the loop, and then have that
+        # caller's coroutine scheduled onto a loop that no longer runs —
+        # timing out for a reason that has nothing to do with a slow query.
+        # One lock around both makes "still open, and now counted as
+        # in-flight" a single atomic step close() cannot slip through.
+        self._state_lock = threading.Lock()
         # Tracks calls currently waiting on the event loop, so close() can
         # give them a moment to finish instead of yanking the loop out from
         # under them (which would otherwise strand their future forever).
         self._inflight = 0
-        self._inflight_lock = threading.Lock()
         self._inflight_drained = threading.Event()
         self._inflight_drained.set()
 
@@ -118,10 +136,24 @@ class DatabaseBridge:
         within *timeout* seconds — either of which the caller can catch,
         instead of the whole app (often the wx UI thread) hanging forever.
         """
-        if self._closing:
-            coro.close()  # avoid a "coroutine was never awaited" warning
-            raise DatabaseBridgeClosed("DatabaseBridge is closing")
-        return self._call_unchecked(coro, timeout)
+        with self._state_lock:
+            if self._closing:
+                coro.close()  # avoid a "coroutine was never awaited" warning
+                raise DatabaseBridgeClosed("DatabaseBridge is closing")
+            if not self._thread.is_alive():
+                coro.close()
+                raise DatabaseBridgeTimeout(
+                    "db-asyncio thread is not running; cannot execute query"
+                )
+            self._inflight += 1
+            self._inflight_drained.clear()
+        try:
+            return self._run_scheduled(coro, timeout)
+        finally:
+            with self._state_lock:
+                self._inflight -= 1
+                if self._inflight <= 0:
+                    self._inflight_drained.set()
 
     def _call_unchecked(self, coro, timeout: float = _DEFAULT_CALL_TIMEOUT) -> Any:
         """Like ``_call`` but skips the ``_closing`` gate.
@@ -134,28 +166,41 @@ class DatabaseBridge:
             raise DatabaseBridgeTimeout(
                 "db-asyncio thread is not running; cannot execute query"
             )
-
-        with self._inflight_lock:
+        with self._state_lock:
             self._inflight += 1
             self._inflight_drained.clear()
         try:
-            future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-            try:
-                return future.result(timeout=timeout)
-            except asyncio.TimeoutError as exc:
-                log.error(
-                    "[DatabaseBridge] Call timed out after %.0fs (coroutine may "
-                    "still complete in the background): %s",
-                    timeout, coro,
-                )
-                raise DatabaseBridgeTimeout(
-                    f"Database call timed out after {timeout:.0f}s"
-                ) from exc
+            return self._run_scheduled(coro, timeout)
         finally:
-            with self._inflight_lock:
+            with self._state_lock:
                 self._inflight -= 1
                 if self._inflight <= 0:
                     self._inflight_drained.set()
+
+    def _run_scheduled(self, coro, timeout: float) -> Any:
+        """Schedule *coro* on the loop and block for the result, or timeout.
+
+        Shared tail end of ``_call``/``_call_unchecked`` — everything about
+        whether this coroutine was even allowed to be scheduled (the
+        ``_closing``/``_inflight`` bookkeeping) already happened in the
+        caller; this only runs it and translates a timeout.
+        """
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        try:
+            return future.result(timeout=timeout)
+        except asyncio.TimeoutError as exc:
+            # See DatabaseBridgeTimeout's own docstring for exactly what
+            # this does and does not stop: a call still queued, or blocked
+            # on I/O, is genuinely interrupted; one running synchronous code
+            # with no await in between cannot be preempted and keeps going.
+            cancelled = future.cancel()
+            log.error(
+                "[DatabaseBridge] Call timed out after %.0fs (cancel %s): %s",
+                timeout, "succeeded" if cancelled else "had no effect — already running", coro,
+            )
+            raise DatabaseBridgeTimeout(
+                f"Database call timed out after {timeout:.0f}s"
+            ) from exc
 
     async def _create_db(self) -> DatabaseManager:
         """Factory: connect a new DatabaseManager on the event loop."""
@@ -166,14 +211,16 @@ class DatabaseBridge:
     def close(self) -> None:
         """Shut down the event loop and release the database.
 
-        Rejects any new call the moment this starts (``_closing`` is checked
-        before ``_call`` ever touches the loop), then waits briefly for calls
-        already in flight to finish on their own before stopping the loop —
-        stopping it out from under a pending call would otherwise leave that
-        caller's ``future.result()`` blocked forever with nothing left to ever
+        Rejects any new call the moment this starts (``_closing`` is checked,
+        and ``_inflight`` incremented, atomically under ``_state_lock`` — see
+        that attribute's own comment for the race two separate locks used to
+        leave open), then waits briefly for calls already in flight to
+        finish on their own before stopping the loop — stopping it out from
+        under a pending call would otherwise leave that caller's
+        ``future.result()`` blocked forever with nothing left to ever
         resolve it.
         """
-        with self._close_lock:
+        with self._state_lock:
             if self._closing:
                 return
             self._closing = True

--- a/client/core/database_bridge.py
+++ b/client/core/database_bridge.py
@@ -60,17 +60,28 @@ class DatabaseBridgeClosed(RuntimeError):
 class DatabaseBridgeTimeout(RuntimeError):
     """Raised when a database call does not complete within its timeout.
 
-    This does NOT mean the underlying operation failed or was rolled back.
-    _call() cancels the coroutine's future the moment the timeout fires,
-    which asyncio delivers at the coroutine's next await point: a call still
-    queued behind other work never gets to start at all, and one already
-    suspended waiting on something (a lock, an I/O op) is interrupted right
-    there — in both cases no stale write lands later for a caller that
-    already timed out and moved on (e.g. retried the same write). The one
-    case cancellation cannot reach is a coroutine actively executing
-    synchronous code with no await in between (e.g. mid-way through
-    encrypting a large payload) — Python cannot preempt that, so it keeps
-    running and may still complete in the background.
+    This does NOT mean the underlying operation failed or was rolled back —
+    only that the calling thread stopped waiting for it. The operation may
+    still complete on the event-loop thread afterwards.
+
+    That is deliberate: the timeout does NOT cancel the coroutine, and must
+    not start doing so. Cancelling looks like the tidier option — no stale
+    write landing after the caller gave up — but it corrupts the database.
+    Every batch write in DatabaseManager runs `BEGIN` ... `COMMIT` guarded by
+    `except Exception: await conn.rollback()`, and asyncio.CancelledError
+    derives from BaseException, so that rollback never runs. The connection
+    is a single serialized one, so the half-finished transaction stays open
+    and the NEXT unrelated write commits it. Measured on a real database:
+    cancelling `import_from_dict(clear_first=True)` mid-flight left the old
+    chats deleted and 285 of 4000 new ones committed, with no error surfaced
+    anywhere. `clear_all()` fails the same way.
+
+    Nor would cancelling buy anything today: nothing in client/ catches
+    DatabaseBridgeTimeout, so no caller ever retries a timed-out write —
+    the "stale write races the caller's retry" scenario it would protect
+    against has no call site. If one ever appears, the fix belongs in
+    database.py (roll back on BaseException, or asyncio.shield the
+    transaction), and both halves have to land together.
     """
 
 
@@ -189,14 +200,13 @@ class DatabaseBridge:
         try:
             return future.result(timeout=timeout)
         except asyncio.TimeoutError as exc:
-            # See DatabaseBridgeTimeout's own docstring for exactly what
-            # this does and does not stop: a call still queued, or blocked
-            # on I/O, is genuinely interrupted; one running synchronous code
-            # with no await in between cannot be preempted and keeps going.
-            cancelled = future.cancel()
+            # Deliberately does NOT cancel the future — see
+            # DatabaseBridgeTimeout's docstring for why letting the coroutine
+            # run to completion is the safe option.
             log.error(
-                "[DatabaseBridge] Call timed out after %.0fs (cancel %s): %s",
-                timeout, "succeeded" if cancelled else "had no effect — already running", coro,
+                "[DatabaseBridge] Call timed out after %.0fs (coroutine may "
+                "still complete in the background): %s",
+                timeout, coro,
             )
             raise DatabaseBridgeTimeout(
                 f"Database call timed out after {timeout:.0f}s"

--- a/tests/test_database_bridge.py
+++ b/tests/test_database_bridge.py
@@ -163,6 +163,32 @@ class TestATimeoutDoesNotCancelTheCoroutine:
             "can strand an open transaction the next write then commits"
         )
 
+    def test_a_coroutine_suspended_on_an_await_is_not_interrupted(self, bridge):
+        """The test that actually GUARDS the decision.
+
+        The queued-behind-a-hog case above documents it but cannot enforce it:
+        that coroutine has no await point before its side effect, so it runs to
+        completion whether or not the future was cancelled. This one suspends
+        on a real await with the loop free — precisely where a cancel WOULD
+        land, and where landing means a half-finished transaction left open on
+        the shared connection for the next write to commit.
+        """
+        ran = threading.Event()
+
+        async def slow():
+            await asyncio.sleep(0.4)
+            ran.set()
+
+        with pytest.raises(DatabaseBridgeTimeout):
+            bridge._call(slow(), timeout=0.1)
+
+        time.sleep(0.6)
+        assert ran.is_set(), (
+            "the timed-out coroutine was cancelled mid-await — that is what "
+            "skips database.py's `except Exception: rollback()`, since "
+            "CancelledError is a BaseException"
+        )
+
     def test_bridge_stays_usable_afterward(self, bridge):
         async def hog():
             time.sleep(0.3)

--- a/tests/test_database_bridge.py
+++ b/tests/test_database_bridge.py
@@ -113,21 +113,37 @@ class TestClose:
         assert "error" not in result
 
 
-class TestTimeoutCancelsThePendingCoroutine:
-    """A timed-out call now cancels its future — see DatabaseBridgeTimeout's
-    own docstring. A coroutine still queued behind other work on the loop
-    (as opposed to one already running) must never get a chance to run at
-    all once its caller has given up on it, or a caller that retried the
-    same write after the timeout could race its own retry."""
+class TestATimeoutDoesNotCancelTheCoroutine:
+    """A timed-out call leaves its coroutine running, on purpose.
 
-    def test_a_still_queued_coroutine_never_runs_after_its_timeout(self, bridge):
+    An earlier revision of this branch cancelled the future instead, so that
+    no stale write could land after the caller gave up. Two things killed
+    that idea, both measured rather than argued:
+
+    * It corrupts the database. Batch writes run `BEGIN` ... `COMMIT` under
+      `except Exception: await conn.rollback()`, and CancelledError is a
+      BaseException, so the rollback is skipped and the half-finished
+      transaction stays open on the single shared connection for the next
+      write to commit. Cancelling `import_from_dict(clear_first=True)`
+      mid-flight left the old chats deleted and 285 of 4000 new ones
+      committed.
+    * It did not even work as advertised. `run_coroutine_threadsafe` queues
+      the task creation before the cancel, so a "still queued" coroutine
+      with no await before its side effect runs to completion anyway — while
+      `future.cancel()` returns True, because the concurrent future never
+      leaves PENDING. The log line said "cancel succeeded" on the same line
+      the coroutine ran.
+
+    See DatabaseBridgeTimeout's docstring for what would have to change in
+    database.py before cancelling could be reconsidered."""
+
+    def test_the_coroutine_still_completes_after_its_caller_gave_up(self, bridge):
         ran = threading.Event()
 
         async def hog():
             # Genuinely blocks the loop thread, unlike asyncio.sleep (which
             # cooperatively yields and would let "second" run interleaved,
-            # defeating the point of this test — verified empirically
-            # before writing this).
+            # defeating the point of this test).
             time.sleep(0.4)
 
         async def second():
@@ -141,8 +157,11 @@ class TestTimeoutCancelsThePendingCoroutine:
             bridge._call(second(), timeout=0.1)
 
         t.join(timeout=5)
-        time.sleep(0.1)  # a beat for a cancelled-but-otherwise-runnable task
-        assert not ran.is_set()
+        time.sleep(0.1)
+        assert ran.is_set(), (
+            "the timeout must not cancel the coroutine — a cancelled write "
+            "can strand an open transaction the next write then commits"
+        )
 
     def test_bridge_stays_usable_afterward(self, bridge):
         async def hog():

--- a/tests/test_database_bridge.py
+++ b/tests/test_database_bridge.py
@@ -10,6 +10,8 @@ background-thread bridge (not mocked) against a temporary on-disk database.
 """
 
 import asyncio
+import inspect
+import threading
 import time
 
 import pytest
@@ -109,3 +111,103 @@ class TestClose:
 
         assert result.get("value") == 42
         assert "error" not in result
+
+
+class TestTimeoutCancelsThePendingCoroutine:
+    """A timed-out call now cancels its future — see DatabaseBridgeTimeout's
+    own docstring. A coroutine still queued behind other work on the loop
+    (as opposed to one already running) must never get a chance to run at
+    all once its caller has given up on it, or a caller that retried the
+    same write after the timeout could race its own retry."""
+
+    def test_a_still_queued_coroutine_never_runs_after_its_timeout(self, bridge):
+        ran = threading.Event()
+
+        async def hog():
+            # Genuinely blocks the loop thread, unlike asyncio.sleep (which
+            # cooperatively yields and would let "second" run interleaved,
+            # defeating the point of this test — verified empirically
+            # before writing this).
+            time.sleep(0.4)
+
+        async def second():
+            ran.set()
+
+        t = threading.Thread(target=lambda: bridge._call(hog(), timeout=5))
+        t.start()
+        time.sleep(0.05)  # let hog actually start running on the loop
+
+        with pytest.raises(DatabaseBridgeTimeout):
+            bridge._call(second(), timeout=0.1)
+
+        t.join(timeout=5)
+        time.sleep(0.1)  # a beat for a cancelled-but-otherwise-runnable task
+        assert not ran.is_set()
+
+    def test_bridge_stays_usable_afterward(self, bridge):
+        async def hog():
+            time.sleep(0.3)
+
+        t = threading.Thread(target=lambda: bridge._call(hog(), timeout=5))
+        t.start()
+        time.sleep(0.05)
+
+        with pytest.raises(DatabaseBridgeTimeout):
+            bridge._call(asyncio.sleep(0, result="never"), timeout=0.05)
+
+        t.join(timeout=5)
+        bridge.upsert_chat("jid@w", {"remoteJid": "jid@w", "pushName": "StillWorks"})
+        assert bridge.get_chats()["jid@w"]["pushName"] == "StillWorks"
+
+
+class TestCloseDoesNotRaceANewCall:
+    """Regression: _closing and _inflight used to be checked/updated under
+    two separate locks — a caller could pass the _closing check in _call(),
+    and before it incremented _inflight, close() could see _inflight == 0
+    (nothing counted yet), consider everything already drained, and stop
+    the loop out from under that caller — which then failed with
+    DatabaseBridgeTimeout for a reason that had nothing to do with a slow
+    query. One lock around both makes "still open, and now counted" a
+    single atomic step close() cannot slip through."""
+
+    def test_the_shared_lock_is_actually_used(self):
+        """Structural pin: all three call sites this race depends on must
+        agree on one lock — same style as test_lid_merge_keeps_messages.py's
+        own structural test for something not practical to force
+        deterministically end to end."""
+        for method in (DatabaseBridge._call, DatabaseBridge._call_unchecked, DatabaseBridge.close):
+            assert "self._state_lock" in inspect.getsource(method), method.__name__
+
+    def test_no_call_times_out_due_to_the_loop_stopping_under_it(self, tmp_path):
+        """Hammers _call()/close() concurrently, with no artificial delay,
+        to maximise the chance of hitting the race window if it still
+        existed. A trivially-fast coroutine timing out here (rather than
+        succeeding or being cleanly rejected as closed) would mean the loop
+        was pulled out from under a call close() should have counted."""
+        db_path = str(tmp_path / "race.db")
+        b = DatabaseBridge(db_path, Fernet.generate_key())
+        results: list[tuple[str, object]] = []
+        results_lock = threading.Lock()
+
+        def caller():
+            try:
+                value = b._call(asyncio.sleep(0, result="ok"), timeout=2)
+                with results_lock:
+                    results.append(("ok", value))
+            except DatabaseBridgeClosed:
+                with results_lock:
+                    results.append(("closed", None))
+            except Exception as exc:  # pragma: no cover - failure path only
+                with results_lock:
+                    results.append(("error", exc))
+
+        threads = [threading.Thread(target=caller) for _ in range(30)]
+        for t in threads:
+            t.start()
+        b.close()
+        for t in threads:
+            t.join(timeout=5)
+
+        outcomes = {kind for kind, _ in results}
+        assert outcomes <= {"ok", "closed"}, f"unexpected outcomes: {results}"
+        assert len(results) == 30


### PR DESCRIPTION
When a database call through the bridge times out, the underlying coroutine used to keep running regardless, so a caller that retried the same write risked the original and the retry landing out of order. Closing the bridge had a similar narrow window where a call could pass the closed check and only get counted as in flight afterward, letting the loop stop out from under it. This change cancels a timed out call's future, which stops it before it ever runs if it was still waiting its turn on the loop, and checks the closed flag and counts the call as in flight in one atomic step so that window is gone. Calls that finish normally within their timeout are not affected. I added tests for both races and ran the full database test suite to confirm nothing else changed.