### PR TITLE
test: fixar o estado de nao-incomodar do Windows na suite inteira

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,46 @@ def wx_app():
     return wx.App()
 
 
+# ── Fixtures: Windows notification state ─────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _no_do_not_disturb(request, monkeypatch):
+    """Pin Windows' do-not-disturb state to OFF for the whole suite.
+
+    core.quiet_hours.is_quiet_hours_active() reads the REAL machine: registry
+    notification switches, WNF, WinRT and SHQueryUserNotificationState. That
+    makes any test touching the notification path pass or fail according to
+    whatever the machine running it happens to be doing — and a headless
+    GitHub Actions runner is not doing the same thing as a developer desktop.
+
+    It cost an alpha release to learn that twice. The gate started out
+    covering only the background sound, so a handful of files monkeypatched it
+    one by one and that was enough. Then it grew to suppress the entire
+    notification — banner included — and every _dispatch() test in
+    test_notifications.py started failing on CI only, with the local suite
+    green: on the runner the real state reads as suppressed, so no toast was
+    ever shown and the assertions had nothing to look at.
+
+    Pinning it here rather than per file is the point: the next test to touch
+    _dispatch() will not have to know this exists. A test that genuinely wants
+    do-not-disturb ON monkeypatches it back, which still works because every
+    caller imports the function inside the function body.
+
+    test_quiet_hours.py is exempt — it is the module that tests this very
+    function, and stubbing it there would test the stub.
+    """
+    import core.quiet_hours as quiet_hours
+    exempt = request.node.fspath.purebasename == "test_quiet_hours"
+    quiet_hours.invalidate_cache()
+    if not exempt:
+        monkeypatch.setattr(quiet_hours, "is_quiet_hours_active", lambda: False)
+    # A generator fixture must yield on every path — returning early makes
+    # pytest raise "did not yield a value" for the exempt module.
+    yield
+    quiet_hours.invalidate_cache()
+
+
 # ── Fixtures: Keys / Encryption ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
Corrige a falha de CI que descartou a alpha do commit `533fd5b5`.

## O que aconteceu

`core.quiet_hours.is_quiet_hours_active()` lê a máquina **de verdade** — chaves de registro de notificação, WNF, WinRT e `SHQueryUserNotificationState`. Então todo teste que toca o caminho de notificação passava ou falhava conforme o que a máquina estivesse fazendo, e um runner headless do GitHub Actions não está fazendo o mesmo que um desktop de desenvolvimento.

Enquanto o gate cobria só o som de background, alguns arquivos faziam monkeypatch dele um a um e isso bastava. Quando ele passou a suprimir a notificação inteira — banner incluído —, todo teste de `_dispatch()` em `test_notifications.py` começou a falhar **apenas no CI**, com a suíte local verde: lá o estado real lê como suprimido, então nenhum toast era exibido e as asserções não tinham o que olhar.

## A correção

Fixture `autouse` em `tests/conftest.py`, não por arquivo: o próximo teste que tocar `_dispatch()` não vai precisar saber que isto existe. Quem quiser o não-incomodar **ligado** faz monkeypatch de volta, que continua funcionando porque todo chamador importa a função dentro do corpo da função. `test_quiet_hours.py` fica isento — é o módulo que testa justamente essa função.

## Verificação

Reproduzi a condição do runner localmente (sondas reportando suprimido) e rodei a suíte inteira contra ela, além da execução normal. **4660 passando nas duas condições.**