### PR TITLE
Corrigir corrida ao reiniciar sessão durante sincronização

### DIFF
--- a/client/api_patches/src/controller/sessionController.ts
+++ b/client/api_patches/src/controller/sessionController.ts
@@ -308,7 +308,8 @@ export async function closeSession(req: Request, res: Response): Promise<any> {
     // status honest: connection_state.session_closed_after_flush() rejects it,
     // so the poll waits for the `finally` below, which only runs once close()
     // has actually returned.
-    (clientsArray as any)[session] = { status: 'CLOSING' };
+    const closingMarker = { status: 'CLOSING' };
+    (clientsArray as any)[session] = closingMarker;
 
     try {
       if (req.client && typeof req.client.close === 'function') {
@@ -328,9 +329,16 @@ export async function closeSession(req: Request, res: Response): Promise<any> {
         //
         // Racing it keeps the slot self-clearing. WinZapp's own POST budget
         // (_WPP_GRACEFUL_STOP_SECONDS) is 10s, so this has to answer first.
-        await Promise.race([
-          req.client.close(),
-          new Promise((resolve) => setTimeout(resolve, 8000)).then(() => {
+        // Promise.race does not cancel its losing promise. The old inline
+        // setTimeout therefore still fired eight seconds after close() had
+        // already won, by which time WinZapp could have started a replacement
+        // browser under the same session name. forceKillSession(session) then
+        // killed that brand-new browser and left the session in INITIALIZING
+        // with a detached Puppeteer frame. Keep the handle and explicitly
+        // cancel the timeout as soon as close() settles.
+        let closeTimeout: ReturnType<typeof setTimeout> | undefined;
+        const closeTimeoutPromise = new Promise<void>((resolve) => {
+          closeTimeout = setTimeout(() => {
             req.logger?.warn?.(
               `[${session}] close() did not settle in 8s — force killing so ` +
                 `the session slot is not left stuck in CLOSING.`
@@ -338,8 +346,14 @@ export async function closeSession(req: Request, res: Response): Promise<any> {
             try {
               SessionUtil.forceKillSession(session, req.logger);
             } catch (e) {}
-          }),
-        ]);
+            resolve();
+          }, 8000);
+        });
+        try {
+          await Promise.race([req.client.close(), closeTimeoutPromise]);
+        } finally {
+          if (closeTimeout !== undefined) clearTimeout(closeTimeout);
+        }
       }
     } catch (closeErr) {
       req.logger?.warn?.(
@@ -349,7 +363,11 @@ export async function closeSession(req: Request, res: Response): Promise<any> {
         SessionUtil.forceKillSession(session, req.logger);
       } catch (e) {}
     } finally {
-      (clientsArray as any)[session] = undefined;
+      // Do not let an old close request erase a replacement client that may
+      // have claimed this session slot after an exceptional teardown path.
+      if ((clientsArray as any)[session] === closingMarker) {
+        (clientsArray as any)[session] = undefined;
+      }
     }
 
     req.io.emit('whatsapp-status', false);

--- a/client/main.py
+++ b/client/main.py
@@ -9655,6 +9655,11 @@ class MainWindow(wx.Frame):
         if now - last < self._WPP_SESSION_RESTART_COOLDOWN:
             return
         self._restarting_wpp_session = True
+        # check_wa_connection_http() uses this gate to avoid issuing its own
+        # /start-session while a close/wait/start recovery sequence owns the
+        # browser. _restarting_wpp_session is only this method's re-entrancy
+        # guard and is not consulted by the health loop.
+        self._recovery_restart_active = True
         self._last_wpp_session_restart_ts = now
         try:
             logging.warning(
@@ -9664,11 +9669,39 @@ class MainWindow(wx.Frame):
             )
             headers = {"Authorization": f"Bearer {self.token}"}
             close_url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/close-session"
+            close_accepted = False
             try:
-                api_post(close_url, headers=headers, timeout=15)
+                response = api_post(close_url, headers=headers, timeout=15)
+                close_accepted = response.status_code in (200, 201)
+                if not close_accepted:
+                    logging.warning(
+                        "[_restart_wpp_session] close-session returned HTTP %s.",
+                        response.status_code,
+                    )
             except Exception as exc:
                 logging.warning("[_restart_wpp_session] close-session failed: %s", exc)
-            time.sleep(2)
+
+            # A 200 only means the controller accepted the request; it is not
+            # permission to start a new browser on top of a CLOSING slot. The
+            # old fixed sleep reproduced a field failure where the close's
+            # eight-second watchdog killed the replacement browser just after
+            # it connected. Wait for the server's honest CLOSED transition.
+            import connection_state as cs
+            closed_status = self._wait_for_status(
+                cs.session_closed_after_flush,
+                self._RECOVERY_CLOSE_WAIT,
+                stop_when_connected=False,
+            )
+            if not cs.session_closed_after_flush(closed_status):
+                logging.error(
+                    "[_restart_wpp_session] Session did not reach CLOSED after "
+                    "close-session (accepted=%s, status=%s) — refusing to start "
+                    "a replacement browser on top of the old one.",
+                    close_accepted,
+                    closed_status or "?",
+                )
+                return
+
             start_url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/start-session"
             try:
                 api_post(start_url, json={"waitQrCode": False}, headers=headers, timeout=15)
@@ -9676,6 +9709,7 @@ class MainWindow(wx.Frame):
             except Exception as exc:
                 logging.warning("[_restart_wpp_session] start-session failed: %s", exc)
         finally:
+            self._recovery_restart_active = False
             self._restarting_wpp_session = False
 
     # A live WPPConnect Socket.IO event this recent is treated as direct

--- a/tests/test_restart_wpp_session.py
+++ b/tests/test_restart_wpp_session.py
@@ -26,18 +26,18 @@ class _Stub:
     _auto_restart_grace_active = MainWindow._auto_restart_grace_active
     _WPP_SESSION_RESTART_COOLDOWN = MainWindow._WPP_SESSION_RESTART_COOLDOWN
     _AUTO_RESTART_LOGOUT_GRACE_SECONDS = MainWindow._AUTO_RESTART_LOGOUT_GRACE_SECONDS
+    _RECOVERY_CLOSE_WAIT = MainWindow._RECOVERY_CLOSE_WAIT
 
     def __init__(self):
         self.wpp_server = "http://127.0.0.1"
         self.wpp_port = 6300
         self.token = "test-token"
+        self.waited_statuses = []
+        self.closed_status = "CLOSED"
 
-
-@pytest.fixture(autouse=True)
-def _no_real_sleep(monkeypatch):
-    """_restart_wpp_session() sleeps 2s between close and start — skip that
-    in tests."""
-    monkeypatch.setattr("main.time.sleep", lambda *_: None)
+    def _wait_for_status(self, predicate, timeout, stop_when_connected=True):
+        self.waited_statuses.append((predicate, timeout, stop_when_connected))
+        return self.closed_status
 
 
 class TestRestartWppSession:
@@ -58,8 +58,10 @@ class TestRestartWppSession:
             "http://127.0.0.1:6300/api/test-token/close-session",
             "http://127.0.0.1:6300/api/test-token/start-session",
         ]
+        assert len(s.waited_statuses) == 1
+        assert s.waited_statuses[0][1:] == (s._RECOVERY_CLOSE_WAIT, False)
 
-    def test_start_session_still_runs_if_close_session_fails(self, monkeypatch):
+    def test_start_session_runs_if_close_request_fails_but_closed_is_confirmed(self, monkeypatch):
         calls = []
 
         def _fake_post(url, **kw):
@@ -78,6 +80,36 @@ class TestRestartWppSession:
             "http://127.0.0.1:6300/api/test-token/close-session",
             "http://127.0.0.1:6300/api/test-token/start-session",
         ]
+
+    def test_does_not_start_replacement_until_closed_is_confirmed(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr("main.requests.post", lambda url, **kw: calls.append(url))
+        s = _Stub()
+        s.closed_status = "CLOSING"
+
+        s._restart_wpp_session()
+
+        assert calls == ["http://127.0.0.1:6300/api/test-token/close-session"]
+
+    def test_health_loop_restart_gate_covers_close_wait_and_start(self, monkeypatch):
+        gate_values = []
+        s = _Stub()
+
+        def _wait(*args, **kwargs):
+            gate_values.append(s._recovery_restart_active)
+            return "CLOSED"
+
+        def _post(url, **kwargs):
+            gate_values.append(s._recovery_restart_active)
+            return type("_Resp", (), {"status_code": 200})()
+
+        s._wait_for_status = _wait
+        monkeypatch.setattr("main.requests.post", _post)
+
+        s._restart_wpp_session()
+
+        assert gate_values and all(gate_values)
+        assert s._recovery_restart_active is False
 
     def test_respects_the_cooldown_between_restarts(self, monkeypatch):
         calls = []

--- a/tests/test_shutdown_closing_state.py
+++ b/tests/test_shutdown_closing_state.py
@@ -81,7 +81,8 @@ class TestTheServerParksClosingNotNull:
 
     def test_the_placeholder_is_closing(self):
         src = self._source()
-        assert "(clientsArray as any)[session] = { status: 'CLOSING' };" in src
+        assert "const closingMarker = { status: 'CLOSING' };" in src
+        assert "(clientsArray as any)[session] = closingMarker;" in src
 
     def test_the_null_placeholder_is_gone(self):
         """`{status: null}` is what getSessionState() reports as CLOSED."""
@@ -96,7 +97,7 @@ class TestTheServerParksClosingNotNull:
         # Anchor on the executable guard, not on `req.client.close()` — the
         # comment above the assignment names that call too.
         guard = "if (req.client && typeof req.client.close === 'function') {"
-        assert src.index("(clientsArray as any)[session] = { status: 'CLOSING' };") < (
+        assert src.index("(clientsArray as any)[session] = closingMarker;") < (
             src.index(guard)
         )
 
@@ -107,6 +108,7 @@ class TestTheServerParksClosingNotNull:
         src = self._source()
         finally_at = src.index("} finally {")
         assert "(clientsArray as any)[session] = undefined;" in src[finally_at:]
+        assert "(clientsArray as any)[session] === closingMarker" in src[finally_at:]
 
     def test_the_close_is_bounded(self):
         """wppconnect's close() swallows both page.close() and browser.close()
@@ -115,7 +117,18 @@ class TestTheServerParksClosingNotNull:
         src = self._source()
         assert "Promise.race([" in src
         race_at = src.index("Promise.race([")
-        assert "setTimeout" in src[race_at:race_at + 400]
+        timeout_at = src.index("const closeTimeoutPromise")
+        assert "setTimeout" in src[timeout_at:race_at]
+
+    def test_the_losing_close_timeout_is_cancelled(self):
+        """Promise.race does not cancel a losing timer. Without clearTimeout,
+        that timer force-kills a replacement browser eight seconds after the
+        old close already completed — the exact detached-frame field failure."""
+        src = self._source()
+        race_at = src.index("await Promise.race(")
+        clear_at = src.index("clearTimeout(closeTimeout)", race_at)
+        slot_clear_at = src.index("[session] = undefined", clear_at)
+        assert race_at < clear_at < slot_clear_at
 
 
 class TestTheWindowsShutdownBudget:


### PR DESCRIPTION
## Resumo

- cancela o watchdog perdedor do fechamento para ele não matar o navegador substituto oito segundos depois
- protege o slot da sessão com um marcador CLOSING específico da operação
- aguarda o estado real CLOSED antes de chamar start-session
- bloqueia reinícios concorrentes disparados pelo health check
- adiciona testes de regressão para o incidente de detached Frame / sessão presa em INITIALIZING

## Causa raiz

Promise.race() não cancela a promise perdedora. Quando client.close() terminava primeiro, o timer de oito segundos continuava vivo e depois chamava orceKillSession(session). Nesse intervalo, o WinZapp já havia iniciado e conectado um novo navegador com o mesmo nome de sessão, que acabava sendo morto pelo timer antigo.

## Verificação

- 216 passed na bateria focada do patch e sincronização
- 4663 passed na suíte completa
- recompilação TypeScript/Babel do WPPConnect Server concluída sem erros
- git diff --check sem erros