### PR TITLE
melhorias nos testes relacionados ao Claude

### DIFF
--- a/tests/locales.py
+++ b/tests/locales.py
@@ -1,0 +1,62 @@
+"""The registered locale set, read once from `languages/language_map.json`.
+
+Not a test module — a helper the locale-parametrized tests derive from, so the
+derivation and the check that it produced anything live in one place.
+
+Why derive at all: the set of locales is data, not code. A locale is added by
+dropping in `<code>.json` plus an entry in that map, with no rebuild
+(CLAUDE.md, "Paths, config, i18n"), so a list written out inside a test goes
+stale the moment one is added and silently stops checking it. That already
+happened — `pl` was missing from the hand-written lists in test_mute.py and
+test_self_reference_label.py, so Polish was never checked by either.
+
+Why the check belongs here rather than in each caller: deriving the list
+introduces a second failure mode in exchange. A hand-written list is at least
+never empty; a derived one is empty if the map is unreadable in a way json
+tolerates (`{}`, or a reshape into a list of objects). Every caller uses it to
+drive a loop or a `parametrize`, and an empty sequence makes those pass with
+zero iterations — a suite that checks nothing and still goes green, which is
+the exact failure the derivation was meant to prevent, moved one level down.
+
+Raising here means a caller cannot obtain the list without the check having
+run: it surfaces as a collection error naming this file, before any test in
+any of those modules reports success.
+"""
+
+import json
+from pathlib import Path
+
+LANGUAGES_DIR = Path(__file__).resolve().parents[1] / "client" / "languages"
+LANGUAGE_MAP = LANGUAGES_DIR / "language_map.json"
+
+#: The locale WinZapp falls back to, and the one guaranteed to be complete.
+#: Its presence doubles as a shape check: a map that parsed but lost its
+#: `{code: display name}` form (a list of objects, say) yields keys that are
+#: not locale codes at all, and this is what notices.
+DEFAULT_LOCALE = "pt-BR"
+
+
+def registered_locale_codes() -> tuple[str, ...]:
+    """Every locale code in language_map.json, sorted.
+
+    Raises rather than returning something empty — see the module docstring.
+    """
+    codes = tuple(sorted(json.loads(LANGUAGE_MAP.read_text(encoding="utf-8"))))
+    if not codes:
+        raise AssertionError(
+            f"{LANGUAGE_MAP} registers no locales, so every test deriving its "
+            f"locale list from it would run zero cases and still pass."
+        )
+    if DEFAULT_LOCALE not in codes:
+        raise AssertionError(
+            f"{LANGUAGE_MAP} does not register {DEFAULT_LOCALE!r}, the locale the "
+            f"app defaults to. Either it was removed — which breaks the fallback "
+            f"i18n.t() relies on — or the file is no longer a {{code: name}} map. "
+            f"Got: {list(codes)}"
+        )
+    return codes
+
+
+def registered_locale_files() -> tuple[str, ...]:
+    """`<code>.json` for every registered locale, in the same order."""
+    return tuple(f"{code}.json" for code in registered_locale_codes())

--- a/tests/test_claude_md_matches_reality.py
+++ b/tests/test_claude_md_matches_reality.py
@@ -244,3 +244,55 @@ def test_every_path_claude_md_names_exists():
         f"CLAUDE.md points at paths that do not exist. If they were renamed, "
         f"update the doc; if they were deleted, delete the claim: {missing}"
     )
+
+
+# ── the same claims, restated under .claude/ ─────────────────────────────────
+
+# CLAUDE.md is not the only prose steering work in this repo any more: the
+# skills and agents under .claude/ restate a good deal of the same
+# architecture, and they name the same paths. Nothing watched them, so the
+# guarantee this file provides stopped at one file while the surface it
+# describes grew past it — the identical hazard CLAUDE.md's own "one document,
+# one place to update it" note exists for.
+#
+# Only path existence is checked here, not counts or prose: a path is a claim
+# with exactly one right answer, and a dangling one turns "go read
+# client/foo.py" into a dead end for whichever agent loads that skill. The
+# looser claims stay CLAUDE.md's alone, which is where they belong.
+CLAUDE_DIR = ROOT / ".claude"
+
+#: Low deliberately. This is a floor against the glob silently finding nothing
+#: (a directory rename, a layout change), not a count of the docs that happen
+#: to exist today — a skill being retired must not turn this red.
+CLAUDE_DOC_FLOOR = 5
+
+
+def _claude_docs():
+    return sorted(CLAUDE_DIR.rglob("*.md"))
+
+
+def test_the_claude_directory_docs_are_still_being_found():
+    """Guards the glob the way PATH_FLOOR guards the regex above: with no
+    files matched, the parametrized test below runs zero cases and passes."""
+    found = _claude_docs()
+    assert len(found) >= CLAUDE_DOC_FLOOR, (
+        f"only {len(found)} Markdown file(s) found under {CLAUDE_DIR} (floor "
+        f"{CLAUDE_DOC_FLOOR}) — the skills/agents layout probably moved and "
+        f"their paths stopped being checked. Found: {[str(p) for p in found]}"
+    )
+
+
+@pytest.mark.parametrize(
+    "doc", _claude_docs(), ids=lambda p: str(p.relative_to(ROOT)).replace("\\", "/")
+)
+def test_every_path_a_claude_doc_names_exists(doc):
+    documented = {
+        p for p in _DOC_PATH.findall(doc.read_text(encoding="utf-8"))
+        if not p.startswith(UNCHECKABLE_PREFIXES)
+    }
+    missing = sorted(p for p in documented if not (ROOT / p).exists())
+    assert missing == [], (
+        f"{doc.relative_to(ROOT)} points at paths that do not exist. A skill or "
+        f"agent that sends the reader to a deleted file is worse than one that "
+        f"says nothing: {missing}"
+    )

--- a/tests/test_menu_mnemonics_dont_collide.py
+++ b/tests/test_menu_mnemonics_dont_collide.py
@@ -17,13 +17,15 @@ import re
 
 from app_paths import resource_path
 
+from tests.locales import registered_locale_codes
+
 #: Derived from language_map.json, not repeated here — the set of locales is
 #: data, not code (a locale is added by dropping in `<code>.json` plus an entry
 #: in that map, with no rebuild), so a list written out here goes stale the
-#: moment one is added and silently stops checking it.
-LOCALES = sorted(
-    json.load(open(resource_path("languages", "language_map.json"), encoding="utf-8"))
-)
+#: moment one is added and silently stops checking it. Through the shared
+#: helper because the derivation has to be checked for emptiness before it is
+#: looped over — see tests/locales.py.
+LOCALES = list(registered_locale_codes())
 
 # Every label MainWindow._build_menubar() adds directly to the wx.MenuBar,
 # in i18n key form. acc_menu_title (Accounts) is intentionally excluded: it

--- a/tests/test_mute.py
+++ b/tests/test_mute.py
@@ -86,13 +86,15 @@ class TestMutePresets:
 
     def test_every_preset_key_is_translated_in_every_locale(self):
         import json
-        import pathlib
 
-        langs = pathlib.Path(__file__).resolve().parents[1] / "client" / "languages"
+        from tests.locales import LANGUAGES_DIR, registered_locale_codes
+
+        langs = LANGUAGES_DIR
         # From language_map.json rather than written out: pl was missing from
-        # the list this replaces, so it was never checked at all.
-        locales = json.loads((langs / "language_map.json").read_text(encoding="utf-8"))
-        for locale in sorted(locales):
+        # the list this replaces, so it was never checked at all. Through the
+        # shared helper so an empty map cannot turn this loop into zero
+        # iterations and still pass — see tests/locales.py.
+        for locale in registered_locale_codes():
             strings = json.loads((langs / f"{locale}.json").read_text(encoding="utf-8"))
             for key, _ in ConversationsPanel.MUTE_PRESETS:
                 assert strings.get(key), f"{locale} is missing {key}"

--- a/tests/test_self_reference_label.py
+++ b/tests/test_self_reference_label.py
@@ -27,6 +27,8 @@ import pytest
 
 from main import MainWindow
 
+from tests.locales import registered_locale_files
+
 
 class _FakeI18n:
     _STRINGS = {
@@ -86,13 +88,10 @@ LANG_DIR = os.path.join(os.path.dirname(__file__), "..", "client", "languages")
 #: Every registered locale, from language_map.json — pl used to be left out
 #: of this list, and this is the only check that the two keys are *distinct*
 #: (the union check in test_language_files_in_sync.py catches a missing or
-#: blank value, never two identical ones).
-_LANG_FILES = [
-    f"{code}.json"
-    for code in sorted(
-        json.load(open(os.path.join(LANG_DIR, "language_map.json"), encoding="utf-8"))
-    )
-]
+#: blank value, never two identical ones). Through the shared helper so an
+#: empty derivation cannot quietly turn the parametrize below into zero cases
+#: — see tests/locales.py.
+_LANG_FILES = list(registered_locale_files())
 
 
 @pytest.mark.parametrize("lang_file", _LANG_FILES)


### PR DESCRIPTION
Duas pendências da revisão dos commits pós-105d785.

test: o guard de lista vazia valia em 1 dos 4 arquivos que derivam locales

Trocar as listas escritas à mão por language_map.json corrigiu um bug real
(pl estava fora de duas delas e o polonês nunca era checado), mas trouxe um
modo de falha novo em troca: uma lista escrita à mão pelo menos nunca está
vazia, e uma derivada fica vazia se o mapa virar algo que o json aceita mas
não é mais `{código: nome}` — `{}`, ou uma lista de objetos. Todos os
chamadores usam a lista para um laço ou um parametrize, e uma sequência
vazia faz esses testes passarem com zero iterações. É exatamente a falha que
a derivação existia para evitar, movida um nível abaixo.

O test_i18n_keys_exist.py já tratava disso com um teste próprio; os outros
três (test_mute, test_self_reference_label, test_menu_mnemonics_dont_collide)
não. Em vez de copiar o mesmo teste mais três vezes, a derivação virou
tests/locales.py e a checagem mora nela: não dá para obter a lista sem que a
checagem tenha rodado, e falha como erro de coleção nomeando o arquivo, antes
de qualquer teste daqueles módulos reportar sucesso. A presença de pt-BR vai
junto porque dobra como checagem de formato — um mapa que virou lista de
objetos ainda produz chaves, só que não são códigos de locale.

test(docs): os caminhos citados em .claude/ também são checados

O CLAUDE.md deixou de ser a única prosa que orienta trabalho aqui: os skills
e agentes sob .claude/ reafirmam boa parte da mesma arquitetura e citam os
mesmos caminhos, e nada os vigiava — a garantia deste arquivo parava em um
arquivo enquanto a superfície que ele descreve crescia além dele. É o mesmo
risco que o próprio AGENTS.md levantou quando entrou como cópia literal.

Só existência de caminho, não contagens nem prosa: um caminho é uma
afirmação com exatamente uma resposta certa, e um pendurado transforma "vá
ler client/foo.py" num beco sem saída para o agente que carregar aquele
skill. As afirmações mais frouxas seguem sendo só do CLAUDE.md.

Com floor próprio contra o glob não achar nada, no mesmo espírito do
PATH_FLOOR — deliberadamente baixo, porque aposentar um skill não pode virar
vermelho. Um teste por arquivo, então a falha nomeia qual.

Confirmado que os dois guards têm dentes: com language_map.json = {} os três
módulos falham na coleção com "registers no locales" em vez de passarem
vazios; com um caminho inexistente colado num SKILL.md, o teste falha
nomeando o arquivo e o caminho. Suíte: 3650 passando (3634 com -m "not
docs", que é o que o release.yml roda).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
