### PR TITLE
Require confirmation before a self-inflicted session close triggers a logout

### DIFF
--- a/build.py
+++ b/build.py
@@ -301,6 +301,7 @@ API_CUSTOM_SRC_FILES = [
     "src/config.ts",
     "src/util/createSessionUtil.ts",
     "src/util/functions.ts",
+    "src/util/tokenStore/fileTokenStory.ts",
     "src/middleware/statusConnection.ts",
     "src/middleware/auth.ts",
     "src/controller/deviceController.ts",

--- a/client/api_patches/src/config.ts
+++ b/client/api_patches/src/config.ts
@@ -1,5 +1,19 @@
 import { ServerOptions } from './types/ServerOptions';
 
+// customUserDataDir is used as `customUserDataDir + session` (string
+// concatenation, not path.join) to build each session's Puppeteer/Chrome
+// profile directory — see createSessionUtil.ts. Left as the literal default
+// './userDataDir/' it resolves relative to the Node process's own cwd, which
+// is only a stable, persistent location in a --onedir build or dev mode; in
+// --onefile it is PyInstaller's per-launch extraction temp dir, so the whole
+// WhatsApp Web browser profile (and therefore the paired session) is
+// silently orphaned every time the app closes. main.py sets
+// WINZAPP_USER_DATA_DIR to an absolute, install-writable path (with the
+// trailing separator this concatenation needs) before spawning Node; the
+// './userDataDir/' fallback below is only for running this server outside
+// WinZapp entirely.
+const customUserDataDir = process.env.WINZAPP_USER_DATA_DIR || './userDataDir/';
+
 export default {
   secretKey: 'THISISMYSECURETOKEN',
   host: 'http://localhost',
@@ -9,7 +23,7 @@ export default {
   startAllSession: false,
   tokenStoreType: 'file',
   maxListeners: 15,
-  customUserDataDir: './userDataDir/',
+  customUserDataDir,
   webhook: {
     url: null,
     autoDownload: true,

--- a/client/api_patches/src/util/tokenStore/fileTokenStory.ts
+++ b/client/api_patches/src/util/tokenStore/fileTokenStory.ts
@@ -1,0 +1,68 @@
+import * as path from 'path';
+
+import { FileTokenStore as fsTokenStore } from './FileTokenStore/FileTokenStore';
+
+// Upstream never passes a `path` option here, so FileTokenStore falls back
+// to its own hardcoded default ('./tokens', resolved against the Node
+// process's own cwd). That is only a stable, persistent location in a
+// --onedir build or dev mode; in a --onefile build the cwd is PyInstaller's
+// per-launch extraction temp dir (a fresh, differently-named folder every
+// single launch), so the saved auth token is silently orphaned the instant
+// the app closes — the very next launch finds an empty tokens/ folder,
+// wppconnect.log logs "Token store returned no data", and WhatsApp
+// correctly (from its own side) decides the session needs a fresh QR scan.
+// Reported live as "closed WinZapp, relaunched, told the device was
+// disconnected" — with nothing wrong in any of WinZapp's own
+// logout-detection logic, which had already been hardened against exactly
+// that report. main.py sets WINZAPP_TOKEN_STORE_DIR to an absolute,
+// install-writable path before spawning Node; the undefined fallback here
+// (which makes FileTokenStore use its own built-in default) only applies
+// when running this server outside WinZapp entirely.
+// Logged once at module load — Node's module cache means this runs once per
+// server process (i.e. once per WinZapp launch, since each account gets its
+// own Node process), not once per session — so wppconnect.log always states
+// in plain terms exactly where the token file for this run will be read
+// from / written to, no more inferring it from "Token store returned no
+// data" after the fact, or assuming it matches the previous run at all.
+const _resolvedTokenDir = path.resolve(
+  process.cwd(),
+  process.env.WINZAPP_TOKEN_STORE_DIR || './tokens'
+);
+console.log(
+  `[WinZapp] Token store directory: ${_resolvedTokenDir} ` +
+  `(from ${process.env.WINZAPP_TOKEN_STORE_DIR ? 'WINZAPP_TOKEN_STORE_DIR env var' : 'built-in default relative to cwd — NOT persistent in a --onefile build'})`
+);
+
+class FileTokenStore {
+  declare client: any;
+  constructor(client: any) {
+    this.client = client;
+  }
+  tokenStore = new fsTokenStore({
+    ...(process.env.WINZAPP_TOKEN_STORE_DIR
+      ? { path: process.env.WINZAPP_TOKEN_STORE_DIR }
+      : {}),
+    encodeFunction: (data) => {
+      return this.encodeFunction(data, this.client.config);
+    },
+    decodeFunction: (text) => {
+      return this.decodeFunction(text, this.client);
+    },
+  });
+
+  public encodeFunction(data: any, config: any) {
+    data.config = config;
+    return JSON.stringify(data);
+  }
+
+  public async decodeFunction(text: string, client: any): Promise<string[]> {
+    const object = JSON.parse(text);
+    if (object.config && Object.keys(client.config).length === 0)
+      client.config = object.config;
+    if (object.webhook && Object.keys(client.config).length === 0)
+      client.config.webhook = object.webhook;
+    return object;
+  }
+}
+
+export default FileTokenStore;

--- a/client/core/message_queue.py
+++ b/client/core/message_queue.py
@@ -145,10 +145,38 @@ class MessageQueue:
             self._report_cancelled_drop(msg)
         return stopped
 
+    # Bounded wait, in stop(), for a send genuinely on the wire to finish
+    # before returning. _perform_shutdown() calls stop() BEFORE
+    # _stop_wpp_server(), which taskkills the same Node process a worker's
+    # HTTP request is talking to — cutting that off mid-flight turns a send
+    # seconds from succeeding into an ambiguous/lost one for no reason.
+    # Bounded (a stuck upload must never block shutdown forever) and kept
+    # short since it is one of the terms ipc.py's _QUIT_RELEASE_POLL_SECONDS
+    # is sized against — raising it requires raising that too.
+    _STOP_DRAIN_SECONDS = 4.0
+    _STOP_DRAIN_POLL_SECONDS = 0.1
+
     def stop(self):
-        """Signal the worker to exit cleanly (call at app shutdown)."""
+        """Signal the worker to exit cleanly (call at app shutdown).
+
+        Waits briefly (see _STOP_DRAIN_SECONDS) for any in-flight send to
+        finish before returning."""
         self._stop.set()
         self.flush()
+        deadline = time.monotonic() + self._STOP_DRAIN_SECONDS
+        while time.monotonic() < deadline:
+            with self._lock:
+                if not self._in_flight:
+                    return
+            time.sleep(self._STOP_DRAIN_POLL_SECONDS)
+        with self._lock:
+            remaining = len(self._in_flight)
+        if remaining:
+            logging.warning(
+                "[MessageQueue] stop() gave up waiting for %d in-flight "
+                "send(s) after %.1fs — proceeding with shutdown anyway",
+                remaining, self._STOP_DRAIN_SECONDS,
+            )
 
     # ── Worker thread ─────────────────────────────────────────────────────────
 

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -322,6 +322,17 @@ class WebSocketClient:
                 data.get("loggedOut", False)
                 or status_code == 401
             )
+
+            if self.main_window._self_inflicted_teardown_expected():
+                # We are mid our own deliberate shutdown or a WPPConnect
+                # Server auto-update — both POST /close-session themselves
+                # with the WebSocket deliberately left connected throughout,
+                # so this "close" is the direct, expected result of that
+                # call, not WhatsApp unlinking anything. A self-inflicted
+                # close is reported the exact same way as a real phone-side
+                # logout (loggedOut=True / statusCode 401).
+                return
+
             # A connection that closes again — for ANY reason, not just an
             # explicit 401/loggedOut — while a pairing attempt is still in
             # progress and before WPPConnect ever delivered real chat data
@@ -1323,7 +1334,13 @@ class WebSocketClient:
             if status in ("disconnectedMobile", "notLogged", "UNPAIRED", "UNPAIRED_IDLE"):
                 # Handle permanent WhatsApp logout / disconnection.
                 # Only trigger if we were previously fully connected (preventing startup false positives).
-                if self.main_window._wa_connected and self.main_window.settings.get("privateinfo", {}).get("paired"):
+                if self.main_window._self_inflicted_teardown_expected():
+                    # Same self-inflicted-close reasoning as on_connection_update's
+                    # "close" branch: never treat this as a real unlink while we
+                    # are the ones tearing the session down, whether that's a
+                    # full app shutdown or a WPPConnect Server auto-update.
+                    pass
+                elif self.main_window._wa_connected and self.main_window.settings.get("privateinfo", {}).get("paired"):
                     wx.CallAfter(self._handle_logout)
         except Exception:
             logging.exception("[WebSocketClient] on_wpp_status_find error")

--- a/client/ipc.py
+++ b/client/ipc.py
@@ -41,6 +41,28 @@ from coord_locks import canonical_dir
 
 _IS_WINDOWS = sys.platform == "win32"
 
+# How long the LISTENER (the process being asked to quit) polls
+# released_predicate() before giving up and answering with whatever it says
+# at that moment — this decides the "released" reply's truthfulness,
+# independent of the CALLER's own request_quit() timeout below. Must stay >=
+# the target's own worst-case graceful-teardown time (kept as a plain
+# duplicated constant, not a cross-module import, since ipc.py must stay
+# importable before a MainWindow/wx.App exists):
+#   MessageQueue._STOP_DRAIN_SECONDS                  (4s:  in-flight send)
+# + MainWindow._SELF_RESTART_YIELD_SECONDS            (5s:  yield to an
+#   in-progress recovery/in-place session restart)
+# + MainWindow._WPP_GRACEFUL_STOP_SECONDS             (10s: close-session POST)
+# + MainWindow._SHUTDOWN_FLUSH_TIMEOUT                (15s: poll for CLOSED)
+# + MainWindow._TOKEN_PERSIST_GRACE_SECONDS           (5s:  token-file wait)
+# + ~2s taskkill-confirm poll
+# + _flush_pending_debounced_saves()                  (~3s)
+# + DatabaseBridge.close()'s own bounds                (12s)
+# = ~56s realistic worst case; 75s leaves real margin. If any of the budgets
+# above changes, this number and request_quit()'s own default (below) both
+# need re-checking together — raising only one silently reintroduces a
+# "gave up early, answered released:False for a session still flushing" bug.
+_QUIT_RELEASE_POLL_SECONDS = 75.0
+
 
 # ── channel identity ─────────────────────────────────────────────────────────
 def _channel_key(global_dir: str, account_id: str) -> str:
@@ -171,9 +193,10 @@ class IpcListener:
                 break
             # Handed off to its own thread for the same reason as the
             # Windows pipe loop below: a "quit" reply waits here for up to
-            # 10s for released_predicate(), and handling it inline would
-            # stall accept() from picking up any other request (e.g. a
-            # concurrent "activate") for that whole window.
+            # _QUIT_RELEASE_POLL_SECONDS for released_predicate(), and
+            # handling it inline would stall accept() from picking up any
+            # other request (e.g. a concurrent "activate") for that whole
+            # window.
             threading.Thread(target=self._handle_conn, args=(conn,), daemon=True).start()
         try:
             srv.close()
@@ -284,7 +307,8 @@ class IpcListener:
                 time.sleep(0.05)
                 continue
             # Handed off to its own thread so a slow reply — "quit" waits
-            # here for up to 10s for released_predicate() — can't stall this
+            # here for up to _QUIT_RELEASE_POLL_SECONDS for
+            # released_predicate() — can't stall this
             # loop from accepting the next connection. Before this, a "quit"
             # in flight made every other request (e.g. a concurrent
             # "activate" from another account switching in) simply time out
@@ -332,15 +356,13 @@ class IpcListener:
                 win32file.WriteFile(handle, (line + "\n").encode("utf-8"))
             win32file.FlushFileBuffers(handle)
         except pywintypes.error as exc:
-            # The peer going away mid-exchange is a transport condition, not a
-            # fault, and it happens on an expected path: a "quit" reply waits up
-            # to 10s for released_predicate(), while the caller's own timeout is
-            # also 10s but starts earlier — so the client always closes first
-            # and our WriteFile/FlushFileBuffers always raises 109. Logging that
-            # as an ERROR traceback would send whoever reads log.log chasing a
-            # broken transport that isn't broken, and drown the ERROR that does
-            # matter — the file is the project's primary diagnostic and is
-            # truncated every launch.
+            # The peer going away mid-exchange is a transport condition, not
+            # a fault: request_quit()'s timeout is kept above
+            # _QUIT_RELEASE_POLL_SECONDS, but a caller with a shorter timeout
+            # (or one that gives up for an unrelated reason) can still
+            # disconnect first, and WriteFile/FlushFileBuffers then raises
+            # 109 (ERROR_BROKEN_PIPE). Logged at info, not error, so it
+            # doesn't drown a real ERROR in log.log.
             logging.info("[ipc] pipe connection ended: winerror=%s %s",
                          exc.winerror, exc.funcname)
         except Exception:
@@ -397,7 +419,7 @@ class IpcListener:
             replies.append(json.dumps({"request_id": rid, "ack": True}))
             # Trigger shutdown, then wait until the process actually releases.
             self.on_quit()
-            deadline = time.monotonic() + 10.0
+            deadline = time.monotonic() + _QUIT_RELEASE_POLL_SECONDS
             while time.monotonic() < deadline:
                 if self.released_predicate():
                     break
@@ -504,11 +526,18 @@ def request_activate(global_dir: str, account_id: str, source: str = "user",
     return any(r.get("ack") for r in replies)
 
 
-def request_quit(global_dir: str, account_id: str, timeout: float = 10.0) -> bool:
+def request_quit(global_dir: str, account_id: str, timeout: float = 85.0) -> bool:
     """Ask the process owning account_id to quit.
 
     Returns True only once the target confirms it has RELEASED (terminated /
     dropped its mutex+lease), not merely acknowledged the request.
+
+    85s default: must stay above _QUIT_RELEASE_POLL_SECONDS (75s, the target
+    LISTENER's own poll budget) plus slack for transport round-trip. A
+    shorter timeout here does not corrupt anything — the target keeps
+    closing regardless — but makes this caller read the target's honest
+    "still working on it" as a flat False. Raise the two together; raising
+    only one changes nothing.
     """
     replies = _send(global_dir, account_id, _make_request("quit"), timeout)
     if not replies:

--- a/client/main.py
+++ b/client/main.py
@@ -1014,6 +1014,19 @@ class MainWindow(wx.Frame):
         self._save_lock = threading.Lock()
         self._save_timer = None
         self._save_timer_lock = threading.Lock()
+        # Guards the _shutting_down check-and-set in _perform_shutdown() and
+        # _on_end_session(): an unlocked check-then-set there is a real
+        # TOCTOU race — a local quit, a WM_ENDSESSION, and an IPC "quit" from
+        # another account can each observe _shutting_down still False and
+        # all proceed into _stop_wpp_server() concurrently, racing on the
+        # same wpp_process/taskkill target.
+        self._teardown_started_lock = threading.Lock()
+        # Set once whichever path actually owns teardown has genuinely
+        # finished it — distinct from _shutting_down, which only means
+        # teardown has STARTED somewhere. A caller that lost the lock race
+        # must wait on this before self-terminating, or it could os._exit()
+        # while the winning call is still mid _stop_wpp_server().
+        self._teardown_complete_event = threading.Event()
         # Guards self.sync_thread creation — see _try_start_sync_thread().
         self._sync_start_lock = threading.Lock()
         # Serializes wake-from-suspend recovery so the two independent triggers
@@ -2445,8 +2458,9 @@ class MainWindow(wx.Frame):
         `released:True`, give it a beat to send that reply over the pipe, and
         only THEN take the process down for good.
         """
+        did_work = False
         try:
-            self._perform_shutdown()
+            did_work = self._perform_shutdown()
         finally:
             # Reachable now (teardown does not call os._exit). Let the IPC
             # listener observe this and reply released:True to the initiator.
@@ -2454,6 +2468,13 @@ class MainWindow(wx.Frame):
         # Give the listener thread a moment to send the released reply before we
         # vanish (its poll loop checks the predicate every 50ms).
         time.sleep(0.3)
+        if not did_work:
+            # Another path already owns teardown — wait for it to actually
+            # finish rather than killing the process out from under its
+            # still-in-progress _stop_wpp_server().
+            self._teardown_complete_event.wait(
+                timeout=self._TEARDOWN_OWNED_ELSEWHERE_WAIT_SECONDS
+            )
         self._terminate_process()
 
     def quit_all_accounts(self):
@@ -2484,7 +2505,9 @@ class MainWindow(wx.Frame):
                 for other in others:
                     try:
                         logging.info("[quit-all] asking account %s to quit", other)
-                        ipc.request_quit(gd, other, timeout=10.0)
+                        # No explicit timeout: request_quit()'s own default
+                        # is sized to the other account's worst-case teardown.
+                        ipc.request_quit(gd, other)
                     except Exception:
                         logging.exception("[quit-all] request_quit failed for %s", other)
             except Exception:
@@ -3259,7 +3282,13 @@ class MainWindow(wx.Frame):
         # Drop the stale lockfile so a relaunch is not refused even if the
         # process was already gone but left the file behind.
         try:
-            udd = resource_path("api", "userDataDir", session_name)
+            # Matches _start_wpp_background()'s WINZAPP_USER_DATA_DIR, not
+            # resource_path("api", "userDataDir") — the latter is a
+            # --onefile launch's ephemeral extraction dir, gone by the time
+            # this wake-recovery path runs.
+            gd = getattr(self, "global_dir", None)
+            udd = (os.path.join(gd, "api", "userDataDir", session_name) if gd
+                   else resource_path("api", "userDataDir", session_name))
             for name in ("lockfile", "SingletonLock", "SingletonCookie", "SingletonSocket"):
                 p = os.path.join(udd, name)
                 if os.path.exists(p):
@@ -3547,23 +3576,26 @@ class MainWindow(wx.Frame):
         WPPConnect still initializing) is ambiguous during the first
         connection attempt of a session and gets the grace window instead.
         """
-        if getattr(self, "_shutting_down", False):
-            # The app is on its way out (real_exit()) — closing the
-            # WPPConnect session ourselves as part of shutdown looks
-            # identical, at this layer, to WhatsApp dropping the connection.
-            # Nothing about a deliberate quit should announce an "offline"
-            # transition with sound/speech in the second before the process
-            # actually exits.
+        if bool(getattr(self, "_shutting_down", False)):
+            # We just closed this session ourselves as part of quitting —
+            # looks identical, at this layer, to WhatsApp dropping the
+            # connection. The process exits moments later regardless, so
+            # nothing here needs to touch offline state, sound, or speech.
+            # NOT the same as the branch below: an update/self-restart still
+            # reconnects afterward, so those genuinely engage offline mode
+            # and only suppress the announcement.
             return
         connected = bool(connected)
         was = bool(getattr(self, "_wa_connected", False))
         self._wa_connected = connected
         # Nothing to do only when the flag *and* the derived offline state are
-        # both already consistent with `connected`.
+        # both already consistent with `connected`. _shutting_down already
+        # returned above, so the check below can only mean still-updating or
+        # still-self-restarting.
         if connected == was and self._auto_offline == (not connected):
             still_owed = (
                 not connected
-                and not getattr(self, "_wpp_updating", False)
+                and not self._self_inflicted_teardown_expected()
                 and getattr(self, "_offline_announce_deferred", False)
             )
             if not still_owed:
@@ -3637,10 +3669,11 @@ class MainWindow(wx.Frame):
 
         self._wa_offline_strikes += 1
 
-        if getattr(self, "_wpp_updating", False):
+        if self._self_inflicted_teardown_expected():
             logging.info(
-                "[connection] WPPConnect update in progress (%s) — engaging "
-                "offline mode and showing 'connecting' instead of 'offline'.",
+                "[connection] Self-inflicted session teardown in progress "
+                "(%s) — engaging offline mode and showing 'connecting' "
+                "instead of 'offline'.",
                 reason or "checked",
             )
             self._auto_offline = True
@@ -4233,6 +4266,14 @@ class MainWindow(wx.Frame):
         except Exception:
             logging.exception("[focus] restoring primary control focus failed")
 
+    # Bound for a caller that lost the _teardown_started_lock race to wait
+    # for the winning path's _teardown_complete_event before
+    # self-terminating. Sized above ipc.py's _QUIT_RELEASE_POLL_SECONDS
+    # (75s — the winning path's own teardown is bounded by that budget).
+    # Bounded rather than indefinite: if the event is somehow never set,
+    # this caller must still terminate on the user's original quit request.
+    _TEARDOWN_OWNED_ELSEWHERE_WAIT_SECONDS = 80.0
+
     def real_exit(self):
         """Completely close WinZapp: graceful teardown, then terminate.
 
@@ -4262,59 +4303,127 @@ class MainWindow(wx.Frame):
             pass
 
         def _teardown():
+            did_work = False
             try:
-                self._perform_shutdown()
+                did_work = self._perform_shutdown()
             finally:
+                if not did_work:
+                    # Another path (a concurrent _on_end_session(), or a
+                    # second overlapping quit) already owns teardown —
+                    # terminating immediately could os._exit() the process
+                    # while it is still mid _stop_wpp_server().
+                    self._teardown_complete_event.wait(
+                        timeout=self._TEARDOWN_OWNED_ELSEWHERE_WAIT_SECONDS
+                    )
                 self._terminate_process()
 
         threading.Thread(target=_teardown, daemon=True, name="winzapp-shutdown").start()
 
-    def _perform_shutdown(self):
+    def _perform_shutdown(self) -> bool:
         """Reversible shutdown: stop timers/threads, gracefully close the WPP
         session (waiting for its flush), stop the Node, close the DB. Does NOT
-        exit the process, so it is safe to call from the IPC quit handler."""
+        exit the process, so it is safe to call from the IPC quit handler.
+
+        Returns True if THIS call actually performed the teardown, False if
+        another path already owns it. Callers must not treat False the same
+        as True and immediately self-terminate — see
+        _teardown_complete_event's own comment for why."""
         # Set FIRST, before anything else: _stop_wpp_server() below closes
         # the WPPConnect session itself, which — while our WebSocket is
         # still connected — arrives as an ordinary "connection closed" event
         # indistinguishable from a real disconnect. _set_wa_connected()
         # checks this flag and skips entirely, so quitting never announces
         # "modo offline ativado" in the moment before the process exits.
-        if getattr(self, "_shutting_down", False):
-            return  # teardown already ran (e.g. real_exit after an IPC quit)
-        self._shutting_down = True
-        # Stop the presence keep-alive timer before tearing down
-        if hasattr(self, "_presence_timer") and self._presence_timer.IsRunning():
-            self._presence_timer.Stop()
-        # Also cancel a pending debounced activate/deactivate — otherwise it
-        # can fire mid-shutdown and spawn a presence POST + restart the timer
-        # just stopped above.
-        if getattr(self, "_presence_debounce_timer", None) is not None and self._presence_debounce_timer.IsRunning():
-            self._presence_debounce_timer.Stop()
-        for identity in list(getattr(self, "_incoming_call_watchdogs", {})):
-            self._cancel_incoming_call_watchdog(identity)
-        for identity in list(getattr(self, "_incoming_call_dialogs", {})):
-            self._close_incoming_call_dialog(identity)
-        if hasattr(self, "call_incoming_sound"):
-            self.call_incoming_sound.stop()
-        if getattr(self, "tray_icon", None) is not None:
+        #
+        # Locked (not a plain getattr-then-set) so this can never race
+        # _on_end_session() or a second concurrent call into this method.
+        with self._teardown_started_lock:
+            if getattr(self, "_shutting_down", False):
+                return False  # another path already owns teardown
+            self._shutting_down = True
+        try:
+            # Stop the presence keep-alive timer before tearing down
+            if hasattr(self, "_presence_timer") and self._presence_timer.IsRunning():
+                self._presence_timer.Stop()
+            # Also cancel a pending debounced activate/deactivate — otherwise it
+            # can fire mid-shutdown and spawn a presence POST + restart the timer
+            # just stopped above.
+            if getattr(self, "_presence_debounce_timer", None) is not None and self._presence_debounce_timer.IsRunning():
+                self._presence_debounce_timer.Stop()
+            for identity in list(getattr(self, "_incoming_call_watchdogs", {})):
+                self._cancel_incoming_call_watchdog(identity)
+            for identity in list(getattr(self, "_incoming_call_dialogs", {})):
+                self._close_incoming_call_dialog(identity)
+            if hasattr(self, "call_incoming_sound"):
+                self.call_incoming_sound.stop()
+            if getattr(self, "tray_icon", None) is not None:
+                try:
+                    self.tray_icon.RemoveIcon()
+                    self.tray_icon.Destroy()
+                except Exception:
+                    pass
+                self.tray_icon = None
+            if hasattr(self, "message_queue"):
+                self.message_queue.stop()
+            if getattr(self, "_update_checker", None) is not None:
+                self._update_checker.stop()
+            if getattr(self, "_wpp_update_checker", None) is not None:
+                self._wpp_update_checker.stop()
+            self._stop_wpp_server()
+            self._flush_pending_debounced_saves()
+            if hasattr(self, "db") and self.db is not None:
+                try:
+                    self.db.close()
+                except Exception:
+                    pass
+            return True
+        finally:
+            # Always, even on an exception above: a caller that lost the
+            # lock race is blocked on this event before self-terminating —
+            # leaving it unset would strand that caller for its full timeout.
+            self._teardown_complete_event.set()
+
+    def _flush_pending_debounced_saves(self):
+        """Synchronously run any pending debounced save BEFORE it can be lost.
+
+        _schedule_save() (0.15s debounce, chats/contacts -> self.db) and
+        _schedule_save_settings() (2s debounce, settings.json) each leave a
+        write sitting on its own daemon threading.Timer. Left alone, either
+        DatabaseBridge.close() rejects it once ``_closing`` flips, or
+        os._exit() kills the timer thread before it fires — os._exit()
+        never waits for other threads. Cancelling and running the callback
+        here, synchronously, beats both: the save runs on THIS thread before
+        either death trap exists.
+
+        Called from both _perform_shutdown() and _on_end_session()
+        (WM_ENDSESSION) — the latter never calls _perform_shutdown(), so
+        without this call here too a Windows shutdown/logoff would lose the
+        same pending writes with no protection at all.
+
+        Not airtight: the WebSocket stays connected throughout
+        _stop_wpp_server(), so a live event landing between this call
+        returning and db.close() running could still schedule a fresh save
+        that loses the same race. Narrows the window, does not close it.
+        """
+        with self._save_timer_lock:
+            pending_chat_save = self._save_timer is not None
+            if pending_chat_save:
+                self._save_timer.cancel()
+                self._save_timer = None
+            pending_settings_save = getattr(self, "_settings_save_timer", None) is not None
+            if pending_settings_save:
+                self._settings_save_timer.cancel()
+                self._settings_save_timer = None
+        if pending_chat_save:
             try:
-                self.tray_icon.RemoveIcon()
-                self.tray_icon.Destroy()
+                self._do_save()
             except Exception:
-                pass
-            self.tray_icon = None
-        if hasattr(self, "message_queue"):
-            self.message_queue.stop()
-        if getattr(self, "_update_checker", None) is not None:
-            self._update_checker.stop()
-        if getattr(self, "_wpp_update_checker", None) is not None:
-            self._wpp_update_checker.stop()
-        self._stop_wpp_server()
-        if hasattr(self, "db") and self.db is not None:
+                logging.exception("[_flush_pending_debounced_saves] _do_save() failed")
+        if pending_settings_save:
             try:
-                self.db.close()
+                self.save_settings()
             except Exception:
-                pass
+                logging.exception("[_flush_pending_debounced_saves] save_settings() failed")
 
     def _terminate_process(self):
         """Terminal exit — never returns.
@@ -6814,6 +6923,32 @@ class MainWindow(wx.Frame):
             except Exception:
                 logging.exception("[startup] node identity env injection failed (non-fatal)")
 
+            # WPPConnect's own defaults for the auth token store and the
+            # Chrome profile (customUserDataDir) are RELATIVE paths, resolved
+            # against the Node process's cwd (resource_path("api")). That is
+            # stable in --onedir/dev, but in --onefile it is PyInstaller's
+            # per-launch extraction temp dir — a fresh folder every launch —
+            # so anything written there is silently orphaned the moment the
+            # process exits, and the next launch's empty tokens/userDataDir
+            # folder finds nothing (WhatsApp then correctly asks for a fresh
+            # QR: the "closed WinZapp, relaunched, told the device was
+            # disconnected" report). Pointing both at an absolute,
+            # install-writable location (via config.ts/fileTokenStory.ts,
+            # which read these two env vars) fixes this for every build mode.
+            try:
+                # self.global_dir, not a "..", ".." walk up from data_path():
+                # this root is intentionally SHARED across accounts —
+                # WPPConnect isolates each session under its own
+                # userDataDir/<session_name> subfolder — and a relative
+                # walk-up silently breaks if the accounts/<id>/ nesting depth
+                # ever changes.
+                _persistent_api_dir = os.path.join(self.global_dir, "api")
+                _token_dir = os.path.join(_persistent_api_dir, "tokens")
+                os.environ["WINZAPP_USER_DATA_DIR"] = os.path.join(_persistent_api_dir, "userDataDir") + os.sep
+                os.environ["WINZAPP_TOKEN_STORE_DIR"] = _token_dir
+            except Exception:
+                logging.exception("[startup] persistent userDataDir/token-store env injection failed (non-fatal)")
+
             # Ensure dist/config.js has useChrome:false so WPPConnect always uses
             # Puppeteer's own bundled Chrome/Chromium instead of searching for a
             # system Chrome installation. Patched here at runtime so existing users
@@ -6973,6 +7108,33 @@ class MainWindow(wx.Frame):
         except Exception:
             pass
 
+    def _self_inflicted_teardown_expected(self) -> bool:
+        """True while WE are deliberately closing this account's own
+        WPPConnect session ourselves — a full app shutdown (_shutting_down),
+        a WPPConnect Server auto-update (_wpp_updating), a power-resume
+        zombie-session recovery restart (_recovery_restart_active), or an
+        in-place session restart after a detached Puppeteer page
+        (_restarting_wpp_session).
+
+        All four call POST /close-session on this account's own session
+        while the WebSocket stays deliberately connected throughout, so a
+        WebSocket "close" carrying loggedOut/401, an unlinked status-find
+        reading, or a status-session CLOSED reading during any of these four
+        windows is the direct, expected result of that call — never WhatsApp
+        actually unlinking the device. The two wake-from-sleep triggers
+        (_recovery_restart_active, _restarting_wpp_session) matter most in
+        practice: laptops sleep far more often than WinZapp is quit or
+        WPPConnect updated. Shared by on_connection_update()'s close branch,
+        on_wpp_status_find(), and check_wa_connection_http()'s CLOSED
+        auto-start guard so all three treat every self-inflicted path the
+        same way."""
+        return (
+            bool(getattr(self, "_shutting_down", False))
+            or bool(getattr(self, "_wpp_updating", False))
+            or bool(getattr(self, "_recovery_restart_active", False))
+            or bool(getattr(self, "_restarting_wpp_session", False))
+        )
+
     def _wait_for_session_flushed(self, token: str, timeout: float = None) -> bool:
         """Poll status-session until WPPConnect reports the session closed, or
         the timeout elapses. Returns True if it confirmed, False on timeout.
@@ -7041,21 +7203,76 @@ class MainWindow(wx.Frame):
             pass
         event.Skip()
 
+    # How long to wait after WM_ENDSESSION before assuming the shutdown was
+    # cancelled and undoing _shutting_down. Per Windows docs bEnding can in
+    # principle still be FALSE (another app vetoed the shutdown) — rare, but
+    # this flag is never reset anywhere else, and every logout-detection
+    # guard trusts it permanently once set. In the ordinary case the process
+    # is long gone within this window; this is a self-healing fallback for
+    # when it is not.
+    _END_SESSION_UNSTICK_SECONDS = 60.0
+
     def _on_end_session(self, event):
-        """Windows is shutting down: stop WPPConnect gracefully before we go."""
+        """Windows is shutting down: stop WPPConnect gracefully before we go.
+
+        Guarded by the same _teardown_started_lock _perform_shutdown() uses:
+        WM_ENDSESSION can arrive while a local quit or an IPC "quit" from
+        another account is already mid-teardown, and without this both would
+        call _stop_wpp_server() concurrently. When teardown already started
+        elsewhere, this only releases the shutdown-block-reason and gets out
+        of the way — it does not arm its own unstick timer, since resetting
+        _shutting_down while the other path is still tearing down would
+        reopen the self-inflicted-logout window.
+        """
         logging.warning("[_on_end_session] Windows is ending the session — stopping WPPConnect.")
-        self._shutting_down = True
+        with self._teardown_started_lock:
+            already_tearing_down = getattr(self, "_shutting_down", False)
+            self._shutting_down = True
+
+        if already_tearing_down:
+            try:
+                import ctypes
+                ctypes.windll.user32.ShutdownBlockReasonDestroy(self.GetHandle())
+            except Exception:
+                pass
+            event.Skip()
+            return
+
+        def _unstick_if_still_running():
+            self._shutting_down = False
+            # Left set, a later genuinely-new teardown's loser would see this
+            # abandoned attempt's event and wrongly assume it finished.
+            self._teardown_complete_event.clear()
+
         try:
-            # Bounded, and deliberately still on this thread: when this handler
-            # returns, Windows terminates the process, so a background thread
-            # doing the teardown would be killed mid-flush — the exact damage
-            # being avoided. See _on_query_end_session for where the 4s comes
-            # from, and why we do not veto to ask for more.
+            t = threading.Timer(self._END_SESSION_UNSTICK_SECONDS, _unstick_if_still_running)
+            t.daemon = True
+            t.start()
+        except Exception:
+            logging.exception("[_on_end_session] Failed to arm the _shutting_down safety timer")
+
+        try:
+            # Deliberately still on this thread: when this handler returns,
+            # Windows terminates the process, so a background thread doing
+            # the teardown would be killed mid-flush.
             self._shutdown_audit(
                 f"WM_ENDSESSION — teardown capped at {self._WINDOWS_SHUTDOWN_BUDGET}s")
             self._stop_wpp_server(budget=self._WINDOWS_SHUTDOWN_BUDGET)
         except Exception:
             logging.exception("[_on_end_session] Failed to stop WPPConnect cleanly")
+        try:
+            # This path never calls _perform_shutdown(), so without this
+            # call it has none of that method's write protection. Does NOT
+            # also close the DB here: bEnding can still turn out to be a
+            # shutdown another app cancels, and closing the DB now would
+            # leave it unusable if the user goes back to using WinZapp.
+            self._flush_pending_debounced_saves()
+        except Exception:
+            logging.exception("[_on_end_session] Failed to flush pending debounced saves")
+        # A caller that lost the lock race above waits on this before
+        # self-terminating — without it, it would sit out its full bounded
+        # wait instead of noticing this path already finished.
+        self._teardown_complete_event.set()
         try:
             import ctypes
             ctypes.windll.user32.ShutdownBlockReasonDestroy(self.GetHandle())
@@ -7088,6 +7305,74 @@ class MainWindow(wx.Frame):
     # process itself releasing userDataDir — instead of the HTTP status.
     _WPP_GRACEFUL_STOP_SECONDS = 10
 
+    # Extra grace on top of _SHUTDOWN_FLUSH_TIMEOUT for the auth token file
+    # to land on disk before killing Node. Bounded like every shutdown wait
+    # here: 5s covers an ordinary small-file write without stalling a user
+    # who genuinely wants out.
+    _TOKEN_PERSIST_GRACE_SECONDS = 5.0
+    _TOKEN_PERSIST_POLL_SECONDS = 0.2
+
+    def _wait_for_token_persisted(self, token: str) -> bool:
+        """Block (briefly, boundedly) until the auth token for `token`'s
+        session actually exists on disk at WINZAPP_TOKEN_STORE_DIR, or the
+        grace window runs out.
+
+        Guards the SECONDARY, REST-API-level token file
+        (<session>.data.json), not the primary credential store — for a
+        modern multi-device session that file is close to a placeholder
+        (WASecretBundle reports the literal string 'MultiDevice', not real
+        secret material). The REAL credential store is Chrome's own
+        userDataDir/IndexedDB (LevelDB) profile, protected by
+        _wait_for_session_flushed()'s wait for a genuine CLOSED status —
+        treat that as the function actually carrying the weight, this one as
+        a cheap, harmless second check in case some path still depends on
+        this file.
+
+        Returns True if found, False if the grace window ran out — callers
+        must treat False as "log it and proceed anyway", never as a reason
+        to keep the process alive forever.
+        """
+        token_dir = os.environ.get("WINZAPP_TOKEN_STORE_DIR")
+        session_name = (token or "").split(":")[0]
+        if not token_dir or not session_name:
+            return True  # nothing to check — never block on missing config
+        token_file = os.path.join(token_dir, f"{session_name}.data.json")
+        deadline = time.monotonic() + self._TOKEN_PERSIST_GRACE_SECONDS
+        while True:
+            try:
+                if os.path.isfile(token_file) and os.path.getsize(token_file) > 2:
+                    return True
+            except OSError:
+                pass
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(self._TOKEN_PERSIST_POLL_SECONDS)
+
+    # Short, bounded grace given to an already-running self-inflicted
+    # session restart (_recovery_restart_active / _restarting_wpp_session)
+    # to finish before _stop_wpp_server() proceeds. Neither holds
+    # _teardown_started_lock (they are a close+start cycle on their own
+    # thread, not teardown), so a quit landing mid-restart would otherwise
+    # race this method's own close-session/flush-wait against the restart's
+    # start-session on the same session — the restart's start-session can
+    # flip status back to INITIALIZING mid-flush-wait, starving it of the
+    # CLOSED reading and risking a "Session Unpaired" taskkill. Deliberately
+    # short, not their own ~30-60s worst case: this narrows the race rather
+    # than closing it.
+    _SELF_RESTART_YIELD_SECONDS = 5.0
+    _SELF_RESTART_YIELD_POLL_SECONDS = 0.2
+
+    def _yield_to_in_progress_self_restart(self):
+        if not (getattr(self, "_recovery_restart_active", False)
+                or getattr(self, "_restarting_wpp_session", False)):
+            return
+        deadline = time.monotonic() + self._SELF_RESTART_YIELD_SECONDS
+        while time.monotonic() < deadline:
+            if not (getattr(self, "_recovery_restart_active", False)
+                    or getattr(self, "_restarting_wpp_session", False)):
+                return
+            time.sleep(self._SELF_RESTART_YIELD_POLL_SECONDS)
+
     def _stop_wpp_server(self, budget: float = None):
         """Terminate the WPPConnect Server process and all its children.
 
@@ -7112,9 +7397,18 @@ class MainWindow(wx.Frame):
         Each account now runs its own Node on its own port, so we only ever kill
         the Node on THIS account's port.
 
-        Must not be called on the wx main thread: step 1 can legitimately block
-        for the whole grace budget.
+        Should not be called on the wx main thread when avoidable: step 1 can
+        block for the whole grace budget, and a blocked main thread stops the
+        message loop from pumping (Windows tags it "Not Responding"). One
+        caller does anyway — _update_wpp_server(), which needs to show a
+        modal dialog immediately after — an accepted tradeoff, not an
+        oversight. Every other caller runs this off the main thread.
         """
+        if budget is None:
+            # Skipped under a budget: this wait sits outside it, so honoring
+            # it during WM_ENDSESSION could add its full 5s on top of a 4s
+            # budget — past what triggers a "Not Responding" kill.
+            self._yield_to_in_progress_self_restart()
         # STEP 1: gracefully close our own session so its state is persisted,
         # regardless of whether we go on to stop the Node or leave it up. This
         # must happen for EVERY closing process, not just the last one.
@@ -7143,6 +7437,19 @@ class MainWindow(wx.Frame):
                              f"session={session_name!r} port={getattr(self,'wpp_port','?')} "
                              f"pre_close_status={pre_status!r}")
         if token:
+            # Decided from two independent signals, not one: pre_status is a
+            # single HTTP probe that returns "" on ANY failure (timeout,
+            # non-200, connection error), and a transient hiccup on exactly
+            # that probe would silently skip the token-persist wait below for
+            # a session that really was CONNECTED. self._wa_connected is a
+            # race-free second opinion updated continuously by
+            # _set_wa_connected(). Either saying "yes" is enough — a false
+            # positive costs a few extra seconds of wait, a false negative
+            # costs a lost/corrupted session.
+            session_was_connected = (
+                pre_status in ("CONNECTED", "open")
+                or getattr(self, "_wa_connected", False)
+            )
             try:
                 url = (
                     f"{self.wpp_server}:{self.wpp_port}"
@@ -7185,6 +7492,23 @@ class MainWindow(wx.Frame):
                     e,
                 )
                 self._shutdown_audit(f"close-session EXCEPTION ({e!r})")
+
+            # The literal "session is OK but the app is closing — do not let
+            # it fully close until the session is properly stored"
+            # requirement: runs UNCONDITIONALLY here, whether the try above
+            # succeeded or raised, as long as this run ever looked
+            # connected. Previously this lived inside the try block, so a
+            # close-session timeout/exception -- precisely the case where
+            # Chrome is most likely still mid-write -- skipped the wait
+            # entirely and went straight to taskkill. Regardless of whether
+            # the flush wait above already succeeded, since that polls the
+            # BROWSER's status, not the separate token file this app does
+            # not otherwise verify. Skipped entirely for a session that was
+            # never actually connected: there is nothing meaningful to wait
+            # for, same "nothing to lose" reasoning _on_disconnect() already
+            # applies to an unpaired account.
+            if session_was_connected:
+                self._wait_for_token_persisted(token)
 
         # STEP 2: stop OUR OWN Node. Each account now runs its own Node on its
         # own port (revised architecture), so there is no shared server to spare
@@ -8688,7 +9012,11 @@ class MainWindow(wx.Frame):
             gd = getattr(self, "global_dir", None)
             if not gd:
                 return
-            udd_root = os.path.abspath(resource_path("api", "userDataDir"))
+            # Matches _start_wpp_background()'s WINZAPP_USER_DATA_DIR, not
+            # resource_path("api", "userDataDir") — the latter is a
+            # --onefile launch's ephemeral extraction temp dir, already gone
+            # by the time this runs, so cleanup would silently find nothing.
+            udd_root = os.path.abspath(os.path.join(gd, "api", "userDataDir"))
             node_down = False  # circuit breaker: stop retrying logout once refused
             # Whole scan -> validate -> rmtree runs under the shared sessions_lock
             # so no other account can register/activate a name mid-cleanup, and
@@ -9787,6 +10115,12 @@ class MainWindow(wx.Frame):
                         # the whole passive observation window).
                         logging.info("[check_wa_connection_http] Skipping auto-start — "
                                      "recovery restart sequence in progress owns it.")
+                    elif self._self_inflicted_teardown_expected():
+                        # This CLOSED is the expected result of our own
+                        # close-session call — starting a fresh session here
+                        # would revive the browser moments before taskkill
+                        # force-kills it.
+                        pass
                     else:
                         try:
                             start_url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/start-session"

--- a/client/ui/dialogs/api_setup.py
+++ b/client/ui/dialogs/api_setup.py
@@ -197,6 +197,7 @@ _CUSTOM_SRC_FILES = [
     "src/util/createSessionUtil.ts",
     "src/util/sessionUtil.ts",
     "src/util/functions.ts",
+    "src/util/tokenStore/fileTokenStory.ts",
     "src/middleware/statusConnection.ts",
     "src/middleware/auth.ts",
     "src/dto/sync.ts",

--- a/client/ui/dialogs/connect.py
+++ b/client/ui/dialogs/connect.py
@@ -1458,8 +1458,73 @@ class Connect:
                                   redact_api_error(e))
             threading.Thread(target=_close_api_session, daemon=True).start()
 
+    # Bounded grace given to a JUST-STARTED pairing attempt before honoring
+    # a Quit/close that lands while Chrome is still opening WhatsApp Web for
+    # the first time. Without this, closing a few seconds after clicking
+    # "Conectar com QR code" (or entering a phone number) killed Chrome
+    # mid-launch, before it produced anything to scan/type. Chrome's first
+    # real page load routinely takes 10-25s; 30s covers that without
+    # stalling a user who wants out anywhere near the pairing flow's own
+    # ~90s wait.
+    _PAIRING_STARTUP_GRACE_SECONDS = 30.0
+    _PAIRING_STARTUP_POLL_SECONDS = 0.5
+
+    def _wait_for_pairing_startup_settled(self):
+        """Block (briefly, boundedly) so Chrome finishes its FIRST attempt at
+        producing a QR/pairing code before we close on the user's way out.
+
+        No-op unless a pairing attempt is actually in flight AND has not yet
+        produced anything — an attempt that never started, or one that
+        already has its QR/code on screen, returns immediately. Must be
+        called BEFORE the caller disconnects the WebSocket or clears
+        _pairing_in_progress, since both are read here.
+        """
+        if not getattr(self.main_window, "_pairing_in_progress", False):
+            return
+        mode = getattr(self, "connection_mode", None)
+        deadline = time.monotonic() + self._PAIRING_STARTUP_GRACE_SECONDS
+        if mode == "phone":
+            ws = getattr(self.main_window, "ws", None)
+            event = getattr(ws, "_phone_code_event", None) if ws else None
+            if event is None or event.is_set():
+                return
+            logging.info("[_wait_for_pairing_startup_settled] phone pairing in flight, "
+                         "waiting up to %.0fs for a code before closing",
+                         self._PAIRING_STARTUP_GRACE_SECONDS)
+            # Blocks the wx main thread with no repaint/accessibility events
+            # pumped — silent dead air looks like a hang and invites a
+            # force-kill mid-wait, the outcome this method exists to
+            # prevent. Reuses the existing "connecting" string.
+            self.main_window.output(self.i18n.t("connecting") or "Conectando...")
+            event.wait(timeout=max(0.0, deadline - time.monotonic()))
+            return
+        if mode == "qrcode":
+            token = getattr(self.main_window, "token", "") or getattr(self, "_last_started_qr_token", "")
+            if not token:
+                return
+            logging.info("[_wait_for_pairing_startup_settled] QR pairing in flight, "
+                         "waiting up to %.0fs for a QR before closing",
+                         self._PAIRING_STARTUP_GRACE_SECONDS)
+            self.main_window.output(self.i18n.t("connecting") or "Conectando...")
+            url = f"{self.main_window.wpp_server}:{self.main_window.wpp_port}/api/{token}/status-session"
+            headers = self._wpp_headers()
+            while time.monotonic() < deadline:
+                try:
+                    resp = api_get(url, headers=headers, timeout=5)
+                    if resp.status_code in (200, 201):
+                        data = resp.json()
+                        payload = data.get("response") if isinstance(data.get("response"), dict) else data
+                        qr = data.get("qrcode") or (payload or {}).get("qrcode")
+                        status = data.get("status") or (payload or {}).get("status")
+                        if qr or status in ("CONNECTED", "qrReadSuccess", "inChat"):
+                            return
+                except Exception:
+                    pass
+                time.sleep(self._PAIRING_STARTUP_POLL_SECONDS)
+
     def on_dialog_close(self, event):
         logging.info("[on_dialog_close] Dialog close event triggered.")
+        self._wait_for_pairing_startup_settled()
         # Invalidate any in-flight _bg_pairing_flow() — see on_continue().
         self._pairing_attempt_id += 1
         self.main_window._pairing_in_progress = False
@@ -1477,6 +1542,7 @@ class Connect:
 
     def on_quit_from_connect(self, event):
         logging.info("[on_quit_from_connect] Quit requested from connection dialog.")
+        self._wait_for_pairing_startup_settled()
         self._pairing_attempt_id += 1
         self.main_window._pairing_in_progress = False
         if hasattr(self.main_window, 'ws') and self.main_window.ws:

--- a/setup_api.py
+++ b/setup_api.py
@@ -76,6 +76,7 @@ CUSTOM_SRC_FILES = [
     "src/util/createSessionUtil.ts",
     "src/util/sessionUtil.ts",
     "src/util/functions.ts",
+    "src/util/tokenStore/fileTokenStory.ts",
     "src/middleware/statusConnection.ts",
     "src/middleware/auth.ts",
     "src/dto/sync.ts",

--- a/tests/test_api_patches_in_sync.py
+++ b/tests/test_api_patches_in_sync.py
@@ -68,6 +68,7 @@ MIRRORED_FILES = [
     "src/util/createSessionUtil.ts",
     "src/util/sessionUtil.ts",
     "src/util/functions.ts",
+    "src/util/tokenStore/fileTokenStory.ts",
     "src/middleware/statusConnection.ts",
     "src/middleware/auth.ts",
     "src/dto/sync.ts",

--- a/tests/test_end_session_unstick.py
+++ b/tests/test_end_session_unstick.py
@@ -1,0 +1,175 @@
+"""Tests for MainWindow._on_end_session()'s self-healing _shutting_down reset.
+
+_shutting_down is never reset anywhere else in the codebase, and every
+logout-detection guard added against the self-inflicted-close bug
+(on_connection_update's "close" branch, on_wpp_status_find,
+check_wa_connection_http's CLOSED auto-start) now trusts it permanently for
+the rest of the process's life once set. _on_end_session() sets it on
+WM_ENDSESSION (Windows telling the app the machine is shutting down) --  but
+per Windows' own documented semantics WM_ENDSESSION's bEnding can in
+principle still be FALSE (another app vetoed a shutdown this one already
+got as far as receiving notice of). If that ever happens and the process
+keeps running, _shutting_down would otherwise stay True forever, silently
+disabling real logout detection for the rest of the session.
+
+WebSocketClient/MainWindow are not directly involved here; only
+_on_end_session and the timer it arms are exercised, bound onto a stub (no
+wx.App / real Windows session needed).
+"""
+
+import threading
+import time
+
+from main import MainWindow
+
+
+class _Stub:
+    _on_end_session = MainWindow._on_end_session
+    _END_SESSION_UNSTICK_SECONDS = 0.05
+    _WINDOWS_SHUTDOWN_BUDGET = MainWindow._WINDOWS_SHUTDOWN_BUDGET
+
+    def __init__(self, already_shutting_down=False):
+        self._shutting_down = already_shutting_down
+        self._teardown_started_lock = threading.Lock()
+        self._teardown_complete_event = threading.Event()
+        self.stop_wpp_server_calls = 0
+        self.flush_calls = 0
+
+    def _shutdown_audit(self, msg):
+        pass
+
+    def _stop_wpp_server(self, budget=None):
+        self.stop_wpp_server_calls += 1
+
+    def _flush_pending_debounced_saves(self):
+        self.flush_calls += 1
+
+    def GetHandle(self):
+        return 0
+
+
+class _FakeEvent:
+    def __init__(self):
+        self.skipped = False
+
+    def Skip(self):
+        self.skipped = True
+
+
+class TestShuttingDownIsSetImmediately:
+    def test_flag_set_and_stop_wpp_server_called(self):
+        s = _Stub()
+        event = _FakeEvent()
+
+        s._on_end_session(event)
+
+        assert s._shutting_down is True
+        assert s.stop_wpp_server_calls == 1
+        assert event.skipped is True
+
+    def test_signals_teardown_complete_when_it_owns_teardown(self):
+        """A real_exit()/_ipc_quit() call that lost the lock race waits on
+        this event before self-terminating -- if this path never sets it,
+        that caller sits out its full 60-85s bound instead of noticing this
+        one already finished in a few milliseconds."""
+        s = _Stub()
+
+        s._on_end_session(_FakeEvent())
+
+        assert s._teardown_complete_event.is_set()
+
+
+class TestDoesNotDoubleTeardownWhenAlreadyInProgress:
+    """The gap found by re-reviewing this method against _perform_shutdown():
+    both used to set/check _shutting_down without any shared lock, so a
+    local quit (real_exit()'s background thread) racing a WM_ENDSESSION (or
+    an IPC "quit" from another account, also delivered on the wx main
+    thread) could see _shutting_down still False on both sides and BOTH
+    call _stop_wpp_server() concurrently -- two threads racing on the same
+    self.wpp_process and taskkill target. _teardown_started_lock closes
+    that: whichever caller wins the lock proceeds normally, the other
+    (finding _shutting_down already True inside the lock) must not repeat
+    the teardown or arm a second unstick timer."""
+
+    def test_stop_wpp_server_is_not_called_again_when_teardown_already_started(self):
+        s = _Stub(already_shutting_down=True)
+        event = _FakeEvent()
+
+        s._on_end_session(event)
+
+        assert s.stop_wpp_server_calls == 0
+        assert s.flush_calls == 0
+        assert event.skipped is True
+
+    def test_does_not_signal_completion_for_teardown_it_does_not_own(self):
+        """This path only skips out of the way -- the OTHER path (still
+        genuinely running) is the one whose own finish should set the event,
+        not this early return."""
+        s = _Stub(already_shutting_down=True)
+
+        s._on_end_session(_FakeEvent())
+
+        assert not s._teardown_complete_event.is_set()
+
+    def test_shutting_down_stays_true_and_no_unstick_timer_is_armed(self):
+        """Arming a second unstick timer here would, after
+        _END_SESSION_UNSTICK_SECONDS, reset _shutting_down back to False
+        while the OTHER path's teardown might still genuinely be running --
+        reopening the exact self-inflicted-logout window this flag exists
+        to close."""
+        s = _Stub(already_shutting_down=True)
+        s._END_SESSION_UNSTICK_SECONDS = 0.05
+
+        s._on_end_session(_FakeEvent())
+        assert s._shutting_down is True
+
+        time.sleep(0.3)  # well past the (would-be) unstick window
+
+        assert s._shutting_down is True, (
+            "no second unstick timer should have been armed by this call"
+        )
+
+
+class TestSelfHealingUnstick:
+    def test_flag_clears_itself_if_process_is_still_running_later(self):
+        s = _Stub()
+        s._on_end_session(_FakeEvent())
+        assert s._shutting_down is True
+
+        # Give the background threading.Timer time to fire (armed for
+        # _END_SESSION_UNSTICK_SECONDS = 0.05s on the stub).
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and s._shutting_down:
+            time.sleep(0.01)
+
+        assert s._shutting_down is False, (
+            "a Windows shutdown that never actually completed must not leave "
+            "logout detection permanently disabled for the rest of the session"
+        )
+
+    def test_unstick_also_clears_the_stale_completion_signal(self):
+        """Left set, a LATER genuinely-new teardown's loser would see this
+        abandoned attempt's event already set and self-terminate immediately,
+        believing that teardown finished when it may still be mid
+        _stop_wpp_server()."""
+        s = _Stub()
+        s._on_end_session(_FakeEvent())
+        assert s._teardown_complete_event.is_set()
+
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and s._shutting_down:
+            time.sleep(0.01)
+
+        assert not s._teardown_complete_event.is_set()
+
+    def test_a_normal_real_exit_never_needs_the_unstick(self):
+        """Sanity check on the assumption the unstick relies on: a real
+        shutdown's own teardown budget is nowhere near the 60s production
+        default, so in the ordinary case the process is long gone before
+        this would ever fire. Guards the constant itself from silently
+        shrinking below what a legitimate slow close-session flush needs."""
+        assert MainWindow._END_SESSION_UNSTICK_SECONDS >= (
+            MainWindow._WPP_GRACEFUL_STOP_SECONDS
+            + MainWindow._SHUTDOWN_FLUSH_TIMEOUT
+            + MainWindow._TOKEN_PERSIST_GRACE_SECONDS
+        )

--- a/tests/test_flush_pending_debounced_saves.py
+++ b/tests/test_flush_pending_debounced_saves.py
@@ -1,0 +1,129 @@
+"""Tests for MainWindow._flush_pending_debounced_saves().
+
+Reported gap (found by re-reviewing the shutdown path end to end, not from a
+live report): _schedule_save() debounces chat/contacts persistence by 0.15s
+and _schedule_save_settings() debounces settings.json by 2s, each on its own
+daemon threading.Timer. _perform_shutdown() never cancelled or flushed
+either before closing the DB and exiting -- so a save that was pending at
+the exact moment of shutdown could be lost two different ways: db.close()
+starts rejecting calls the instant it flips _closing (and _do_save() clears
+_dirty_jids_for_save *before* attempting the write, so there is nothing
+left to retry even if it were called again), or os._exit() simply kills the
+daemon timer thread before it ever fires at all, since it does not wait for
+other threads.
+
+_flush_pending_debounced_saves() cancels both timers and runs their
+callbacks synchronously, right in the shutdown path, before either of those
+can cut them off. Called from both _perform_shutdown() (normal/IPC quit)
+and _on_end_session() (WM_ENDSESSION) -- the latter never goes through
+_perform_shutdown() at all.
+"""
+
+import threading
+
+from main import MainWindow
+
+
+class _Stub:
+    _flush_pending_debounced_saves = MainWindow._flush_pending_debounced_saves
+
+    def __init__(self):
+        self._save_timer_lock = threading.Lock()
+        self._save_timer = None
+        self._settings_save_timer = None
+        self.do_save_calls = 0
+        self.save_settings_calls = 0
+        self.do_save_raises = False
+        self.save_settings_raises = False
+
+    def _do_save(self):
+        self.do_save_calls += 1
+        if self.do_save_raises:
+            raise RuntimeError("boom")
+
+    def save_settings(self):
+        self.save_settings_calls += 1
+        if self.save_settings_raises:
+            raise RuntimeError("boom")
+
+
+class TestNoPendingTimers:
+    def test_does_nothing_when_neither_timer_is_pending(self):
+        s = _Stub()
+        s._flush_pending_debounced_saves()
+        assert s.do_save_calls == 0
+        assert s.save_settings_calls == 0
+
+
+class TestPendingChatSaveIsFlushed:
+    def test_pending_chat_timer_is_cancelled_and_run_synchronously(self):
+        s = _Stub()
+        fired = threading.Event()
+        t = threading.Timer(999, fired.set)  # long enough it would never fire on its own
+        t.daemon = True
+        t.start()
+        s._save_timer = t
+
+        s._flush_pending_debounced_saves()
+
+        assert s.do_save_calls == 1
+        assert s._save_timer is None
+        assert not fired.is_set(), "the original timer callback must never fire"
+
+    def test_an_exception_in_do_save_does_not_propagate(self):
+        """A flush failure must not abort the rest of shutdown (settings
+        flush, db.close(), process exit)."""
+        s = _Stub()
+        s.do_save_raises = True
+        t = threading.Timer(999, lambda: None)
+        t.daemon = True
+        t.start()
+        s._save_timer = t
+
+        s._flush_pending_debounced_saves()  # must not raise
+
+        assert s.do_save_calls == 1
+
+
+class TestPendingSettingsSaveIsFlushed:
+    def test_pending_settings_timer_is_cancelled_and_run_synchronously(self):
+        s = _Stub()
+        t = threading.Timer(999, lambda: None)
+        t.daemon = True
+        t.start()
+        s._settings_save_timer = t
+
+        s._flush_pending_debounced_saves()
+
+        assert s.save_settings_calls == 1
+        assert s._settings_save_timer is None
+
+    def test_an_exception_in_save_settings_does_not_propagate(self):
+        s = _Stub()
+        s.save_settings_raises = True
+        t = threading.Timer(999, lambda: None)
+        t.daemon = True
+        t.start()
+        s._settings_save_timer = t
+
+        s._flush_pending_debounced_saves()  # must not raise
+
+        assert s.save_settings_calls == 1
+
+
+class TestBothPendingAtOnce:
+    def test_both_timers_flushed_independently(self):
+        s = _Stub()
+        t1 = threading.Timer(999, lambda: None)
+        t1.daemon = True
+        t1.start()
+        s._save_timer = t1
+        t2 = threading.Timer(999, lambda: None)
+        t2.daemon = True
+        t2.start()
+        s._settings_save_timer = t2
+
+        s._flush_pending_debounced_saves()
+
+        assert s.do_save_calls == 1
+        assert s.save_settings_calls == 1

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -155,10 +155,11 @@ def test_queue_before_window_then_flush(tmp_path):
 
 def test_a_concurrent_activate_is_not_blocked_by_an_in_flight_quit(tmp_path):
     """Regression: handling "quit" used to happen inline in the accept loop,
-    including its up-to-10s wait for released_predicate() — so any other
-    request sent while a quit was in flight had nowhere to connect to until
-    that wait finished. Each connection is now handed to its own thread so
-    the accept loop is free to pick up the next one immediately."""
+    including its up-to-_QUIT_RELEASE_POLL_SECONDS wait for
+    released_predicate() — so any other request sent while a quit was in
+    flight had nowhere to connect to until that wait finished. Each
+    connection is now handed to its own thread so the accept loop is free
+    to pick up the next one immediately."""
     gd = _gd(tmp_path)
     acc = "d" * 32
     released = threading.Event()

--- a/tests/test_message_queue_stop_drains_in_flight.py
+++ b/tests/test_message_queue_stop_drains_in_flight.py
@@ -1,0 +1,119 @@
+"""Tests for MessageQueue.stop() waiting (briefly, boundedly) for an
+in-flight send to finish before returning.
+
+Reported gap (found by re-reviewing the shutdown path, not from a live
+report): _perform_shutdown() calls message_queue.stop() BEFORE
+_stop_wpp_server(), which goes on to close-session and eventually taskkill
+the same Node process a worker thread might be mid-HTTP-request to. Before
+this fix, stop() only signalled the workers and returned immediately --
+so a send that was seconds from succeeding could get its connection cut by
+the session close/kill that follows right after, turning a legitimate send
+into an ambiguous/lost one for no reason. Bounded (not indefinite) so a
+stuck/huge upload can never block Ctrl+Alt+Shift+Q forever.
+"""
+
+import pathlib
+import sys
+import threading
+import time
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "client"))
+
+import core.message_queue as message_queue
+from core.message_queue import MessageQueue, PendingMessage
+
+
+@pytest.fixture(autouse=True)
+def direct_call_after(monkeypatch):
+    monkeypatch.setattr(
+        message_queue.wx, "CallAfter",
+        lambda callback, *args: callback(*args), raising=False,
+    )
+
+
+class _MainWindow:
+    offline_mode = False
+    _wa_connected = True
+
+    def __init__(self):
+        self._own_sent_ids_lock = threading.Lock()
+        self._own_sent_ids = set()
+        self.send_started = threading.Event()
+        self.release_send = threading.Event()
+
+    def send_text_message(self, *_args, **_kwargs):
+        self.send_started.set()
+        self.release_send.wait(timeout=5)
+        return "text-id"
+
+    def _on_message_sent(self, *_args):
+        pass
+
+    def _on_message_failed(self, *_args):
+        pass
+
+    def _on_message_unconfirmed(self, *_args):
+        pass
+
+    def _on_cancelled_message_dropped(self, *_args):
+        pass
+
+
+class TestStopWaitsForInFlightSend:
+    def test_stop_blocks_until_the_in_flight_send_actually_finishes(self):
+        main_window = _MainWindow()
+        queue = MessageQueue(main_window)
+        queue._STOP_DRAIN_SECONDS = 2.0
+        queue._STOP_DRAIN_POLL_SECONDS = 0.02
+        try:
+            queue.enqueue(PendingMessage("t1", "chat-a", text="hello"))
+            assert main_window.send_started.wait(timeout=1)
+
+            # Release the in-flight send a little after stop() is called, so a
+            # stop() that returned immediately (the old behaviour) would win
+            # the race and this assertion would catch it.
+            def _release_soon():
+                time.sleep(0.3)
+                main_window.release_send.set()
+            threading.Thread(target=_release_soon, daemon=True).start()
+
+            started = time.monotonic()
+            queue.stop()
+            elapsed = time.monotonic() - started
+
+            assert elapsed >= 0.25, "stop() must not return before the send finished"
+            assert elapsed < queue._STOP_DRAIN_SECONDS, "must return as soon as drained, not wait out the whole budget"
+        finally:
+            main_window.release_send.set()
+
+    def test_stop_gives_up_after_the_bound_and_still_returns(self):
+        """A send that never finishes (stuck upload) must not block shutdown
+        forever -- stop() must return once the bound elapses regardless."""
+        main_window = _MainWindow()
+        queue = MessageQueue(main_window)
+        queue._STOP_DRAIN_SECONDS = 0.3
+        queue._STOP_DRAIN_POLL_SECONDS = 0.02
+        try:
+            queue.enqueue(PendingMessage("t1", "chat-a", text="hello"))
+            assert main_window.send_started.wait(timeout=1)
+
+            started = time.monotonic()
+            queue.stop()  # release_send is never set
+            elapsed = time.monotonic() - started
+
+            assert elapsed >= queue._STOP_DRAIN_SECONDS
+            assert elapsed < queue._STOP_DRAIN_SECONDS + 1.0, "must not overshoot the bound by much"
+        finally:
+            main_window.release_send.set()
+
+    def test_stop_returns_immediately_when_nothing_is_in_flight(self):
+        main_window = _MainWindow()
+        queue = MessageQueue(main_window)
+        queue._STOP_DRAIN_SECONDS = 5.0
+        started = time.monotonic()
+        queue.stop()
+        elapsed = time.monotonic() - started
+        assert elapsed < 0.2

--- a/tests/test_no_offline_during_wpp_update.py
+++ b/tests/test_no_offline_during_wpp_update.py
@@ -72,6 +72,7 @@ class _Queue:
 
 class _Stub:
     _set_wa_connected = MainWindow._set_wa_connected
+    _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
     _reset_startup_probe = MainWindow._reset_startup_probe
     # The real recompute, not a spy: self.offline_mode is precisely what
     # MessageQueue._run reads before sending, so the tests assert the thing

--- a/tests/test_pairing_startup_grace.py
+++ b/tests/test_pairing_startup_grace.py
@@ -1,0 +1,250 @@
+"""Tests for MainWindow._wait_for_pairing_startup_settled() (Connect class,
+client/ui/dialogs/connect.py).
+
+Reported: "the QR code never shows up" / "the pairing code never shows up so
+I could not type it on the phone". The connection dialog's Quit/close handlers
+used to call _close_active_session() and exit immediately, no matter how
+recently the user had clicked "Conectar com QR code" or "Continuar" — killing
+Chrome mid-launch, before WhatsApp Web had ever finished loading enough to
+produce a QR/pairing code. A first-time Chrome launch here routinely takes
+10-25s; someone who clicked the button and gave up a few seconds later was
+closing a session that was seconds away from actually showing something.
+
+_wait_for_pairing_startup_settled() gives that in-flight attempt a short,
+bounded grace window before the close proceeds — narrowing the race, not
+adding an unconditional delay: an attempt that never started, or one that
+already produced its QR/code, returns immediately.
+
+Connect is a plain class (no wx.Dialog needed for this method), so it is
+exercised directly against a stub main_window.
+"""
+
+import threading
+
+import pytest
+
+import ui.dialogs.connect as connect_module
+from ui.dialogs.connect import Connect
+
+
+class _FakeEvent:
+    """Stand-in for WebSocketClient._phone_code_event (a real threading.Event
+    would also work, but this lets tests control is_set()/wait() precisely)."""
+
+    def __init__(self, already_set=False):
+        self._set = already_set
+        self.wait_calls = []
+
+    def is_set(self):
+        return self._set
+
+    def wait(self, timeout=None):
+        self.wait_calls.append(timeout)
+        return self._set
+
+    def set(self):
+        self._set = True
+
+
+class _FakeWs:
+    def __init__(self, already_set=False):
+        self._phone_code_event = _FakeEvent(already_set)
+
+
+class _FakeMainWindow:
+    def __init__(self, pairing_in_progress=True, token="sess:hash", ws=None):
+        self._pairing_in_progress = pairing_in_progress
+        self.token = token
+        self.wpp_server = "http://127.0.0.1"
+        self.wpp_port = 6300
+        self.wpp_api_key = "api-key"
+        self.ws = ws
+        self.settings = {"general": {"language": "pt-BR"}}
+        self.spoken = []
+
+    def output(self, text, **kwargs):
+        self.spoken.append(text)
+
+
+def _clock(values):
+    """A monotonic() stand-in that walks a fixed sequence, then holds."""
+    seq = list(values)
+
+    def _now():
+        return seq.pop(0) if len(seq) > 1 else seq[0]
+
+    return _now
+
+
+class _Response:
+    def __init__(self, status_code=200, body=None):
+        self.status_code = status_code
+        self._body = body or {}
+
+    def json(self):
+        return self._body
+
+
+class TestNoPairingInFlight:
+    def test_returns_immediately_when_nothing_is_in_progress(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(connect_module, "api_get", lambda *a, **kw: calls.append(1))
+        mw = _FakeMainWindow(pairing_in_progress=False)
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+
+        c._wait_for_pairing_startup_settled()
+
+        assert calls == []
+
+
+class TestPhoneMode:
+    def test_returns_immediately_if_the_code_already_arrived(self):
+        ws = _FakeWs(already_set=True)
+        mw = _FakeMainWindow(ws=ws)
+        c = Connect(mw)
+        c.connection_mode = "phone"
+
+        c._wait_for_pairing_startup_settled()
+
+        assert ws._phone_code_event.wait_calls == []
+
+    def test_waits_on_the_real_phone_code_event_when_not_yet_set(self):
+        ws = _FakeWs(already_set=False)
+        mw = _FakeMainWindow(ws=ws)
+        c = Connect(mw)
+        c.connection_mode = "phone"
+
+        c._wait_for_pairing_startup_settled()
+
+        assert len(ws._phone_code_event.wait_calls) == 1
+        assert ws._phone_code_event.wait_calls[0] > 0
+
+    def test_no_ws_is_a_no_op(self):
+        mw = _FakeMainWindow(ws=None)
+        c = Connect(mw)
+        c.connection_mode = "phone"
+
+        c._wait_for_pairing_startup_settled()  # must not raise
+
+
+class TestQrCodeMode:
+    def test_returns_at_once_when_the_first_poll_already_has_a_qr(self, monkeypatch):
+        polls = []
+
+        def fake_get(url, headers=None, timeout=None):
+            polls.append(url)
+            return _Response(200, {"qrcode": "data:image/png;base64,abc"})
+
+        monkeypatch.setattr(connect_module, "api_get", fake_get)
+        monkeypatch.setattr(connect_module.time, "sleep", lambda _s: None)
+        mw = _FakeMainWindow()
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+
+        c._wait_for_pairing_startup_settled()
+
+        assert len(polls) == 1
+
+    def test_keeps_polling_until_the_qr_appears(self, monkeypatch):
+        responses = iter([
+            _Response(200, {"status": "INITIALIZING"}),
+            _Response(200, {"status": "INITIALIZING"}),
+            _Response(200, {"qrcode": "abc"}),
+        ])
+        monkeypatch.setattr(connect_module, "api_get", lambda *a, **kw: next(responses))
+        monkeypatch.setattr(connect_module.time, "sleep", lambda _s: None)
+        mw = _FakeMainWindow()
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+
+        c._wait_for_pairing_startup_settled()  # must not raise StopIteration
+
+    def test_a_connected_status_also_ends_the_wait(self, monkeypatch):
+        monkeypatch.setattr(connect_module, "api_get",
+                             lambda *a, **kw: _Response(200, {"status": "CONNECTED"}))
+        monkeypatch.setattr(connect_module.time, "sleep", lambda _s: None)
+        mw = _FakeMainWindow()
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+
+        c._wait_for_pairing_startup_settled()
+
+    def test_no_token_at_all_is_a_no_op(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(connect_module, "api_get", lambda *a, **kw: calls.append(1))
+        mw = _FakeMainWindow(token="")
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+        c._last_started_qr_token = ""
+
+        c._wait_for_pairing_startup_settled()
+
+        assert calls == []
+
+    def test_is_bounded_when_no_qr_ever_arrives(self, monkeypatch):
+        """Never blocks a genuine quit forever: a pairing attempt that keeps
+        failing to produce anything must still let the close proceed."""
+        monkeypatch.setattr(connect_module, "api_get",
+                             lambda *a, **kw: _Response(200, {"status": "INITIALIZING"}))
+        monkeypatch.setattr(connect_module.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(
+            connect_module.time, "monotonic",
+            _clock([0] + [i * Connect._PAIRING_STARTUP_POLL_SECONDS for i in range(1, 200)])
+        )
+        mw = _FakeMainWindow()
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+
+        c._wait_for_pairing_startup_settled()  # returns instead of looping forever
+
+    def test_an_exception_on_a_poll_does_not_abort_the_wait(self, monkeypatch):
+        calls = {"n": 0}
+
+        def flaky_get(*a, **kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ConnectionError("boom")
+            return _Response(200, {"qrcode": "abc"})
+
+        monkeypatch.setattr(connect_module, "api_get", flaky_get)
+        monkeypatch.setattr(connect_module.time, "sleep", lambda _s: None)
+        mw = _FakeMainWindow()
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+
+        c._wait_for_pairing_startup_settled()
+
+        assert calls["n"] == 2
+
+
+class TestUnknownMode:
+    def test_an_unrecognized_mode_is_a_no_op(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(connect_module, "api_get", lambda *a, **kw: calls.append(1))
+        mw = _FakeMainWindow()
+        c = Connect(mw)
+        c.connection_mode = None
+
+        c._wait_for_pairing_startup_settled()
+
+        assert calls == []
+
+
+class TestWiredIntoTheQuitHandlers:
+    """The gate is only useful if the handlers actually call it, before they
+    tear down the state it reads."""
+
+    def test_on_quit_from_connect_calls_it_before_clearing_pairing_state(self):
+        import inspect
+        source = inspect.getsource(Connect.on_quit_from_connect)
+        wait_at = source.index("_wait_for_pairing_startup_settled")
+        cleared_at = source.index("_pairing_in_progress = False")
+        assert wait_at < cleared_at
+
+    def test_on_dialog_close_calls_it_before_clearing_pairing_state(self):
+        import inspect
+        source = inspect.getsource(Connect.on_dialog_close)
+        wait_at = source.index("_wait_for_pairing_startup_settled")
+        cleared_at = source.index("_pairing_in_progress = False")
+        assert wait_at < cleared_at

--- a/tests/test_perform_shutdown_reentrancy.py
+++ b/tests/test_perform_shutdown_reentrancy.py
@@ -1,0 +1,101 @@
+"""Tests for _perform_shutdown()'s return value and _teardown_complete_event.
+
+The gap found by re-reviewing real_exit()'s _teardown() and _ipc_quit()
+against the new _teardown_started_lock (added to fix a separate TOCTOU race
+between _perform_shutdown() and _on_end_session()): both callers used to
+call self._terminate_process() unconditionally in a `finally`, regardless
+of whether _perform_shutdown() actually did the teardown work or found it
+already owned by another concurrent caller (a second call into this same
+method, or _on_end_session() running on another thread). Self-terminating
+in that second case could os._exit() the process while the OTHER, WINNING
+call was still genuinely mid _stop_wpp_server() -- killing Chrome before it
+finished flushing, the exact LevelDB-corruption failure mode this whole
+mechanism exists to prevent.
+
+_perform_shutdown() now returns True only when THIS call performed the
+teardown, and always sets _teardown_complete_event in a `finally` (even on
+an unexpected exception) so a caller that got False back has something
+bounded to wait on before it is safe to terminate.
+
+MainWindow is a wx.Frame and cannot be instantiated without a running
+wx.App, so _perform_shutdown() is exercised as a plain function against a
+minimal stub -- same approach as tests/test_shutdown_suppresses_offline.py.
+Every attribute _perform_shutdown() touches through hasattr()/getattr() is
+simply omitted from the stub so those branches no-op; only the
+unconditionally-called ones (_stop_wpp_server, _flush_pending_debounced_saves)
+need a stand-in.
+"""
+
+import threading
+
+import pytest
+
+from main import MainWindow
+
+
+class _Stub:
+    _perform_shutdown = MainWindow._perform_shutdown
+
+    def __init__(self, raise_in_stop_wpp_server=False):
+        self._teardown_started_lock = threading.Lock()
+        self._teardown_complete_event = threading.Event()
+        self._shutting_down = False
+        self.stop_wpp_server_calls = 0
+        self.flush_calls = 0
+        self._raise_in_stop_wpp_server = raise_in_stop_wpp_server
+
+    def _stop_wpp_server(self):
+        self.stop_wpp_server_calls += 1
+        if self._raise_in_stop_wpp_server:
+            raise RuntimeError("boom")
+
+    def _flush_pending_debounced_saves(self):
+        self.flush_calls += 1
+
+
+class TestFirstCallOwnsTeardown:
+    def test_returns_true_and_does_the_work(self):
+        s = _Stub()
+        assert s._perform_shutdown() is True
+        assert s.stop_wpp_server_calls == 1
+        assert s.flush_calls == 1
+        assert s._shutting_down is True
+
+    def test_sets_the_completion_event(self):
+        s = _Stub()
+        s._perform_shutdown()
+        assert s._teardown_complete_event.is_set()
+
+
+class TestSecondCallDefersToTheFirst:
+    def test_returns_false_and_does_not_repeat_the_work(self):
+        s = _Stub()
+        s._shutting_down = True  # simulates another path having already started
+
+        result = s._perform_shutdown()
+
+        assert result is False
+        assert s.stop_wpp_server_calls == 0
+        assert s.flush_calls == 0
+
+    def test_does_not_set_the_completion_event_itself(self):
+        """The deferring call must not fake-signal completion -- only the
+        call that actually did the work may set it."""
+        s = _Stub()
+        s._shutting_down = True
+
+        s._perform_shutdown()
+
+        assert not s._teardown_complete_event.is_set()
+
+
+class TestCompletionEventIsSetEvenOnException:
+    def test_an_exception_inside_teardown_still_sets_the_event(self):
+        """A caller waiting on _teardown_complete_event must not be stranded
+        for its full timeout just because something inside teardown raised."""
+        s = _Stub(raise_in_stop_wpp_server=True)
+
+        with pytest.raises(RuntimeError):
+            s._perform_shutdown()
+
+        assert s._teardown_complete_event.is_set()

--- a/tests/test_self_inflicted_teardown_expected.py
+++ b/tests/test_self_inflicted_teardown_expected.py
@@ -1,0 +1,124 @@
+"""Direct tests for MainWindow._self_inflicted_teardown_expected().
+
+This helper consolidates four independent "we did this to ourselves, not
+WhatsApp" flags into one check shared by every logout-detection guard
+(on_connection_update's "close" branch, on_wpp_status_find,
+check_wa_connection_http's CLOSED auto-start guard):
+
+  - _shutting_down       (real_exit -> _perform_shutdown)
+  - _wpp_updating        (_update_wpp_server(), which replaces a running
+                           WPPConnect Server build without the app closing)
+  - _recovery_restart_active (_run_recovery_attempts() /
+                           _restart_session_once(), the wake-from-sleep
+                           zombie-session close/kill/start cycle)
+  - _restarting_wpp_session (_restart_wpp_session(), the detached-Puppeteer-
+                           page in-place restart -- also a wake-from-sleep
+                           trigger, a *different* one from the one above)
+
+Each was added one at a time, found only by re-checking every OTHER caller
+of a close-session-triggering method against the same question, not from a
+live report pointing at it: with only _shutting_down checked, a
+close/logout-shaped signal arriving during an update (not a shutdown) was
+misread as a real WhatsApp unlink; with those two, the same signal arriving
+during a zombie-session recovery cycle was ALSO misread the same way; with
+all three, _restart_wpp_session()'s own close-session call was STILL
+unguarded here even though that function's own docstring already documents
+a real incident from exactly this mechanism -- the fix that shipped then
+only covered check_wa_connection_http()'s slower strike-based path, never
+on_connection_update()'s immediate single-event close branch. Two of the
+four triggers are both wake-from-sleep paths, arguably the most common
+real-world trigger of all of them, since a laptop sleeps far more often
+than WinZapp is quit or WPPConnect updated. Same bug, reached through a
+different trigger each time.
+"""
+
+from main import MainWindow
+
+
+class _Stub:
+    _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
+
+
+def test_false_when_no_flag_set():
+    s = _Stub()
+    s._shutting_down = False
+    s._wpp_updating = False
+    s._recovery_restart_active = False
+    s._restarting_wpp_session = False
+
+    assert s._self_inflicted_teardown_expected() is False
+
+
+def test_true_during_shutdown_only():
+    s = _Stub()
+    s._shutting_down = True
+    s._wpp_updating = False
+    s._recovery_restart_active = False
+    s._restarting_wpp_session = False
+
+    assert s._self_inflicted_teardown_expected() is True
+
+
+def test_true_during_update_only():
+    s = _Stub()
+    s._shutting_down = False
+    s._wpp_updating = True
+    s._recovery_restart_active = False
+    s._restarting_wpp_session = False
+
+    assert s._self_inflicted_teardown_expected() is True
+
+
+def test_true_during_recovery_restart_only():
+    """The gap found by re-reviewing _restart_session_once() (the
+    power-resume zombie-session recovery cycle) against the same question
+    already asked of the shutdown and update paths: it too posts
+    /close-session on this account's own session while the WebSocket stays
+    connected, and was previously guarded only inside
+    check_wa_connection_http()'s own CLOSED auto-start branch -- not in
+    on_connection_update()'s close branch or on_wpp_status_find(), leaving
+    the exact same self-inflicted-logout bug reachable through an ordinary
+    sleep/wake cycle."""
+    s = _Stub()
+    s._shutting_down = False
+    s._wpp_updating = False
+    s._recovery_restart_active = True
+
+    assert s._self_inflicted_teardown_expected() is True
+
+
+def test_true_during_restarting_wpp_session_only():
+    """The gap found by re-checking every OTHER close-session caller against
+    the same question one more time: _restart_wpp_session() (the
+    detached-Puppeteer-page in-place restart, a DIFFERENT wake-from-sleep
+    trigger than _recovery_restart_active) posts /close-session on this
+    account's own session too, and was not guarded here at all -- only
+    check_wa_connection_http()'s slower strike-based path had a (different,
+    narrower) mitigation for it."""
+    s = _Stub()
+    s._shutting_down = False
+    s._wpp_updating = False
+    s._recovery_restart_active = False
+    s._restarting_wpp_session = True
+
+    assert s._self_inflicted_teardown_expected() is True
+
+
+def test_true_when_all_set():
+    s = _Stub()
+    s._shutting_down = True
+    s._wpp_updating = True
+    s._recovery_restart_active = True
+    s._restarting_wpp_session = True
+
+    assert s._self_inflicted_teardown_expected() is True
+
+
+def test_missing_attributes_default_to_false():
+    """None of the four flags is guaranteed to exist yet this early (e.g. a
+    live event arriving before __init__ has set any of them) -- must
+    degrade to "not self-inflicted", not raise, since _live_events_ready()
+    is the gate that decides whether processing happens at all this early."""
+    s = _Stub()
+
+    assert s._self_inflicted_teardown_expected() is False

--- a/tests/test_shutdown_close_not_treated_as_logout.py
+++ b/tests/test_shutdown_close_not_treated_as_logout.py
@@ -1,0 +1,280 @@
+"""Tests for WebSocketClient.on_connection_update()'s "close" branch during
+our own deliberate shutdown.
+
+The bug: real_exit() -> _perform_shutdown() -> _stop_wpp_server() posts
+/close-session itself and then polls for the flush, all while the WebSocket
+is deliberately left connected (see _perform_shutdown()'s own comment on
+_shutting_down, which already exists specifically to stop this exact kind of
+self-inflicted event from being misread -- but was only ever wired into
+_set_wa_connected(), not into the destructive logout-detection branch here).
+
+Baileys/WPPConnect reports a session WE closed ourselves via /close-session
+the same way it reports a real phone-side logout: connection.update fires
+with state="close" and loggedOut=True or statusCode=401. Before this fix,
+on_connection_update() could not tell the two apart, so an entirely ordinary
+quit (Ctrl+Alt+Shift+Q or any other exit path) could wipe the token, drop
+`paired`, and run clear_local_data() -- all persisted to disk before the
+process finished exiting. The next launch then found an empty token and
+showed "Your device has been disconnected" for a device that was never
+actually disconnected. This is the exact "closed WinZapp, relaunched, told
+the device was disconnected" report.
+
+WebSocketClient is exercised as a plain function bound onto a small stub (no
+real socketio/wx.App needed) -- same approach as
+tests/test_qrcode_auto_repair_dialog.py uses for on_qrcode_update.
+"""
+
+import pytest
+
+from core.websocket_client import WebSocketClient
+from main import MainWindow
+
+
+class _FakeI18n:
+    def t(self, key):
+        return key
+
+
+class _FakeSound:
+    def play(self):
+        pass
+
+
+class _FakeMainWindow:
+    # Bound for real (not re-implemented) so this test exercises the exact
+    # same helper on_connection_update()/on_wpp_status_find() call in
+    # production -- a hand-rolled stub method here would silently stop
+    # catching a future regression where the two drift apart again.
+    _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
+
+    def __init__(self, *, shutting_down=False, wpp_updating=False,
+                 recovery_restart_active=False, restarting_wpp_session=False,
+                 paired=True, pairing_in_progress=False,
+                 messages_set_completed=True, wa_connected=True):
+        self.settings = {"privateinfo": {"paired": paired}}
+        self._shutting_down = shutting_down
+        self._wpp_updating = wpp_updating
+        self._recovery_restart_active = recovery_restart_active
+        self._restarting_wpp_session = restarting_wpp_session
+        self._pairing_in_progress = pairing_in_progress
+        self.messages_set_completed = messages_set_completed
+        self._wa_connected = wa_connected
+        self.error_sound = _FakeSound()
+        self.app_name = "WinZapp"
+        self.wa_connected_calls = []
+
+    def _set_wa_connected(self, connected, reason, *a, **kw):
+        self.wa_connected_calls.append((connected, reason))
+
+    def output(self, text, interrupt=False):
+        pass
+
+    def _set_status(self, text):
+        pass
+
+
+class _Stub:
+    on_connection_update = WebSocketClient.on_connection_update
+    on_wpp_status_find = WebSocketClient.on_wpp_status_find
+
+    def __init__(self, main_window):
+        self.main_window = main_window
+        self.i18n = _FakeI18n()
+        self.logout_calls = 0
+        self.pairing_failed_calls = 0
+        self._logout_handled = False
+
+    def _handle_logout(self):
+        self.logout_calls += 1
+
+    def _handle_pairing_failed(self):
+        self.pairing_failed_calls += 1
+
+
+@pytest.fixture(autouse=True)
+def _synchronous_call_after(monkeypatch):
+    monkeypatch.setattr("core.websocket_client.wx.CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+    monkeypatch.setattr("core.websocket_client.wx.MessageBox", lambda *a, **kw: None)
+
+
+def _close_event(*, logged_out=True, status_code=None):
+    data = {"state": "close"}
+    if logged_out:
+        data["loggedOut"] = True
+    if status_code is not None:
+        data["statusCode"] = status_code
+    return {"data": data}
+
+
+class TestCloseDuringOwnShutdownIsNeverALogout:
+    def test_logged_out_flag_during_shutdown_does_not_wipe(self):
+        mw = _FakeMainWindow(shutting_down=True)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=True))
+
+        assert s.logout_calls == 0
+        assert s.pairing_failed_calls == 0
+
+    def test_statuscode_401_during_shutdown_does_not_wipe(self):
+        mw = _FakeMainWindow(shutting_down=True)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=False, status_code=401))
+
+        assert s.logout_calls == 0
+
+    def test_failed_pairing_during_shutdown_is_also_ignored(self):
+        """A close mid-shutdown must never fire ANY destructive branch, not
+        just the logout one."""
+        mw = _FakeMainWindow(shutting_down=True, pairing_in_progress=True,
+                             messages_set_completed=False)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=False, status_code=None))
+
+        assert s.pairing_failed_calls == 0
+        assert s.logout_calls == 0
+
+    def test_status_find_during_shutdown_also_does_not_wipe(self):
+        mw = _FakeMainWindow(shutting_down=True, wa_connected=True, paired=True)
+        s = _Stub(mw)
+
+        s.on_wpp_status_find({"status": "notLogged", "session": None})
+
+        assert s.logout_calls == 0
+
+
+class TestCloseDuringOwnUpdateIsAlsoNeverALogout:
+    """The gap found by re-reviewing every _stop_wpp_server() caller, not
+    just the one already fixed: _update_wpp_server() sets _wpp_updating
+    (not _shutting_down) and calls _stop_wpp_server() directly to replace a
+    running WPPConnect Server build. Before _self_inflicted_teardown_expected()
+    consolidated both flags, a close/notLogged signal arriving during an
+    ordinary auto-update was indistinguishable from the shutdown case this
+    file already covers, and would have wiped the token exactly the same way.
+    """
+
+    def test_logged_out_flag_during_update_does_not_wipe(self):
+        mw = _FakeMainWindow(wpp_updating=True)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=True))
+
+        assert s.logout_calls == 0
+
+    def test_status_find_during_update_does_not_wipe(self):
+        mw = _FakeMainWindow(wpp_updating=True, wa_connected=True, paired=True)
+        s = _Stub(mw)
+
+        s.on_wpp_status_find({"status": "notLogged", "session": None})
+
+        assert s.logout_calls == 0
+
+
+class TestCloseDuringRecoveryRestartIsAlsoNeverALogout:
+    """The gap found by re-reviewing every close-session-triggering method,
+    not just the two already fixed: _restart_session_once() (called from
+    _run_recovery_attempts(), the power-resume zombie-session recovery
+    cycle) sets _recovery_restart_active (not _shutting_down or
+    _wpp_updating) and posts /close-session on this account's own session
+    directly. Previously guarded only inside check_wa_connection_http()'s
+    own CLOSED auto-start branch -- not here -- so an ordinary sleep/wake
+    cycle could wipe a perfectly good session's token the exact same way as
+    the shutdown and update cases above."""
+
+    def test_logged_out_flag_during_recovery_restart_does_not_wipe(self):
+        mw = _FakeMainWindow(recovery_restart_active=True)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=True))
+
+        assert s.logout_calls == 0
+
+    def test_status_find_during_recovery_restart_does_not_wipe(self):
+        mw = _FakeMainWindow(recovery_restart_active=True, wa_connected=True, paired=True)
+        s = _Stub(mw)
+
+        s.on_wpp_status_find({"status": "notLogged", "session": None})
+
+        assert s.logout_calls == 0
+
+
+class TestCloseDuringInPlaceSessionRestartIsAlsoNeverALogout:
+    """The gap found by re-checking every OTHER close-session-triggering
+    method one more time, after the shutdown/update/recovery-restart cases
+    above were already fixed: _restart_wpp_session() (the detached-
+    Puppeteer-page in-place restart -- a DIFFERENT wake-from-sleep trigger
+    than the recovery-restart case) sets _restarting_wpp_session and posts
+    /close-session on this account's own session directly. That function's
+    own docstring documents a real incident from exactly this mechanism,
+    but the fix that shipped then only covered check_wa_connection_http()'s
+    slower strike-based path -- this immediate, single-event close branch
+    stayed completely unguarded against it."""
+
+    def test_logged_out_flag_during_restart_does_not_wipe(self):
+        mw = _FakeMainWindow(restarting_wpp_session=True)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=True))
+
+        assert s.logout_calls == 0
+
+    def test_status_find_during_restart_does_not_wipe(self):
+        mw = _FakeMainWindow(restarting_wpp_session=True, wa_connected=True, paired=True)
+        s = _Stub(mw)
+
+        s.on_wpp_status_find({"status": "notLogged", "session": None})
+
+        assert s.logout_calls == 0
+
+
+class TestCloseOutsideShutdownStillDetectsARealLogout:
+    """The guard must not swallow a genuine logout that happens to arrive
+    while _shutting_down is False (the overwhelmingly common case: the app
+    is just running normally and WhatsApp actually unlinks the device)."""
+
+    def test_logged_out_flag_not_shutting_down_still_wipes(self):
+        mw = _FakeMainWindow(shutting_down=False)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=True))
+
+        assert s.logout_calls == 1
+
+    def test_statuscode_401_not_shutting_down_still_wipes(self):
+        mw = _FakeMainWindow(shutting_down=False)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=False, status_code=401))
+
+        assert s.logout_calls == 1
+
+    def test_failed_pairing_not_shutting_down_still_detected(self):
+        mw = _FakeMainWindow(shutting_down=False, pairing_in_progress=True,
+                             messages_set_completed=False)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=False, status_code=None))
+
+        assert s.pairing_failed_calls == 1
+        assert s.logout_calls == 0
+
+    def test_status_find_not_shutting_down_still_detected(self):
+        mw = _FakeMainWindow(shutting_down=False, wa_connected=True, paired=True)
+        s = _Stub(mw)
+
+        s.on_wpp_status_find({"status": "notLogged", "session": None})
+
+        assert s.logout_calls == 1
+
+    def test_an_ordinary_temporary_close_never_wipes_either_way(self):
+        """Not a logout, not a failed pairing -- just a normal reconnect
+        blip. Must never touch credentials, shutting down or not."""
+        mw = _FakeMainWindow(shutting_down=False, pairing_in_progress=False)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=False, status_code=None))
+
+        assert s.logout_calls == 0
+        assert s.pairing_failed_calls == 0

--- a/tests/test_shutdown_suppresses_auto_start.py
+++ b/tests/test_shutdown_suppresses_auto_start.py
@@ -1,0 +1,70 @@
+"""Tests for check_wa_connection_http()'s CLOSED branch skipping the
+auto-start-session call during our own deliberate shutdown.
+
+Reported live: quitting WinZapp (Ctrl+Alt+Shift+Q) hit the same class of bug
+as on_connection_update()'s self-inflicted-close guard, just on a different
+method and a different action. _stop_wpp_server() posts /close-session
+itself, which makes status-session correctly read CLOSED a moment later --
+but the health-check loop runs on its own independent thread with no idea a
+shutdown is in progress, saw that CLOSED, and "helpfully" called
+/start-session to bring the session back. That revived the browser right as
+taskkill was about to force-kill it, so the kill landed on a session that
+had just started re-initializing instead of one that had actually finished
+closing -- and it also starved _wait_for_session_flushed() of the CLOSED
+reading it needed, timing out its 15s wait. Observed live in connection.log:
+status-session read CLOSED, then INITIALIZING, then CONNECTED again, all
+inside that 15s window, followed by "flush TIMEOUT ... never saw CLOSED".
+
+check_wa_connection_http() is a large method with many dependencies (HTTP
+calls, wx, several other subsystems) that make it impractical to drive end
+to end in a unit test -- same situation test_startup_invalid_namespace_no_wipe.py
+is in for _post_ui_init, checked the same way: at source level.
+"""
+
+import inspect
+
+from main import MainWindow
+
+
+def _closed_branch_source() -> str:
+    """The CLOSED/DESTROYED/'' branch's source, isolated from the rest of
+    check_wa_connection_http so assertions can't accidentally match
+    unrelated code."""
+    src = inspect.getsource(MainWindow.check_wa_connection_http)
+    start = src.index('elif status in ("CLOSED", "DESTROYED", ""):')
+    end = src.index("Sent auto-start session command", start)
+    return src[start:end]
+
+
+class TestClosedDuringShutdownSkipsAutoStart:
+    def test_shutting_down_is_checked_before_auto_starting(self):
+        """Consolidated into _self_inflicted_teardown_expected() (covers both
+        _shutting_down and _wpp_updating -- see
+        tests/test_self_inflicted_teardown_expected.py for that helper's own
+        coverage); this branch must actually call it."""
+        branch = _closed_branch_source()
+        assert "_self_inflicted_teardown_expected" in branch
+
+    def test_the_pairing_dialog_guard_is_unaffected(self):
+        """The two pre-existing guards (pairing dialog active, an active
+        recovery-restart sequence) must still both be present -- this fix
+        adds a third condition, it does not replace either existing one."""
+        branch = _closed_branch_source()
+        assert "_is_pairing_dialog_active" in branch
+        assert "_recovery_restart_active" in branch
+
+    def test_the_shutting_down_check_actually_skips_the_start_session_call(self):
+        """Guard against the guard being present but not actually wired to
+        skip anything (e.g. a check that never reaches a `return`/skip)."""
+        branch = _closed_branch_source()
+        shutting_down_clause = branch[branch.index("_self_inflicted_teardown_expected"):]
+        # The actual api_post(start_url, ...) call must not appear between
+        # the self-inflicted-teardown check and the final `else:` that guards
+        # it -- i.e. it is reachable only in that final else, not inside the
+        # self-inflicted-teardown branch itself. Searches for the call
+        # expression specifically (not the bare words "start-session", which
+        # this branch's own explanatory comments also use in prose).
+        call_pos = shutting_down_clause.find("api_post(start_url")
+        else_pos = shutting_down_clause.find("else:")
+        assert else_pos != -1
+        assert call_pos == -1 or call_pos > else_pos

--- a/tests/test_shutdown_suppresses_offline.py
+++ b/tests/test_shutdown_suppresses_offline.py
@@ -24,6 +24,7 @@ from main import MainWindow
 
 class _Stub:
     _set_wa_connected = MainWindow._set_wa_connected
+    _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
 
     def __init__(self, shutting_down):
         self._shutting_down = shutting_down

--- a/tests/test_shutdown_wait.py
+++ b/tests/test_shutdown_wait.py
@@ -125,3 +125,32 @@ class TestGracefulStopBudgetIsBounded:
         sleep (the thing that started this whole chain of fixes, by corrupting
         the WhatsApp Web session) must not either."""
         assert 2 < MainWindow._WPP_GRACEFUL_STOP_SECONDS <= 15
+
+
+class TestPerformShutdownReentrancyIsAtomic:
+    """The gap found by re-reviewing _perform_shutdown() against
+    _on_end_session(): the original `if getattr(self, "_shutting_down",
+    False): return` / `self._shutting_down = True` pair was a plain
+    check-then-set with no lock. A local quit (real_exit()'s background
+    teardown thread) racing a WM_ENDSESSION or an IPC "quit" from another
+    account (both delivered on the wx main thread) could both observe
+    _shutting_down as still False and both proceed into a full
+    _stop_wpp_server() concurrently. _teardown_started_lock closes that."""
+
+    def test_the_check_and_set_are_inside_the_lock(self):
+        src = inspect.getsource(MainWindow._perform_shutdown)
+        lock_pos = src.index("with self._teardown_started_lock:")
+        guard_pos = src.index('getattr(self, "_shutting_down", False)')
+        set_pos = src.index("self._shutting_down = True")
+        assert lock_pos < guard_pos < set_pos, (
+            "the check-then-set must both happen inside the lock, not just "
+            "one of them"
+        )
+
+    def test_on_end_session_uses_the_same_lock(self):
+        src = inspect.getsource(MainWindow._on_end_session)
+        assert "self._teardown_started_lock" in src, (
+            "_on_end_session() must guard its own _shutting_down "
+            "check-and-set with the same lock _perform_shutdown() uses, or "
+            "the two can still race each other"
+        )

--- a/tests/test_startup_grace.py
+++ b/tests/test_startup_grace.py
@@ -56,6 +56,7 @@ class _Stub:
     _set_wa_connected = MainWindow._set_wa_connected
     _reset_startup_probe = MainWindow._reset_startup_probe
     _announce_sync_events_enabled = MainWindow._announce_sync_events_enabled
+    _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
     _WA_STARTUP_GRACE_SECONDS = MainWindow._WA_STARTUP_GRACE_SECONDS
 
     # Overridden per-test; the default keeps the grace intact.
@@ -66,6 +67,7 @@ class _Stub:
         self.network_down = network_down
         self.settings = {}
         self._shutting_down = False
+        self._wpp_updating = False
         self._wa_connected = False
         self._auto_offline = False
         self._wa_connect_announced = False

--- a/tests/test_startup_invalid_namespace_no_wipe.py
+++ b/tests/test_startup_invalid_namespace_no_wipe.py
@@ -60,7 +60,7 @@ class TestInvalidNamespaceRetries:
 class TestInvalidNamespaceNeverWipes:
     def test_the_invalid_namespace_branch_disconnects_without_wiping(self):
         step6 = _step6_source()
-        assert "self._on_disconnect(wipe=False)" in step6
+        assert "self._on_disconnect(wipe=False" in step6
 
     def test_the_default_wipe_true_disconnect_call_is_gone(self):
         """Guards against the exact old call (self._on_disconnect() with no

--- a/tests/test_status_synced_with_connected_sound.py
+++ b/tests/test_status_synced_with_connected_sound.py
@@ -44,11 +44,14 @@ class _Stub:
             MainWindow._set_preparing_status_if_idle.__get__(self))
         self._reset_startup_probe = MainWindow._reset_startup_probe.__get__(self)
         self._announce_sync_events_enabled = MainWindow._announce_sync_events_enabled.__get__(self)
+        self._self_inflicted_teardown_expected = (
+            MainWindow._self_inflicted_teardown_expected.__get__(self))
         self._WA_STARTUP_GRACE_SECONDS = MainWindow._WA_STARTUP_GRACE_SECONDS
 
         self.settings = {}
 
         self._shutting_down = False
+        self._wpp_updating = False
         self._wa_connected = False
         self._auto_offline = False
         self._wa_connect_announced = False

--- a/tests/test_stop_wpp_server_token_persist_gate.py
+++ b/tests/test_stop_wpp_server_token_persist_gate.py
@@ -1,0 +1,94 @@
+"""Tests for two gaps found by re-reviewing _stop_wpp_server()'s token-persist
+gate (main.py) after the first pass of this fix (_wait_for_token_persisted()
+itself, covered by tests/test_token_store_persistent_path.py).
+
+Gap 1 -- the wait was nested INSIDE the close-session try block, so a
+close-session request that raised (timeout, connection error -- precisely
+the case where Chrome is most likely to still be mid-write) skipped the
+token-persist wait entirely and went straight to taskkill. It must run
+unconditionally after the try/except, not only on the happy path.
+
+Gap 2 -- the decision to even bother waiting was gated on a single fresh
+HTTP probe (_raw_session_status(), called pre_status here), which returns ""
+on ANY failure of that one call (timeout, non-200, connection error). A
+transient hiccup on exactly that probe -- at the single busiest moment in
+the process's life -- would silently skip protecting a session that really
+was CONNECTED. self._wa_connected is the app's own in-memory belief,
+updated continuously all run and frozen (not clearable) the instant
+_shutting_down/_wpp_updating goes True, so it is a race-free second signal
+that costs no extra network round trip. Either signal must be enough to
+trigger the wait.
+
+_stop_wpp_server() is a large method with many dependencies (HTTP calls,
+subprocess, taskkill) that make it impractical to drive end to end in a unit
+test -- same situation check_wa_connection_http is in
+(tests/test_shutdown_suppresses_auto_start.py), checked the same way: at
+source level.
+"""
+
+import inspect
+
+from main import MainWindow
+
+
+def _body_source() -> str:
+    return inspect.getsource(MainWindow._stop_wpp_server)
+
+
+def _if_token_block() -> str:
+    """The `if token:` block through STEP 2's node-lease release, isolated so
+    assertions can't accidentally match unrelated code."""
+    src = _body_source()
+    start = src.index("if token:")
+    end = src.index("# STEP 2:", start)
+    return src[start:end]
+
+
+class TestSessionWasConnectedUsesTwoSignals:
+    def test_gate_checks_the_in_memory_flag_not_only_the_fresh_probe(self):
+        block = _if_token_block()
+        assert "session_was_connected" in block
+        assert '"_wa_connected"' in block or "_wa_connected" in block
+        assert 'pre_status in ("CONNECTED", "open")' in block
+
+    def test_session_was_connected_is_computed_before_the_try(self):
+        block = _if_token_block()
+        decl_pos = block.index("session_was_connected =")
+        try_pos = block.index("try:")
+        assert decl_pos < try_pos, (
+            "session_was_connected must be decided from pre_status/_wa_connected "
+            "BEFORE the close-session attempt, not derived from anything the "
+            "try block itself produces"
+        )
+
+
+class TestTokenPersistWaitRunsRegardlessOfException:
+    def test_wait_for_token_persisted_call_is_outside_the_try_block(self):
+        """The actual regression: this call must not be nested inside the
+        `try:` whose `except Exception:` catches a close-session timeout/
+        connection error -- otherwise that exact failure mode skips the wait
+        that matters most."""
+        block = _if_token_block()
+        try_start = block.index("try:")
+        except_start = block.index("except Exception as e:", try_start)
+        # Find the end of the except suite: the next line at the same
+        # indentation as `except` itself that isn't part of its body. The
+        # except body in this method ends where the closing dedent to the
+        # `if session_was_connected:` gate begins.
+        gate_pos = block.index("if session_was_connected:")
+        wait_pos = block.index("self._wait_for_token_persisted(token)")
+
+        assert except_start < gate_pos < wait_pos, (
+            "_wait_for_token_persisted must be called after (not nested "
+            "inside) both the try and except suites"
+        )
+
+    def test_no_early_return_between_except_and_the_wait(self):
+        """Guard against a future edit reintroducing an early return/continue
+        inside except that would once again skip the wait on that path."""
+        block = _if_token_block()
+        except_start = block.index("except Exception as e:")
+        gate_pos = block.index("if session_was_connected:")
+        except_body = block[except_start:gate_pos]
+        assert "return" not in except_body
+        assert "continue" not in except_body

--- a/tests/test_yield_to_in_progress_self_restart.py
+++ b/tests/test_yield_to_in_progress_self_restart.py
@@ -1,0 +1,112 @@
+"""Tests for MainWindow._yield_to_in_progress_self_restart().
+
+The gap found by re-reviewing _stop_wpp_server() against the two
+wake-from-sleep self-restart cycles (_recovery_restart_active /
+_restarting_wpp_session, see _self_inflicted_teardown_expected()): neither
+holds _teardown_started_lock, because they are not teardown -- they are a
+close+start cycle running on their own thread, independent of any quit. A
+user quit landing exactly while one is in flight let _stop_wpp_server()'s
+own close-session/flush-wait race the restart's close-session/start-session
+call on the SAME session: the restart's start-session can flip status back
+to INITIALIZING mid-_wait_for_session_flushed(), starving it of the CLOSED
+reading it needs and falling through to a taskkill that risks the exact
+"Session Unpaired" corruption this whole mechanism exists to prevent.
+
+_yield_to_in_progress_self_restart() gives a short, bounded grace for an
+already-in-progress restart to finish before _stop_wpp_server() proceeds --
+narrowing this race, not eliminating it (a restart that outlasts the grace
+still races), which is the deliberate, documented tradeoff: a user who
+explicitly asked to quit should not wait anywhere near that cycle's own
+~30-60s worst case for an invisible background operation.
+"""
+
+import threading
+import time
+
+from main import MainWindow
+
+
+class _Stub:
+    _yield_to_in_progress_self_restart = MainWindow._yield_to_in_progress_self_restart
+    _SELF_RESTART_YIELD_SECONDS = 0.3
+    _SELF_RESTART_YIELD_POLL_SECONDS = 0.02
+
+    def __init__(self):
+        self._recovery_restart_active = False
+        self._restarting_wpp_session = False
+
+
+class TestNoRestartInProgress:
+    def test_returns_immediately_when_neither_flag_is_set(self):
+        s = _Stub()
+        started = time.monotonic()
+
+        s._yield_to_in_progress_self_restart()
+
+        assert time.monotonic() - started < 0.1
+
+
+class TestRestartClearsBeforeTheGraceWindow:
+    def test_recovery_restart_active_clearing_returns_early(self):
+        s = _Stub()
+        s._recovery_restart_active = True
+
+        def _clear_soon():
+            time.sleep(0.05)
+            s._recovery_restart_active = False
+        threading.Thread(target=_clear_soon, daemon=True).start()
+
+        started = time.monotonic()
+        s._yield_to_in_progress_self_restart()
+        elapsed = time.monotonic() - started
+
+        assert elapsed < s._SELF_RESTART_YIELD_SECONDS
+
+    def test_restarting_wpp_session_clearing_returns_early(self):
+        s = _Stub()
+        s._restarting_wpp_session = True
+
+        def _clear_soon():
+            time.sleep(0.05)
+            s._restarting_wpp_session = False
+        threading.Thread(target=_clear_soon, daemon=True).start()
+
+        started = time.monotonic()
+        s._yield_to_in_progress_self_restart()
+        elapsed = time.monotonic() - started
+
+        assert elapsed < s._SELF_RESTART_YIELD_SECONDS
+
+
+class TestRestartOutlivesTheGraceWindow:
+    def test_gives_up_after_the_bound_and_still_returns(self):
+        """Must never block shutdown indefinitely for an invisible
+        background recovery cycle -- proceeds anyway once the short grace
+        elapses, logging that the race was not fully closed."""
+        s = _Stub()
+        s._recovery_restart_active = True  # never cleared
+
+        started = time.monotonic()
+        s._yield_to_in_progress_self_restart()
+        elapsed = time.monotonic() - started
+
+        assert elapsed >= s._SELF_RESTART_YIELD_SECONDS
+        assert elapsed < s._SELF_RESTART_YIELD_SECONDS + 1.0
+
+
+class TestOnlyCalledWhenNothingElseOwnsTheDeadline:
+    """_stop_wpp_server(budget=...) is WM_ENDSESSION's own tightly-bounded
+    call (Windows kills an unresponsive app in ~5s). This yield's own wait
+    sits OUTSIDE that budget, so honoring it there could add its full
+    _SELF_RESTART_YIELD_SECONDS on top of a 4s budget -- comfortably past
+    what triggers a "Not Responding" kill mid-shutdown. Skipped entirely
+    when a budget is given, rather than budgeted, so a tight budget's real
+    phases (close-session, flush poll) are never starved by it."""
+
+    def test_the_call_is_guarded_on_budget_is_none(self):
+        import inspect
+        from main import MainWindow
+        source = inspect.getsource(MainWindow._stop_wpp_server)
+        call_at = source.index("_yield_to_in_progress_self_restart()")
+        guard = source[:call_at]
+        assert "if budget is None:" in guard[-500:]


### PR DESCRIPTION
This closes the other major cause of accounts randomly signing out: unlike #134, which guarded against a local 401/403 being misread as a logout, this covers four cases where WinZapp itself deliberately closes a session (quit, a WPPConnect Server auto-update, and two separate wake-from-sleep session-restart paths) and the resulting WebSocket close event was indistinguishable from WhatsApp actually unlinking the device. It also fixes the real root cause behind most "closed WinZapp, reopened it, told device disconnected" reports: the WhatsApp Web auth token and Chrome profile were written to a path that only persists in a normal onedir install, so a onefile build silently lost them on every restart. Several smaller shutdown races are closed too: a lock around the teardown sequence so two quit paths can no longer race each other, a wait so pending database/settings writes are flushed before the process exits, and a short grace window so a message still uploading isn't cut off mid-send. Closing the pairing dialog moments after clicking "connect" also no longer kills Chrome before it has a chance to show a QR code or phone-pairing code. All of this is covered by new unit tests, and the existing suite passes unchanged.