### PR TITLE
Detect when switching accounts fails to actually launch

### DIFF
--- a/client/account_launcher.py
+++ b/client/account_launcher.py
@@ -16,6 +16,12 @@ from __future__ import annotations
 import logging
 import subprocess
 import sys
+import time
+
+# Long enough to catch a spawn that fails almost immediately (missing DLL,
+# corrupted install, blocked by antivirus) without noticeably freezing the
+# UI for what is otherwise a rare, deliberate user action.
+_SPAWN_VERIFY_DELAY = 0.3
 
 
 def build_launch_command(argv0: str, executable: str, account_id: str,
@@ -38,21 +44,37 @@ def build_launch_command(argv0: str, executable: str, account_id: str,
 
 
 def switch_to_account(global_dir: str, account_id: str,
-                      frozen: bool | None = None) -> bool:
+                      frozen: bool | None = None) -> str:
     """Switch to ``account_id``: activate its running process if any, else spawn.
 
-    Returns True if an existing process was activated, False if a new one was
-    spawned (or spawn failed — see log). The current window stays open (1b).
+    Returns "activated" if an existing process answered the IPC request,
+    "spawned" if a new process was started and was still running a moment
+    later, or "failed" if the spawn itself raised or the process died
+    almost immediately (missing DLL, corrupted install, blocked by
+    antivirus). Before this, both "spawned fine" and "failed to spawn" were
+    the same plain False — a caller had no way to tell a genuine failure
+    apart from a normal spawn, so a crashed target silently left the user
+    with no indication the switch never actually happened. The current
+    window stays open (1b) unless the caller decides otherwise.
     """
     import ipc
 
     if ipc.request_activate(global_dir, account_id, source="user"):
-        return True
+        return "activated"
     if frozen is None:
         frozen = getattr(sys, "frozen", False)
     try:
-        subprocess.Popen(build_launch_command(
+        proc = subprocess.Popen(build_launch_command(
             sys.argv[0], sys.executable, account_id, frozen, startup_source="user"))
     except Exception:
         logging.exception("[switch_to_account] failed to spawn %s", account_id)
-    return False
+        return "failed"
+
+    time.sleep(_SPAWN_VERIFY_DELAY)
+    if proc.poll() is not None:
+        logging.error(
+            "[switch_to_account] %s exited immediately after spawning (code=%s)",
+            account_id, proc.returncode,
+        )
+        return "failed"
+    return "spawned"

--- a/client/account_launcher.py
+++ b/client/account_launcher.py
@@ -48,9 +48,11 @@ def switch_to_account(global_dir: str, account_id: str,
     """Switch to ``account_id``: activate its running process if any, else spawn.
 
     Returns "activated" if an existing process answered the IPC request,
-    "spawned" if a new process was started and was still running a moment
-    later, or "failed" if the spawn itself raised or the process died
-    almost immediately (missing DLL, corrupted install, blocked by
+    "spawned" if a new process was started and either was still running a
+    moment later or had already exited cleanly (see the poll() check for why
+    exit code 0 counts as success), or "failed" if the spawn itself raised or
+    the process died with a nonzero code almost immediately (missing DLL,
+    corrupted install, blocked by
     antivirus). Before this, both "spawned fine" and "failed to spawn" were
     the same plain False — a caller had no way to tell a genuine failure
     apart from a normal spawn, so a crashed target silently left the user
@@ -71,7 +73,15 @@ def switch_to_account(global_dir: str, account_id: str,
         return "failed"
 
     time.sleep(_SPAWN_VERIFY_DELAY)
-    if proc.poll() is not None:
+    # A clean exit is NOT a failure. The spawned process legitimately exits 0
+    # when it loses the single-instance race: it fails to take the mutex,
+    # forwards its own ipc.request_activate() and quits (see main.py's
+    # startup path). That happens exactly when our request_activate above
+    # lost to a stale socket or a busy target — i.e. the switch DID work, and
+    # reporting "failed" there would show the user an error box on top of a
+    # window that just came to the front. Only a nonzero code means the
+    # process actually died on us (missing DLL, corrupted install, AV block).
+    if proc.poll() not in (None, 0):
         logging.error(
             "[switch_to_account] %s exited immediately after spawning (code=%s)",
             account_id, proc.returncode,

--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -315,6 +315,7 @@
     "menu_disconnect": "&Disconnect",
     "disconnect_confirm_title": "Disconnect",
     "disconnect_confirm_msg": "Are you sure you want to disconnect? This will remove the pairing and local data for this account.",
+    "account_switch_failed": "Could not switch accounts. The other WinZapp process failed to start.",
     "menu_exit": "E&xit",
     "menu_sync": "S&ync",
     "menu_resync_all": "&Resync all chats",

--- a/client/languages/es-ES.json
+++ b/client/languages/es-ES.json
@@ -315,6 +315,7 @@
     "menu_disconnect": "&Desconectar",
     "disconnect_confirm_title": "Desconectar",
     "disconnect_confirm_msg": "¿Seguro que deseas desconectar? Esto eliminará el emparejamiento y los datos locales de esta cuenta.",
+    "account_switch_failed": "No se pudo cambiar de cuenta. El otro proceso de WinZapp no se pudo iniciar.",
     "menu_exit": "&Salir",
     "menu_sync": "&Sincronización",
     "menu_resync_all": "&Resincronizar todas las conversaciones",

--- a/client/languages/pl.json
+++ b/client/languages/pl.json
@@ -315,6 +315,7 @@
     "menu_disconnect": "&Rozłącz",
     "disconnect_confirm_title": "Rozłącz",
     "disconnect_confirm_msg": "Czy na pewno chcesz się rozłączyć? Spowoduje to usunięcie parowania i danych lokalnych tego konta.",
+    "account_switch_failed": "Nie udało się przełączyć konta. Nie udało się uruchomić drugiego procesu WinZapp.",
     "menu_exit": "Za&kończ",
     "menu_sync": "S&ynchronizacja",
     "menu_resync_all": "&Zsynchronizuj ponownie wszystkie rozmowy",

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -315,6 +315,7 @@
     "menu_disconnect": "&Desconectar",
     "disconnect_confirm_title": "Desconectar",
     "disconnect_confirm_msg": "Tem certeza de que deseja desconectar? Isso removerá o pareamento e os dados locais desta conta.",
+    "account_switch_failed": "Não foi possível trocar de conta. O outro processo do WinZapp falhou ao iniciar.",
     "menu_exit": "&Sair",
     "menu_sync": "&Sincronização",
     "menu_resync_all": "&Ressincronizar todas as conversas",

--- a/client/languages/pt-PT.json
+++ b/client/languages/pt-PT.json
@@ -315,6 +315,7 @@
     "menu_disconnect": "&Desconectar",
     "disconnect_confirm_title": "Desconectar",
     "disconnect_confirm_msg": "Tem a certeza de que pretende desconectar? Isto vai remover o emparelhamento e os dados locais desta conta.",
+    "account_switch_failed": "Não foi possível trocar de conta. O outro processo do WinZapp falhou ao iniciar.",
     "menu_exit": "&Sair",
     "menu_sync": "&Sincronização",
     "menu_resync_all": "&Ressincronizar todas as conversas",

--- a/client/main.py
+++ b/client/main.py
@@ -2098,9 +2098,21 @@ class MainWindow(wx.Frame):
         stays open (accounts run in the background, choice 1b)."""
         try:
             from account_launcher import switch_to_account
-            activated = switch_to_account(self.global_dir, account_id)
-            logging.info("[accounts] switch to %s -> %s", account_id,
-                         "activated existing process" if activated else "spawned new process")
+            result = switch_to_account(self.global_dir, account_id)
+            logging.info("[accounts] switch to %s -> %s", account_id, result)
+            if result == "failed":
+                # Before this, a spawn that raised or crashed immediately
+                # (missing DLL, corrupted install, blocked by antivirus)
+                # was indistinguishable from a normal spawn — the button
+                # just did nothing, with the switch never having actually
+                # happened and no indication why. Stay open and visible
+                # instead of hiding into a switch that never completed.
+                wx.MessageBox(
+                    self.i18n.t("account_switch_failed"),
+                    self.i18n.t("error").format(app_name=self.app_name),
+                    wx.OK | wx.ICON_ERROR,
+                )
+                return
             switch_behavior = "single"
             if getattr(self, "app_settings", None):
                 switch_behavior = self.app_settings.get("switch_behavior")
@@ -2186,7 +2198,21 @@ class MainWindow(wx.Frame):
             if result == account_ui.UnpairedStartDialog.RESULT_SWITCH and dlg.chosen_account_id:
                 logging.info("[accounts] unpaired start: switching to %s", dlg.chosen_account_id)
                 from account_launcher import switch_to_account
-                switch_to_account(self.global_dir, dlg.chosen_account_id)
+                switch_result = switch_to_account(self.global_dir, dlg.chosen_account_id)
+                if switch_result == "failed":
+                    # This path used to exit unconditionally right after —
+                    # a failed spawn (missing DLL, corrupted install,
+                    # blocked by antivirus) left the user with no WinZapp
+                    # process running at all, since this one was about to
+                    # quit into a switch that never actually happened.
+                    # Fall through to this account's own pairing flow
+                    # instead of exiting into nothing.
+                    wx.MessageBox(
+                        self.i18n.t("account_switch_failed"),
+                        self.i18n.t("error").format(app_name=self.app_name),
+                        wx.OK | wx.ICON_ERROR,
+                    )
+                    return False
                 wx.CallAfter(self.real_exit)
                 return True
             if result == account_ui.UnpairedStartDialog.RESULT_QUIT:

--- a/tests/test_account_launcher.py
+++ b/tests/test_account_launcher.py
@@ -107,3 +107,94 @@ class TestSwitchToAccount:
         monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: _FakeProcess(exit_code=1))
 
         assert switch_to_account("gd", A, frozen=True) == "failed"
+
+    def test_a_clean_exit_is_not_a_failure(self, monkeypatch):
+        """Exit code 0 means the child lost the single-instance race: it could
+        not take the mutex, forwarded its own ipc.request_activate() and quit.
+        That happens precisely when our own request_activate lost to a stale
+        socket or a busy target — so the switch DID work, and calling it
+        "failed" would put an error box on top of a window that just came to
+        the front."""
+        monkeypatch.setattr(ipc, "request_activate", lambda *a, **k: False)
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: _FakeProcess(exit_code=0))
+
+        assert switch_to_account("gd", A, frozen=True) == "spawned"
+
+
+class _MainWindowStub:
+    """Only what the two MainWindow methods under test actually touch.
+
+    ConversationsPanel/MainWindow are wx classes that cannot be instantiated
+    without a running wx.App, so the unbound methods are bound onto this
+    plain object — the pattern the rest of this suite uses.
+    """
+
+    def __init__(self):
+        self.global_dir = "gd"
+        self.account_id = A
+        self.app_name = "WinZapp"
+        self.app_settings = None
+        self.settings = {"general": {"switch_behavior": "single"}}
+        self.hidden_to_tray = False
+        self.message_boxes = []
+        self.exited = False
+
+    def hide_to_tray(self):
+        self.hidden_to_tray = True
+
+    def real_exit(self):
+        self.exited = True
+
+    class _I18n:
+        @staticmethod
+        def t(key):
+            return "{app_name} Error" if key == "error" else key
+
+    i18n = _I18n()
+
+
+@pytest.fixture
+def stub(monkeypatch):
+    """Bind the two real methods onto the stub and neutralise wx."""
+    import main
+
+    s = _MainWindowStub()
+    monkeypatch.setattr(
+        main.wx, "MessageBox",
+        lambda msg, caption="", style=0, *a, **k: s.message_boxes.append(msg),
+    )
+    monkeypatch.setattr(main.wx, "CallAfter", lambda fn, *a, **k: fn(*a, **k))
+    s._switch_to_account = main.MainWindow._switch_to_account.__get__(s)
+    s._offer_switch_when_unpaired = main.MainWindow._offer_switch_when_unpaired.__get__(s)
+    return s
+
+
+class TestAFailedSwitchIsVisibleAndNonDestructive:
+    """The behaviour this PR actually delivers to the user. switch_to_account()
+    returning "failed" is only useful if the callers act on it — and both of
+    them previously did something irreversible on the assumption the switch
+    had worked."""
+
+    def test_a_failed_switch_does_not_hide_to_tray(self, stub, monkeypatch):
+        """Hiding into a switch that never happened leaves the user with no
+        visible window and no idea why the button did nothing."""
+        import main
+        monkeypatch.setattr(main, "switch_to_account", lambda *a, **k: "failed",
+                            raising=False)
+        monkeypatch.setattr(account_launcher, "switch_to_account",
+                            lambda *a, **k: "failed")
+
+        stub._switch_to_account("b" * 32)
+
+        assert stub.hidden_to_tray is False
+        assert stub.message_boxes, "the user must be told the switch failed"
+
+    def test_a_successful_switch_still_hides_to_tray(self, stub, monkeypatch):
+        """The guard must not cost the normal path its behaviour."""
+        monkeypatch.setattr(account_launcher, "switch_to_account",
+                            lambda *a, **k: "spawned")
+
+        stub._switch_to_account("b" * 32)
+
+        assert stub.hidden_to_tray is True
+        assert not stub.message_boxes

--- a/tests/test_account_launcher.py
+++ b/tests/test_account_launcher.py
@@ -1,6 +1,28 @@
-"""Tests for client/account_launcher.py — spawn command construction (pure)."""
+"""Tests for client/account_launcher.py — spawn command construction (pure)
+plus switch_to_account()'s activate-or-spawn decision and spawn-failure
+detection.
 
-from account_launcher import build_launch_command
+Before this change, switch_to_account() returned a plain bool that only
+ever distinguished "activated an existing process" from everything else —
+a Popen() that raised outright and a spawn that started fine were both the
+same False, so a caller had no way to tell a genuine failure (missing DLL,
+corrupted install, blocked by antivirus) apart from a normal spawn. It now
+returns one of three strings ("activated"/"spawned"/"failed"), verified by
+polling the spawned process a moment after starting it — see the function's
+own docstring.
+
+ipc.request_activate and subprocess.Popen are the only I/O this function
+does; both are monkeypatched so these tests need no real second process or
+IPC listener.
+"""
+
+import subprocess
+
+import pytest
+
+import account_launcher
+import ipc
+from account_launcher import build_launch_command, switch_to_account
 
 A = "a" * 32
 
@@ -33,3 +55,55 @@ def test_dev_command_uses_interpreter_and_script():
 def test_account_value_follows_flag():
     cmd = build_launch_command("x.exe", "py", A, frozen=True, startup_source="user")
     assert cmd[cmd.index("--account") + 1] == A
+
+
+class _FakeProcess:
+    def __init__(self, exit_code=None):
+        self.returncode = exit_code
+
+    def poll(self):
+        return self.returncode
+
+
+@pytest.fixture(autouse=True)
+def _no_real_delay(monkeypatch):
+    """The spawn-verification sleep is real production behaviour (give a
+    just-spawned process a moment before polling it) but would make every
+    test here pay its cost for nothing — there is no real process on the
+    other end."""
+    monkeypatch.setattr(account_launcher.time, "sleep", lambda *_a, **_k: None)
+
+
+class TestSwitchToAccount:
+    def test_an_already_running_process_is_activated_not_spawned(self, monkeypatch):
+        monkeypatch.setattr(ipc, "request_activate", lambda *a, **k: True)
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda *a, **k: pytest.fail("should not spawn when activation succeeds"),
+        )
+
+        assert switch_to_account("gd", A) == "activated"
+
+    def test_a_healthy_spawn_that_is_still_running_reports_spawned(self, monkeypatch):
+        monkeypatch.setattr(ipc, "request_activate", lambda *a, **k: False)
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: _FakeProcess(exit_code=None))
+
+        assert switch_to_account("gd", A, frozen=True) == "spawned"
+
+    def test_popen_raising_reports_failed(self, monkeypatch):
+        monkeypatch.setattr(ipc, "request_activate", lambda *a, **k: False)
+
+        def _raise(*a, **k):
+            raise OSError("no such file")
+        monkeypatch.setattr(subprocess, "Popen", _raise)
+
+        assert switch_to_account("gd", A, frozen=True) == "failed"
+
+    def test_a_process_that_exits_immediately_reports_failed(self, monkeypatch):
+        """The case this fix actually closes: Popen() itself succeeded, but
+        the child crashed (missing DLL, corrupted install, blocked by
+        antivirus) before this function ever gets a chance to say so."""
+        monkeypatch.setattr(ipc, "request_activate", lambda *a, **k: False)
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: _FakeProcess(exit_code=1))
+
+        assert switch_to_account("gd", A, frozen=True) == "failed"


### PR DESCRIPTION
Switching to another account spawned a new process without ever checking whether it actually stayed running, so a crash right after starting, for example from a corrupted install or antivirus interference, left the switch button doing nothing with no error shown and, in one startup path, could quit the current process into nothing at all. This change gives the spawned process a brief moment to start, checks whether it is still alive, and shows a clear message and stays put if it is not, at the cost of a short pause on every switch instead of none. I added tests covering both a process that exits immediately and one that starts fine, and ran the account test suite to confirm nothing else changed.