### PR TITLE
Merge PR #141 com as correções da revisão (migração de sessão + teardown fora da thread da UI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,19 @@ Entry point is `client/main.py`, guarded by `if __name__ == "__main__":` near th
 pytest                                   # from repo root; pytest.ini sets pythonpath=client, asyncio_mode=auto
 pytest tests/test_database.py            # single file
 pytest tests/test_database.py::TestChats::test_upsert_chat_creates_record  # single test
+pytest -m "not wxgui"                    # skip the modules that open a real dialog
 ```
+**Run `-m "not wxgui"` whenever somebody is actually using the machine.** A
+handful of modules construct a real top-level wx dialog, and that steals focus
+from whatever the user is doing — worse, it has crashed NVDA live: NVDA takes
+focus on the throwaway window and is still enumerating its children over COM
+(`event_gainFocus` → `getDialogText` → `IAccessible._get_children` →
+`oleacc.AccessibleObjectFromEvent`) when the test destroys it. Confirmed from
+NVDA's own traceback. Everything else builds its windows through
+`tests/conftest.py`'s `hidden_frame()` — real, fully functional parents, but
+off-screen tool windows with no taskbar button, so they never become
+foreground. `tests/test_no_desktop_visible_windows.py` enforces both halves;
+CI has no screen reader and runs the whole suite.
 Tests cover `client/core/database.py` and `client/core/database_bridge.py` (async SQLite layer + its sync façade) and small islands of pure logic pulled out of `main.py`/`core/notification_manager.py`/`ui/conversations.py` (e.g. `tests/test_sender_names.py`, `tests/test_notifications.py`, `tests/test_delivery_status.py`, `tests/test_send_jid_resolution.py`, `tests/test_message_bookmarks.py`) by binding their unbound methods onto a plain stub object — `MainWindow`/`ConversationsPanel` are wx.Frame/wx.Panel and can't be instantiated without a running wx.App, so the stub carries only the attributes the method under test actually touches. There are no tests for the wx UI in bulk. Async tests use `pytest-asyncio` in `auto` mode — no `@pytest.mark.asyncio` decorator needed, just declare test functions `async def`. **New functions/features should come with a test in this style as part of the same change.**
 
 ### Building the distributable

--- a/build.py
+++ b/build.py
@@ -301,6 +301,7 @@ API_CUSTOM_SRC_FILES = [
     "src/config.ts",
     "src/util/createSessionUtil.ts",
     "src/util/functions.ts",
+    "src/util/tokenStore/fileTokenStory.ts",
     "src/middleware/statusConnection.ts",
     "src/middleware/auth.ts",
     "src/controller/deviceController.ts",

--- a/client/api_patches/src/config.ts
+++ b/client/api_patches/src/config.ts
@@ -1,5 +1,19 @@
 import { ServerOptions } from './types/ServerOptions';
 
+// customUserDataDir is used as `customUserDataDir + session` (string
+// concatenation, not path.join) to build each session's Puppeteer/Chrome
+// profile directory — see createSessionUtil.ts. Left as the literal default
+// './userDataDir/' it resolves relative to the Node process's own cwd, which
+// is only a stable, persistent location in a --onedir build or dev mode; in
+// --onefile it is PyInstaller's per-launch extraction temp dir, so the whole
+// WhatsApp Web browser profile (and therefore the paired session) is
+// silently orphaned every time the app closes. main.py sets
+// WINZAPP_USER_DATA_DIR to an absolute, install-writable path (with the
+// trailing separator this concatenation needs) before spawning Node; the
+// './userDataDir/' fallback below is only for running this server outside
+// WinZapp entirely.
+const customUserDataDir = process.env.WINZAPP_USER_DATA_DIR || './userDataDir/';
+
 export default {
   secretKey: 'THISISMYSECURETOKEN',
   host: 'http://localhost',
@@ -9,7 +23,7 @@ export default {
   startAllSession: false,
   tokenStoreType: 'file',
   maxListeners: 15,
-  customUserDataDir: './userDataDir/',
+  customUserDataDir,
   webhook: {
     url: null,
     autoDownload: true,

--- a/client/api_patches/src/util/tokenStore/fileTokenStory.ts
+++ b/client/api_patches/src/util/tokenStore/fileTokenStory.ts
@@ -1,0 +1,68 @@
+import * as path from 'path';
+
+import { FileTokenStore as fsTokenStore } from './FileTokenStore/FileTokenStore';
+
+// Upstream never passes a `path` option here, so FileTokenStore falls back
+// to its own hardcoded default ('./tokens', resolved against the Node
+// process's own cwd). That is only a stable, persistent location in a
+// --onedir build or dev mode; in a --onefile build the cwd is PyInstaller's
+// per-launch extraction temp dir (a fresh, differently-named folder every
+// single launch), so the saved auth token is silently orphaned the instant
+// the app closes — the very next launch finds an empty tokens/ folder,
+// wppconnect.log logs "Token store returned no data", and WhatsApp
+// correctly (from its own side) decides the session needs a fresh QR scan.
+// Reported live as "closed WinZapp, relaunched, told the device was
+// disconnected" — with nothing wrong in any of WinZapp's own
+// logout-detection logic, which had already been hardened against exactly
+// that report. main.py sets WINZAPP_TOKEN_STORE_DIR to an absolute,
+// install-writable path before spawning Node; the undefined fallback here
+// (which makes FileTokenStore use its own built-in default) only applies
+// when running this server outside WinZapp entirely.
+// Logged once at module load — Node's module cache means this runs once per
+// server process (i.e. once per WinZapp launch, since each account gets its
+// own Node process), not once per session — so wppconnect.log always states
+// in plain terms exactly where the token file for this run will be read
+// from / written to, no more inferring it from "Token store returned no
+// data" after the fact, or assuming it matches the previous run at all.
+const _resolvedTokenDir = path.resolve(
+  process.cwd(),
+  process.env.WINZAPP_TOKEN_STORE_DIR || './tokens'
+);
+console.log(
+  `[WinZapp] Token store directory: ${_resolvedTokenDir} ` +
+  `(from ${process.env.WINZAPP_TOKEN_STORE_DIR ? 'WINZAPP_TOKEN_STORE_DIR env var' : 'built-in default relative to cwd — NOT persistent in a --onefile build'})`
+);
+
+class FileTokenStore {
+  declare client: any;
+  constructor(client: any) {
+    this.client = client;
+  }
+  tokenStore = new fsTokenStore({
+    ...(process.env.WINZAPP_TOKEN_STORE_DIR
+      ? { path: process.env.WINZAPP_TOKEN_STORE_DIR }
+      : {}),
+    encodeFunction: (data) => {
+      return this.encodeFunction(data, this.client.config);
+    },
+    decodeFunction: (text) => {
+      return this.decodeFunction(text, this.client);
+    },
+  });
+
+  public encodeFunction(data: any, config: any) {
+    data.config = config;
+    return JSON.stringify(data);
+  }
+
+  public async decodeFunction(text: string, client: any): Promise<string[]> {
+    const object = JSON.parse(text);
+    if (object.config && Object.keys(client.config).length === 0)
+      client.config = object.config;
+    if (object.webhook && Object.keys(client.config).length === 0)
+      client.config.webhook = object.webhook;
+    return object;
+  }
+}
+
+export default FileTokenStore;

--- a/client/core/message_queue.py
+++ b/client/core/message_queue.py
@@ -145,10 +145,38 @@ class MessageQueue:
             self._report_cancelled_drop(msg)
         return stopped
 
+    # Bounded wait, in stop(), for a send genuinely on the wire to finish
+    # before returning. _perform_shutdown() calls stop() BEFORE
+    # _stop_wpp_server(), which taskkills the same Node process a worker's
+    # HTTP request is talking to — cutting that off mid-flight turns a send
+    # seconds from succeeding into an ambiguous/lost one for no reason.
+    # Bounded (a stuck upload must never block shutdown forever) and kept
+    # short since it is one of the terms ipc.py's _QUIT_RELEASE_POLL_SECONDS
+    # is sized against — raising it requires raising that too.
+    _STOP_DRAIN_SECONDS = 4.0
+    _STOP_DRAIN_POLL_SECONDS = 0.1
+
     def stop(self):
-        """Signal the worker to exit cleanly (call at app shutdown)."""
+        """Signal the worker to exit cleanly (call at app shutdown).
+
+        Waits briefly (see _STOP_DRAIN_SECONDS) for any in-flight send to
+        finish before returning."""
         self._stop.set()
         self.flush()
+        deadline = time.monotonic() + self._STOP_DRAIN_SECONDS
+        while time.monotonic() < deadline:
+            with self._lock:
+                if not self._in_flight:
+                    return
+            time.sleep(self._STOP_DRAIN_POLL_SECONDS)
+        with self._lock:
+            remaining = len(self._in_flight)
+        if remaining:
+            logging.warning(
+                "[MessageQueue] stop() gave up waiting for %d in-flight "
+                "send(s) after %.1fs — proceeding with shutdown anyway",
+                remaining, self._STOP_DRAIN_SECONDS,
+            )
 
     # ── Worker thread ─────────────────────────────────────────────────────────
 

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -322,6 +322,17 @@ class WebSocketClient:
                 data.get("loggedOut", False)
                 or status_code == 401
             )
+
+            if self.main_window._self_inflicted_teardown_expected():
+                # We are mid our own deliberate shutdown or a WPPConnect
+                # Server auto-update — both POST /close-session themselves
+                # with the WebSocket deliberately left connected throughout,
+                # so this "close" is the direct, expected result of that
+                # call, not WhatsApp unlinking anything. A self-inflicted
+                # close is reported the exact same way as a real phone-side
+                # logout (loggedOut=True / statusCode 401).
+                return
+
             # A connection that closes again — for ANY reason, not just an
             # explicit 401/loggedOut — while a pairing attempt is still in
             # progress and before WPPConnect ever delivered real chat data
@@ -1323,7 +1334,13 @@ class WebSocketClient:
             if status in ("disconnectedMobile", "notLogged", "UNPAIRED", "UNPAIRED_IDLE"):
                 # Handle permanent WhatsApp logout / disconnection.
                 # Only trigger if we were previously fully connected (preventing startup false positives).
-                if self.main_window._wa_connected and self.main_window.settings.get("privateinfo", {}).get("paired"):
+                if self.main_window._self_inflicted_teardown_expected():
+                    # Same self-inflicted-close reasoning as on_connection_update's
+                    # "close" branch: never treat this as a real unlink while we
+                    # are the ones tearing the session down, whether that's a
+                    # full app shutdown or a WPPConnect Server auto-update.
+                    pass
+                elif self.main_window._wa_connected and self.main_window.settings.get("privateinfo", {}).get("paired"):
                     wx.CallAfter(self._handle_logout)
         except Exception:
             logging.exception("[WebSocketClient] on_wpp_status_find error")

--- a/client/ipc.py
+++ b/client/ipc.py
@@ -41,6 +41,28 @@ from coord_locks import canonical_dir
 
 _IS_WINDOWS = sys.platform == "win32"
 
+# How long the LISTENER (the process being asked to quit) polls
+# released_predicate() before giving up and answering with whatever it says
+# at that moment — this decides the "released" reply's truthfulness,
+# independent of the CALLER's own request_quit() timeout below. Must stay >=
+# the target's own worst-case graceful-teardown time (kept as a plain
+# duplicated constant, not a cross-module import, since ipc.py must stay
+# importable before a MainWindow/wx.App exists):
+#   MessageQueue._STOP_DRAIN_SECONDS                  (4s:  in-flight send)
+# + MainWindow._SELF_RESTART_YIELD_SECONDS            (5s:  yield to an
+#   in-progress recovery/in-place session restart)
+# + MainWindow._WPP_GRACEFUL_STOP_SECONDS             (10s: close-session POST)
+# + MainWindow._SHUTDOWN_FLUSH_TIMEOUT                (15s: poll for CLOSED)
+# + MainWindow._TOKEN_PERSIST_GRACE_SECONDS           (5s:  token-file wait)
+# + ~2s taskkill-confirm poll
+# + _flush_pending_debounced_saves()                  (~3s)
+# + DatabaseBridge.close()'s own bounds                (12s)
+# = ~56s realistic worst case; 75s leaves real margin. If any of the budgets
+# above changes, this number and request_quit()'s own default (below) both
+# need re-checking together — raising only one silently reintroduces a
+# "gave up early, answered released:False for a session still flushing" bug.
+_QUIT_RELEASE_POLL_SECONDS = 75.0
+
 
 # ── channel identity ─────────────────────────────────────────────────────────
 def _channel_key(global_dir: str, account_id: str) -> str:
@@ -171,9 +193,10 @@ class IpcListener:
                 break
             # Handed off to its own thread for the same reason as the
             # Windows pipe loop below: a "quit" reply waits here for up to
-            # 10s for released_predicate(), and handling it inline would
-            # stall accept() from picking up any other request (e.g. a
-            # concurrent "activate") for that whole window.
+            # _QUIT_RELEASE_POLL_SECONDS for released_predicate(), and
+            # handling it inline would stall accept() from picking up any
+            # other request (e.g. a concurrent "activate") for that whole
+            # window.
             threading.Thread(target=self._handle_conn, args=(conn,), daemon=True).start()
         try:
             srv.close()
@@ -284,7 +307,8 @@ class IpcListener:
                 time.sleep(0.05)
                 continue
             # Handed off to its own thread so a slow reply — "quit" waits
-            # here for up to 10s for released_predicate() — can't stall this
+            # here for up to _QUIT_RELEASE_POLL_SECONDS for
+            # released_predicate() — can't stall this
             # loop from accepting the next connection. Before this, a "quit"
             # in flight made every other request (e.g. a concurrent
             # "activate" from another account switching in) simply time out
@@ -332,15 +356,13 @@ class IpcListener:
                 win32file.WriteFile(handle, (line + "\n").encode("utf-8"))
             win32file.FlushFileBuffers(handle)
         except pywintypes.error as exc:
-            # The peer going away mid-exchange is a transport condition, not a
-            # fault, and it happens on an expected path: a "quit" reply waits up
-            # to 10s for released_predicate(), while the caller's own timeout is
-            # also 10s but starts earlier — so the client always closes first
-            # and our WriteFile/FlushFileBuffers always raises 109. Logging that
-            # as an ERROR traceback would send whoever reads log.log chasing a
-            # broken transport that isn't broken, and drown the ERROR that does
-            # matter — the file is the project's primary diagnostic and is
-            # truncated every launch.
+            # The peer going away mid-exchange is a transport condition, not
+            # a fault: request_quit()'s timeout is kept above
+            # _QUIT_RELEASE_POLL_SECONDS, but a caller with a shorter timeout
+            # (or one that gives up for an unrelated reason) can still
+            # disconnect first, and WriteFile/FlushFileBuffers then raises
+            # 109 (ERROR_BROKEN_PIPE). Logged at info, not error, so it
+            # doesn't drown a real ERROR in log.log.
             logging.info("[ipc] pipe connection ended: winerror=%s %s",
                          exc.winerror, exc.funcname)
         except Exception:
@@ -397,7 +419,7 @@ class IpcListener:
             replies.append(json.dumps({"request_id": rid, "ack": True}))
             # Trigger shutdown, then wait until the process actually releases.
             self.on_quit()
-            deadline = time.monotonic() + 10.0
+            deadline = time.monotonic() + _QUIT_RELEASE_POLL_SECONDS
             while time.monotonic() < deadline:
                 if self.released_predicate():
                     break
@@ -504,11 +526,18 @@ def request_activate(global_dir: str, account_id: str, source: str = "user",
     return any(r.get("ack") for r in replies)
 
 
-def request_quit(global_dir: str, account_id: str, timeout: float = 10.0) -> bool:
+def request_quit(global_dir: str, account_id: str, timeout: float = 85.0) -> bool:
     """Ask the process owning account_id to quit.
 
     Returns True only once the target confirms it has RELEASED (terminated /
     dropped its mutex+lease), not merely acknowledged the request.
+
+    85s default: must stay above _QUIT_RELEASE_POLL_SECONDS (75s, the target
+    LISTENER's own poll budget) plus slack for transport round-trip. A
+    shorter timeout here does not corrupt anything — the target keeps
+    closing regardless — but makes this caller read the target's honest
+    "still working on it" as a flat False. Raise the two together; raising
+    only one changes nothing.
     """
     replies = _send(global_dir, account_id, _make_request("quit"), timeout)
     if not replies:

--- a/client/main.py
+++ b/client/main.py
@@ -1014,6 +1014,19 @@ class MainWindow(wx.Frame):
         self._save_lock = threading.Lock()
         self._save_timer = None
         self._save_timer_lock = threading.Lock()
+        # Guards the _shutting_down check-and-set in _perform_shutdown() and
+        # _on_end_session(): an unlocked check-then-set there is a real
+        # TOCTOU race — a local quit, a WM_ENDSESSION, and an IPC "quit" from
+        # another account can each observe _shutting_down still False and
+        # all proceed into _stop_wpp_server() concurrently, racing on the
+        # same wpp_process/taskkill target.
+        self._teardown_started_lock = threading.Lock()
+        # Set once whichever path actually owns teardown has genuinely
+        # finished it — distinct from _shutting_down, which only means
+        # teardown has STARTED somewhere. A caller that lost the lock race
+        # must wait on this before self-terminating, or it could os._exit()
+        # while the winning call is still mid _stop_wpp_server().
+        self._teardown_complete_event = threading.Event()
         # Guards self.sync_thread creation — see _try_start_sync_thread().
         self._sync_start_lock = threading.Lock()
         # Serializes wake-from-suspend recovery so the two independent triggers
@@ -2445,8 +2458,9 @@ class MainWindow(wx.Frame):
         `released:True`, give it a beat to send that reply over the pipe, and
         only THEN take the process down for good.
         """
+        did_work = False
         try:
-            self._perform_shutdown()
+            did_work = self._perform_shutdown()
         finally:
             # Reachable now (teardown does not call os._exit). Let the IPC
             # listener observe this and reply released:True to the initiator.
@@ -2454,6 +2468,13 @@ class MainWindow(wx.Frame):
         # Give the listener thread a moment to send the released reply before we
         # vanish (its poll loop checks the predicate every 50ms).
         time.sleep(0.3)
+        if not did_work:
+            # Another path already owns teardown — wait for it to actually
+            # finish rather than killing the process out from under its
+            # still-in-progress _stop_wpp_server().
+            self._teardown_complete_event.wait(
+                timeout=self._TEARDOWN_OWNED_ELSEWHERE_WAIT_SECONDS
+            )
         self._terminate_process()
 
     def quit_all_accounts(self):
@@ -2484,7 +2505,9 @@ class MainWindow(wx.Frame):
                 for other in others:
                     try:
                         logging.info("[quit-all] asking account %s to quit", other)
-                        ipc.request_quit(gd, other, timeout=10.0)
+                        # No explicit timeout: request_quit()'s own default
+                        # is sized to the other account's worst-case teardown.
+                        ipc.request_quit(gd, other)
                     except Exception:
                         logging.exception("[quit-all] request_quit failed for %s", other)
             except Exception:
@@ -3259,7 +3282,13 @@ class MainWindow(wx.Frame):
         # Drop the stale lockfile so a relaunch is not refused even if the
         # process was already gone but left the file behind.
         try:
-            udd = resource_path("api", "userDataDir", session_name)
+            # Matches _start_wpp_background()'s WINZAPP_USER_DATA_DIR, not
+            # resource_path("api", "userDataDir") — the latter is a
+            # --onefile launch's ephemeral extraction dir, gone by the time
+            # this wake-recovery path runs.
+            gd = getattr(self, "global_dir", None)
+            udd = (os.path.join(gd, "api", "userDataDir", session_name) if gd
+                   else resource_path("api", "userDataDir", session_name))
             for name in ("lockfile", "SingletonLock", "SingletonCookie", "SingletonSocket"):
                 p = os.path.join(udd, name)
                 if os.path.exists(p):
@@ -3547,23 +3576,26 @@ class MainWindow(wx.Frame):
         WPPConnect still initializing) is ambiguous during the first
         connection attempt of a session and gets the grace window instead.
         """
-        if getattr(self, "_shutting_down", False):
-            # The app is on its way out (real_exit()) — closing the
-            # WPPConnect session ourselves as part of shutdown looks
-            # identical, at this layer, to WhatsApp dropping the connection.
-            # Nothing about a deliberate quit should announce an "offline"
-            # transition with sound/speech in the second before the process
-            # actually exits.
+        if bool(getattr(self, "_shutting_down", False)):
+            # We just closed this session ourselves as part of quitting —
+            # looks identical, at this layer, to WhatsApp dropping the
+            # connection. The process exits moments later regardless, so
+            # nothing here needs to touch offline state, sound, or speech.
+            # NOT the same as the branch below: an update/self-restart still
+            # reconnects afterward, so those genuinely engage offline mode
+            # and only suppress the announcement.
             return
         connected = bool(connected)
         was = bool(getattr(self, "_wa_connected", False))
         self._wa_connected = connected
         # Nothing to do only when the flag *and* the derived offline state are
-        # both already consistent with `connected`.
+        # both already consistent with `connected`. _shutting_down already
+        # returned above, so the check below can only mean still-updating or
+        # still-self-restarting.
         if connected == was and self._auto_offline == (not connected):
             still_owed = (
                 not connected
-                and not getattr(self, "_wpp_updating", False)
+                and not self._self_inflicted_teardown_expected()
                 and getattr(self, "_offline_announce_deferred", False)
             )
             if not still_owed:
@@ -3637,10 +3669,11 @@ class MainWindow(wx.Frame):
 
         self._wa_offline_strikes += 1
 
-        if getattr(self, "_wpp_updating", False):
+        if self._self_inflicted_teardown_expected():
             logging.info(
-                "[connection] WPPConnect update in progress (%s) — engaging "
-                "offline mode and showing 'connecting' instead of 'offline'.",
+                "[connection] Self-inflicted session teardown in progress "
+                "(%s) — engaging offline mode and showing 'connecting' "
+                "instead of 'offline'.",
                 reason or "checked",
             )
             self._auto_offline = True
@@ -4233,6 +4266,14 @@ class MainWindow(wx.Frame):
         except Exception:
             logging.exception("[focus] restoring primary control focus failed")
 
+    # Bound for a caller that lost the _teardown_started_lock race to wait
+    # for the winning path's _teardown_complete_event before
+    # self-terminating. Sized above ipc.py's _QUIT_RELEASE_POLL_SECONDS
+    # (75s — the winning path's own teardown is bounded by that budget).
+    # Bounded rather than indefinite: if the event is somehow never set,
+    # this caller must still terminate on the user's original quit request.
+    _TEARDOWN_OWNED_ELSEWHERE_WAIT_SECONDS = 80.0
+
     def real_exit(self):
         """Completely close WinZapp: graceful teardown, then terminate.
 
@@ -4262,59 +4303,127 @@ class MainWindow(wx.Frame):
             pass
 
         def _teardown():
+            did_work = False
             try:
-                self._perform_shutdown()
+                did_work = self._perform_shutdown()
             finally:
+                if not did_work:
+                    # Another path (a concurrent _on_end_session(), or a
+                    # second overlapping quit) already owns teardown —
+                    # terminating immediately could os._exit() the process
+                    # while it is still mid _stop_wpp_server().
+                    self._teardown_complete_event.wait(
+                        timeout=self._TEARDOWN_OWNED_ELSEWHERE_WAIT_SECONDS
+                    )
                 self._terminate_process()
 
         threading.Thread(target=_teardown, daemon=True, name="winzapp-shutdown").start()
 
-    def _perform_shutdown(self):
+    def _perform_shutdown(self) -> bool:
         """Reversible shutdown: stop timers/threads, gracefully close the WPP
         session (waiting for its flush), stop the Node, close the DB. Does NOT
-        exit the process, so it is safe to call from the IPC quit handler."""
+        exit the process, so it is safe to call from the IPC quit handler.
+
+        Returns True if THIS call actually performed the teardown, False if
+        another path already owns it. Callers must not treat False the same
+        as True and immediately self-terminate — see
+        _teardown_complete_event's own comment for why."""
         # Set FIRST, before anything else: _stop_wpp_server() below closes
         # the WPPConnect session itself, which — while our WebSocket is
         # still connected — arrives as an ordinary "connection closed" event
         # indistinguishable from a real disconnect. _set_wa_connected()
         # checks this flag and skips entirely, so quitting never announces
         # "modo offline ativado" in the moment before the process exits.
-        if getattr(self, "_shutting_down", False):
-            return  # teardown already ran (e.g. real_exit after an IPC quit)
-        self._shutting_down = True
-        # Stop the presence keep-alive timer before tearing down
-        if hasattr(self, "_presence_timer") and self._presence_timer.IsRunning():
-            self._presence_timer.Stop()
-        # Also cancel a pending debounced activate/deactivate — otherwise it
-        # can fire mid-shutdown and spawn a presence POST + restart the timer
-        # just stopped above.
-        if getattr(self, "_presence_debounce_timer", None) is not None and self._presence_debounce_timer.IsRunning():
-            self._presence_debounce_timer.Stop()
-        for identity in list(getattr(self, "_incoming_call_watchdogs", {})):
-            self._cancel_incoming_call_watchdog(identity)
-        for identity in list(getattr(self, "_incoming_call_dialogs", {})):
-            self._close_incoming_call_dialog(identity)
-        if hasattr(self, "call_incoming_sound"):
-            self.call_incoming_sound.stop()
-        if getattr(self, "tray_icon", None) is not None:
+        #
+        # Locked (not a plain getattr-then-set) so this can never race
+        # _on_end_session() or a second concurrent call into this method.
+        with self._teardown_started_lock:
+            if getattr(self, "_shutting_down", False):
+                return False  # another path already owns teardown
+            self._shutting_down = True
+        try:
+            # Stop the presence keep-alive timer before tearing down
+            if hasattr(self, "_presence_timer") and self._presence_timer.IsRunning():
+                self._presence_timer.Stop()
+            # Also cancel a pending debounced activate/deactivate — otherwise it
+            # can fire mid-shutdown and spawn a presence POST + restart the timer
+            # just stopped above.
+            if getattr(self, "_presence_debounce_timer", None) is not None and self._presence_debounce_timer.IsRunning():
+                self._presence_debounce_timer.Stop()
+            for identity in list(getattr(self, "_incoming_call_watchdogs", {})):
+                self._cancel_incoming_call_watchdog(identity)
+            for identity in list(getattr(self, "_incoming_call_dialogs", {})):
+                self._close_incoming_call_dialog(identity)
+            if hasattr(self, "call_incoming_sound"):
+                self.call_incoming_sound.stop()
+            if getattr(self, "tray_icon", None) is not None:
+                try:
+                    self.tray_icon.RemoveIcon()
+                    self.tray_icon.Destroy()
+                except Exception:
+                    pass
+                self.tray_icon = None
+            if hasattr(self, "message_queue"):
+                self.message_queue.stop()
+            if getattr(self, "_update_checker", None) is not None:
+                self._update_checker.stop()
+            if getattr(self, "_wpp_update_checker", None) is not None:
+                self._wpp_update_checker.stop()
+            self._stop_wpp_server()
+            self._flush_pending_debounced_saves()
+            if hasattr(self, "db") and self.db is not None:
+                try:
+                    self.db.close()
+                except Exception:
+                    pass
+            return True
+        finally:
+            # Always, even on an exception above: a caller that lost the
+            # lock race is blocked on this event before self-terminating —
+            # leaving it unset would strand that caller for its full timeout.
+            self._teardown_complete_event.set()
+
+    def _flush_pending_debounced_saves(self):
+        """Synchronously run any pending debounced save BEFORE it can be lost.
+
+        _schedule_save() (0.15s debounce, chats/contacts -> self.db) and
+        _schedule_save_settings() (2s debounce, settings.json) each leave a
+        write sitting on its own daemon threading.Timer. Left alone, either
+        DatabaseBridge.close() rejects it once ``_closing`` flips, or
+        os._exit() kills the timer thread before it fires — os._exit()
+        never waits for other threads. Cancelling and running the callback
+        here, synchronously, beats both: the save runs on THIS thread before
+        either death trap exists.
+
+        Called from both _perform_shutdown() and _on_end_session()
+        (WM_ENDSESSION) — the latter never calls _perform_shutdown(), so
+        without this call here too a Windows shutdown/logoff would lose the
+        same pending writes with no protection at all.
+
+        Not airtight: the WebSocket stays connected throughout
+        _stop_wpp_server(), so a live event landing between this call
+        returning and db.close() running could still schedule a fresh save
+        that loses the same race. Narrows the window, does not close it.
+        """
+        with self._save_timer_lock:
+            pending_chat_save = self._save_timer is not None
+            if pending_chat_save:
+                self._save_timer.cancel()
+                self._save_timer = None
+            pending_settings_save = getattr(self, "_settings_save_timer", None) is not None
+            if pending_settings_save:
+                self._settings_save_timer.cancel()
+                self._settings_save_timer = None
+        if pending_chat_save:
             try:
-                self.tray_icon.RemoveIcon()
-                self.tray_icon.Destroy()
+                self._do_save()
             except Exception:
-                pass
-            self.tray_icon = None
-        if hasattr(self, "message_queue"):
-            self.message_queue.stop()
-        if getattr(self, "_update_checker", None) is not None:
-            self._update_checker.stop()
-        if getattr(self, "_wpp_update_checker", None) is not None:
-            self._wpp_update_checker.stop()
-        self._stop_wpp_server()
-        if hasattr(self, "db") and self.db is not None:
+                logging.exception("[_flush_pending_debounced_saves] _do_save() failed")
+        if pending_settings_save:
             try:
-                self.db.close()
+                self.save_settings()
             except Exception:
-                pass
+                logging.exception("[_flush_pending_debounced_saves] save_settings() failed")
 
     def _terminate_process(self):
         """Terminal exit — never returns.
@@ -6814,6 +6923,32 @@ class MainWindow(wx.Frame):
             except Exception:
                 logging.exception("[startup] node identity env injection failed (non-fatal)")
 
+            # WPPConnect's own defaults for the auth token store and the
+            # Chrome profile (customUserDataDir) are RELATIVE paths, resolved
+            # against the Node process's cwd (resource_path("api")). That is
+            # stable in --onedir/dev, but in --onefile it is PyInstaller's
+            # per-launch extraction temp dir — a fresh folder every launch —
+            # so anything written there is silently orphaned the moment the
+            # process exits, and the next launch's empty tokens/userDataDir
+            # folder finds nothing (WhatsApp then correctly asks for a fresh
+            # QR: the "closed WinZapp, relaunched, told the device was
+            # disconnected" report). Pointing both at an absolute,
+            # install-writable location (via config.ts/fileTokenStory.ts,
+            # which read these two env vars) fixes this for every build mode.
+            try:
+                # self.global_dir, not a "..", ".." walk up from data_path():
+                # this root is intentionally SHARED across accounts —
+                # WPPConnect isolates each session under its own
+                # userDataDir/<session_name> subfolder — and a relative
+                # walk-up silently breaks if the accounts/<id>/ nesting depth
+                # ever changes.
+                _persistent_api_dir = os.path.join(self.global_dir, "api")
+                _token_dir = os.path.join(_persistent_api_dir, "tokens")
+                os.environ["WINZAPP_USER_DATA_DIR"] = os.path.join(_persistent_api_dir, "userDataDir") + os.sep
+                os.environ["WINZAPP_TOKEN_STORE_DIR"] = _token_dir
+            except Exception:
+                logging.exception("[startup] persistent userDataDir/token-store env injection failed (non-fatal)")
+
             # Ensure dist/config.js has useChrome:false so WPPConnect always uses
             # Puppeteer's own bundled Chrome/Chromium instead of searching for a
             # system Chrome installation. Patched here at runtime so existing users
@@ -6973,6 +7108,33 @@ class MainWindow(wx.Frame):
         except Exception:
             pass
 
+    def _self_inflicted_teardown_expected(self) -> bool:
+        """True while WE are deliberately closing this account's own
+        WPPConnect session ourselves — a full app shutdown (_shutting_down),
+        a WPPConnect Server auto-update (_wpp_updating), a power-resume
+        zombie-session recovery restart (_recovery_restart_active), or an
+        in-place session restart after a detached Puppeteer page
+        (_restarting_wpp_session).
+
+        All four call POST /close-session on this account's own session
+        while the WebSocket stays deliberately connected throughout, so a
+        WebSocket "close" carrying loggedOut/401, an unlinked status-find
+        reading, or a status-session CLOSED reading during any of these four
+        windows is the direct, expected result of that call — never WhatsApp
+        actually unlinking the device. The two wake-from-sleep triggers
+        (_recovery_restart_active, _restarting_wpp_session) matter most in
+        practice: laptops sleep far more often than WinZapp is quit or
+        WPPConnect updated. Shared by on_connection_update()'s close branch,
+        on_wpp_status_find(), and check_wa_connection_http()'s CLOSED
+        auto-start guard so all three treat every self-inflicted path the
+        same way."""
+        return (
+            bool(getattr(self, "_shutting_down", False))
+            or bool(getattr(self, "_wpp_updating", False))
+            or bool(getattr(self, "_recovery_restart_active", False))
+            or bool(getattr(self, "_restarting_wpp_session", False))
+        )
+
     def _wait_for_session_flushed(self, token: str, timeout: float = None) -> bool:
         """Poll status-session until WPPConnect reports the session closed, or
         the timeout elapses. Returns True if it confirmed, False on timeout.
@@ -7041,21 +7203,76 @@ class MainWindow(wx.Frame):
             pass
         event.Skip()
 
+    # How long to wait after WM_ENDSESSION before assuming the shutdown was
+    # cancelled and undoing _shutting_down. Per Windows docs bEnding can in
+    # principle still be FALSE (another app vetoed the shutdown) — rare, but
+    # this flag is never reset anywhere else, and every logout-detection
+    # guard trusts it permanently once set. In the ordinary case the process
+    # is long gone within this window; this is a self-healing fallback for
+    # when it is not.
+    _END_SESSION_UNSTICK_SECONDS = 60.0
+
     def _on_end_session(self, event):
-        """Windows is shutting down: stop WPPConnect gracefully before we go."""
+        """Windows is shutting down: stop WPPConnect gracefully before we go.
+
+        Guarded by the same _teardown_started_lock _perform_shutdown() uses:
+        WM_ENDSESSION can arrive while a local quit or an IPC "quit" from
+        another account is already mid-teardown, and without this both would
+        call _stop_wpp_server() concurrently. When teardown already started
+        elsewhere, this only releases the shutdown-block-reason and gets out
+        of the way — it does not arm its own unstick timer, since resetting
+        _shutting_down while the other path is still tearing down would
+        reopen the self-inflicted-logout window.
+        """
         logging.warning("[_on_end_session] Windows is ending the session — stopping WPPConnect.")
-        self._shutting_down = True
+        with self._teardown_started_lock:
+            already_tearing_down = getattr(self, "_shutting_down", False)
+            self._shutting_down = True
+
+        if already_tearing_down:
+            try:
+                import ctypes
+                ctypes.windll.user32.ShutdownBlockReasonDestroy(self.GetHandle())
+            except Exception:
+                pass
+            event.Skip()
+            return
+
+        def _unstick_if_still_running():
+            self._shutting_down = False
+            # Left set, a later genuinely-new teardown's loser would see this
+            # abandoned attempt's event and wrongly assume it finished.
+            self._teardown_complete_event.clear()
+
         try:
-            # Bounded, and deliberately still on this thread: when this handler
-            # returns, Windows terminates the process, so a background thread
-            # doing the teardown would be killed mid-flush — the exact damage
-            # being avoided. See _on_query_end_session for where the 4s comes
-            # from, and why we do not veto to ask for more.
+            t = threading.Timer(self._END_SESSION_UNSTICK_SECONDS, _unstick_if_still_running)
+            t.daemon = True
+            t.start()
+        except Exception:
+            logging.exception("[_on_end_session] Failed to arm the _shutting_down safety timer")
+
+        try:
+            # Deliberately still on this thread: when this handler returns,
+            # Windows terminates the process, so a background thread doing
+            # the teardown would be killed mid-flush.
             self._shutdown_audit(
                 f"WM_ENDSESSION — teardown capped at {self._WINDOWS_SHUTDOWN_BUDGET}s")
             self._stop_wpp_server(budget=self._WINDOWS_SHUTDOWN_BUDGET)
         except Exception:
             logging.exception("[_on_end_session] Failed to stop WPPConnect cleanly")
+        try:
+            # This path never calls _perform_shutdown(), so without this
+            # call it has none of that method's write protection. Does NOT
+            # also close the DB here: bEnding can still turn out to be a
+            # shutdown another app cancels, and closing the DB now would
+            # leave it unusable if the user goes back to using WinZapp.
+            self._flush_pending_debounced_saves()
+        except Exception:
+            logging.exception("[_on_end_session] Failed to flush pending debounced saves")
+        # A caller that lost the lock race above waits on this before
+        # self-terminating — without it, it would sit out its full bounded
+        # wait instead of noticing this path already finished.
+        self._teardown_complete_event.set()
         try:
             import ctypes
             ctypes.windll.user32.ShutdownBlockReasonDestroy(self.GetHandle())
@@ -7088,6 +7305,74 @@ class MainWindow(wx.Frame):
     # process itself releasing userDataDir — instead of the HTTP status.
     _WPP_GRACEFUL_STOP_SECONDS = 10
 
+    # Extra grace on top of _SHUTDOWN_FLUSH_TIMEOUT for the auth token file
+    # to land on disk before killing Node. Bounded like every shutdown wait
+    # here: 5s covers an ordinary small-file write without stalling a user
+    # who genuinely wants out.
+    _TOKEN_PERSIST_GRACE_SECONDS = 5.0
+    _TOKEN_PERSIST_POLL_SECONDS = 0.2
+
+    def _wait_for_token_persisted(self, token: str) -> bool:
+        """Block (briefly, boundedly) until the auth token for `token`'s
+        session actually exists on disk at WINZAPP_TOKEN_STORE_DIR, or the
+        grace window runs out.
+
+        Guards the SECONDARY, REST-API-level token file
+        (<session>.data.json), not the primary credential store — for a
+        modern multi-device session that file is close to a placeholder
+        (WASecretBundle reports the literal string 'MultiDevice', not real
+        secret material). The REAL credential store is Chrome's own
+        userDataDir/IndexedDB (LevelDB) profile, protected by
+        _wait_for_session_flushed()'s wait for a genuine CLOSED status —
+        treat that as the function actually carrying the weight, this one as
+        a cheap, harmless second check in case some path still depends on
+        this file.
+
+        Returns True if found, False if the grace window ran out — callers
+        must treat False as "log it and proceed anyway", never as a reason
+        to keep the process alive forever.
+        """
+        token_dir = os.environ.get("WINZAPP_TOKEN_STORE_DIR")
+        session_name = (token or "").split(":")[0]
+        if not token_dir or not session_name:
+            return True  # nothing to check — never block on missing config
+        token_file = os.path.join(token_dir, f"{session_name}.data.json")
+        deadline = time.monotonic() + self._TOKEN_PERSIST_GRACE_SECONDS
+        while True:
+            try:
+                if os.path.isfile(token_file) and os.path.getsize(token_file) > 2:
+                    return True
+            except OSError:
+                pass
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(self._TOKEN_PERSIST_POLL_SECONDS)
+
+    # Short, bounded grace given to an already-running self-inflicted
+    # session restart (_recovery_restart_active / _restarting_wpp_session)
+    # to finish before _stop_wpp_server() proceeds. Neither holds
+    # _teardown_started_lock (they are a close+start cycle on their own
+    # thread, not teardown), so a quit landing mid-restart would otherwise
+    # race this method's own close-session/flush-wait against the restart's
+    # start-session on the same session — the restart's start-session can
+    # flip status back to INITIALIZING mid-flush-wait, starving it of the
+    # CLOSED reading and risking a "Session Unpaired" taskkill. Deliberately
+    # short, not their own ~30-60s worst case: this narrows the race rather
+    # than closing it.
+    _SELF_RESTART_YIELD_SECONDS = 5.0
+    _SELF_RESTART_YIELD_POLL_SECONDS = 0.2
+
+    def _yield_to_in_progress_self_restart(self):
+        if not (getattr(self, "_recovery_restart_active", False)
+                or getattr(self, "_restarting_wpp_session", False)):
+            return
+        deadline = time.monotonic() + self._SELF_RESTART_YIELD_SECONDS
+        while time.monotonic() < deadline:
+            if not (getattr(self, "_recovery_restart_active", False)
+                    or getattr(self, "_restarting_wpp_session", False)):
+                return
+            time.sleep(self._SELF_RESTART_YIELD_POLL_SECONDS)
+
     def _stop_wpp_server(self, budget: float = None):
         """Terminate the WPPConnect Server process and all its children.
 
@@ -7112,9 +7397,18 @@ class MainWindow(wx.Frame):
         Each account now runs its own Node on its own port, so we only ever kill
         the Node on THIS account's port.
 
-        Must not be called on the wx main thread: step 1 can legitimately block
-        for the whole grace budget.
+        Should not be called on the wx main thread when avoidable: step 1 can
+        block for the whole grace budget, and a blocked main thread stops the
+        message loop from pumping (Windows tags it "Not Responding"). One
+        caller does anyway — _update_wpp_server(), which needs to show a
+        modal dialog immediately after — an accepted tradeoff, not an
+        oversight. Every other caller runs this off the main thread.
         """
+        if budget is None:
+            # Skipped under a budget: this wait sits outside it, so honoring
+            # it during WM_ENDSESSION could add its full 5s on top of a 4s
+            # budget — past what triggers a "Not Responding" kill.
+            self._yield_to_in_progress_self_restart()
         # STEP 1: gracefully close our own session so its state is persisted,
         # regardless of whether we go on to stop the Node or leave it up. This
         # must happen for EVERY closing process, not just the last one.
@@ -7143,6 +7437,19 @@ class MainWindow(wx.Frame):
                              f"session={session_name!r} port={getattr(self,'wpp_port','?')} "
                              f"pre_close_status={pre_status!r}")
         if token:
+            # Decided from two independent signals, not one: pre_status is a
+            # single HTTP probe that returns "" on ANY failure (timeout,
+            # non-200, connection error), and a transient hiccup on exactly
+            # that probe would silently skip the token-persist wait below for
+            # a session that really was CONNECTED. self._wa_connected is a
+            # race-free second opinion updated continuously by
+            # _set_wa_connected(). Either saying "yes" is enough — a false
+            # positive costs a few extra seconds of wait, a false negative
+            # costs a lost/corrupted session.
+            session_was_connected = (
+                pre_status in ("CONNECTED", "open")
+                or getattr(self, "_wa_connected", False)
+            )
             try:
                 url = (
                     f"{self.wpp_server}:{self.wpp_port}"
@@ -7185,6 +7492,23 @@ class MainWindow(wx.Frame):
                     e,
                 )
                 self._shutdown_audit(f"close-session EXCEPTION ({e!r})")
+
+            # The literal "session is OK but the app is closing — do not let
+            # it fully close until the session is properly stored"
+            # requirement: runs UNCONDITIONALLY here, whether the try above
+            # succeeded or raised, as long as this run ever looked
+            # connected. Previously this lived inside the try block, so a
+            # close-session timeout/exception -- precisely the case where
+            # Chrome is most likely still mid-write -- skipped the wait
+            # entirely and went straight to taskkill. Regardless of whether
+            # the flush wait above already succeeded, since that polls the
+            # BROWSER's status, not the separate token file this app does
+            # not otherwise verify. Skipped entirely for a session that was
+            # never actually connected: there is nothing meaningful to wait
+            # for, same "nothing to lose" reasoning _on_disconnect() already
+            # applies to an unpaired account.
+            if session_was_connected:
+                self._wait_for_token_persisted(token)
 
         # STEP 2: stop OUR OWN Node. Each account now runs its own Node on its
         # own port (revised architecture), so there is no shared server to spare
@@ -8688,7 +9012,11 @@ class MainWindow(wx.Frame):
             gd = getattr(self, "global_dir", None)
             if not gd:
                 return
-            udd_root = os.path.abspath(resource_path("api", "userDataDir"))
+            # Matches _start_wpp_background()'s WINZAPP_USER_DATA_DIR, not
+            # resource_path("api", "userDataDir") — the latter is a
+            # --onefile launch's ephemeral extraction temp dir, already gone
+            # by the time this runs, so cleanup would silently find nothing.
+            udd_root = os.path.abspath(os.path.join(gd, "api", "userDataDir"))
             node_down = False  # circuit breaker: stop retrying logout once refused
             # Whole scan -> validate -> rmtree runs under the shared sessions_lock
             # so no other account can register/activate a name mid-cleanup, and
@@ -9787,6 +10115,12 @@ class MainWindow(wx.Frame):
                         # the whole passive observation window).
                         logging.info("[check_wa_connection_http] Skipping auto-start — "
                                      "recovery restart sequence in progress owns it.")
+                    elif self._self_inflicted_teardown_expected():
+                        # This CLOSED is the expected result of our own
+                        # close-session call — starting a fresh session here
+                        # would revive the browser moments before taskkill
+                        # force-kills it.
+                        pass
                     else:
                         try:
                             start_url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/start-session"

--- a/client/main.py
+++ b/client/main.py
@@ -478,6 +478,75 @@ BOOKMARK_ZERO_HOTKEY_ID = 0xB000
 _PREVIEW_ONLY_MESSAGE_TYPES = frozenset({"protocolMessage", "groupNotification"})
 
 
+# Marker file dropped in the new, persistent api/ root once the one-time move
+# below has run, so the scan never repeats (and never fights a second
+# account's process for the same folders on every launch).
+LEGACY_API_STATE_MARKER = ".migrated_from_install_dir"
+
+# The two folders WPPConnect writes a paired session into: the Chrome
+# profile - the REAL credential store - and the REST-level token file.
+LEGACY_API_STATE_DIRS = ("userDataDir", "tokens")
+
+
+def migrate_legacy_api_state(legacy_api_dir: str, persistent_api_dir: str) -> list:
+    """Move a pre-existing install's WhatsApp session state from the old,
+    cwd-relative location into the new persistent one. Returns what moved.
+
+    Until WINZAPP_USER_DATA_DIR/WINZAPP_TOKEN_STORE_DIR existed, both folders
+    were written relative to the Node process's cwd (``resource_path("api")``
+    - the install dir in a --onedir build, which is what every released
+    installer produces). Pointing them at ``<global_dir>/api`` fixes --onefile
+    losing them on every launch, but on its own it also aims every ALREADY
+    PAIRED install at an empty folder: Chrome starts on a virgin profile, the
+    token store reads nothing, and WhatsApp correctly asks for a fresh QR.
+    That is the exact "closed WinZapp, relaunched, told the device was
+    disconnected" report the new path exists to fix, so shipping the move
+    without this would deliver the bug as its own fix, once, to everybody.
+
+    Deliberately conservative - this runs against a real paired session:
+      * never overwrites anything already at the destination (a folder there
+        means this install is already using the new location);
+      * moves per folder, so a half-done previous attempt still completes;
+      * writes the marker only after a successful pass, but writes it even
+        when nothing needed moving, so a fresh install stops scanning;
+      * a failure is logged and swallowed - the caller must still be able to
+        start Node (the user re-pairs, which is no worse than not migrating).
+
+    Must be called BEFORE Node is spawned: moving a userDataDir out from
+    under a live Chrome would corrupt exactly what this is protecting.
+    """
+    moved = []
+    if not (legacy_api_dir and persistent_api_dir):
+        return moved
+    if os.path.abspath(legacy_api_dir) == os.path.abspath(persistent_api_dir):
+        return moved  # nothing to do: same folder (dev checkout edge case)
+    marker = os.path.join(persistent_api_dir, LEGACY_API_STATE_MARKER)
+    if os.path.exists(marker):
+        return moved
+    for name in LEGACY_API_STATE_DIRS:
+        src = os.path.join(legacy_api_dir, name)
+        dst = os.path.join(persistent_api_dir, name)
+        try:
+            if not os.path.isdir(src):
+                continue
+            if os.path.exists(dst):
+                continue
+            os.makedirs(persistent_api_dir, exist_ok=True)
+            shutil.move(src, dst)
+            moved.append(name)
+            logging.warning("[api-migrate] moved %s -> %s", src, dst)
+        except Exception:
+            logging.exception("[api-migrate] could not move %s -> %s", src, dst)
+            return moved  # leave the marker unwritten so the next launch retries
+    try:
+        os.makedirs(persistent_api_dir, exist_ok=True)
+        with open(marker, "w", encoding="utf-8") as fh:
+            fh.write(legacy_api_dir)
+    except Exception:
+        logging.exception("[api-migrate] could not write the migration marker")
+    return moved
+
+
 def is_countable_message(msg: dict) -> bool:
     """True for a message type that should count as real conversation
     activity (unread badge, chat-list sort order, notifications).
@@ -2594,7 +2663,16 @@ class MainWindow(wx.Frame):
             self._ipc_listener = ipc.IpcListener(
                 gd, acc_id,
                 on_activate=lambda source: wx.CallAfter(self._ipc_activate, source),
-                on_quit=lambda: wx.CallAfter(self._ipc_quit),
+                # NOT wx.CallAfter: _ipc_quit() runs the full graceful
+                # teardown (close-session + flush wait + Node stop + the
+                # loser path's bounded wait), tens of seconds' worth, and on
+                # the wx main thread that freezes this account's window -
+                # silently, for a screen-reader user - while a DIFFERENT
+                # account is the one quitting. real_exit() already runs the
+                # same teardown off the main thread for exactly this reason.
+                on_quit=lambda: threading.Thread(
+                    target=self._ipc_quit, daemon=True,
+                    name="winzapp-ipc-quit").start(),
                 released_predicate=lambda: getattr(self, "_ipc_released", False),
                 window_ready_predicate=lambda: getattr(self, "_window_ready", False),
             )
@@ -2640,6 +2718,10 @@ class MainWindow(wx.Frame):
         stop Node) FIRST, then flag released so the IPC handler can reply
         `released:True`, give it a beat to send that reply over the pipe, and
         only THEN take the process down for good.
+
+        Runs on its own thread (see _start_ipc_listener), never on the wx
+        main thread — everything below is bounded in tens of seconds and a
+        blocked main thread means a frozen, silent window.
         """
         did_work = False
         try:
@@ -2673,11 +2755,30 @@ class MainWindow(wx.Frame):
         no session is ever hard-killed by the shared-Node taskkill. We ask them
         sequentially and wait for each to confirm RELEASED before we exit, so
         the last-one-out Node teardown happens only after every session is
-        cleanly closed. Best-effort: an unresponsive peer never blocks our exit.
+        cleanly closed. Best-effort: a peer that never confirms is given up on
+        after request_quit()'s own timeout and never keeps us alive.
+
+        The peer loop runs on a worker thread, and that is not incidental:
+        request_quit()'s timeout is sized against a peer's worst-case
+        teardown (tens of seconds) and the loop is sequential, so with
+        several accounts open, running it here would freeze this window —
+        with no repaint and nothing spoken — for minutes. This method is
+        bound straight to the Exit menu item and the tray Exit, i.e. it is
+        always entered on the wx main thread. The window is hidden first so
+        quitting still looks instant.
         """
         gd = getattr(self, "global_dir", None)
         acc_id = getattr(self, "account_id", None)
-        if gd and acc_id:
+        if not (gd and acc_id):
+            self.real_exit()
+            return
+
+        try:
+            self.Hide()
+        except Exception:
+            pass
+
+        def _quit_peers_then_exit():
             try:
                 import ipc
                 import node_coord
@@ -2695,7 +2796,13 @@ class MainWindow(wx.Frame):
                         logging.exception("[quit-all] request_quit failed for %s", other)
             except Exception:
                 logging.exception("[quit-all] enumerating peers failed (non-fatal)")
-        self.real_exit()
+            # real_exit() only touches wx to Hide() (already done above) and
+            # then hands off to its own thread, but keep it on the main
+            # thread anyway so the wx contract is not quietly widened here.
+            wx.CallAfter(self.real_exit)
+
+        threading.Thread(target=_quit_peers_then_exit, daemon=True,
+                         name="winzapp-quit-all").start()
 
     def _refresh_menubar(self):
         """Retranslate the menu bar labels after a language change."""
@@ -7134,6 +7241,14 @@ class MainWindow(wx.Frame):
                 _token_dir = os.path.join(_persistent_api_dir, "tokens")
                 os.environ["WINZAPP_USER_DATA_DIR"] = os.path.join(_persistent_api_dir, "userDataDir") + os.sep
                 os.environ["WINZAPP_TOKEN_STORE_DIR"] = _token_dir
+                # One-time move of an ALREADY PAIRED install's session state
+                # from the old cwd-relative location. Without it, every
+                # existing user is pointed at an empty folder on their first
+                # launch after this change and is asked to pair again - the
+                # very symptom the new path exists to remove. Runs here, with
+                # Node not yet spawned, because moving a userDataDir out from
+                # under a live Chrome would corrupt it.
+                migrate_legacy_api_state(resource_path("api"), _persistent_api_dir)
             except Exception:
                 logging.exception("[startup] persistent userDataDir/token-store env injection failed (non-fatal)")
 
@@ -7397,7 +7512,10 @@ class MainWindow(wx.Frame):
     # this flag is never reset anywhere else, and every logout-detection
     # guard trusts it permanently once set. In the ordinary case the process
     # is long gone within this window; this is a self-healing fallback for
-    # when it is not.
+    # when it is not. Deliberately BELOW
+    # _TEARDOWN_OWNED_ELSEWHERE_WAIT_SECONDS (80s): a loser blocked on
+    # _teardown_complete_event must never outlive the timer that would have
+    # freed it. Raise one and re-check the other.
     _END_SESSION_UNSTICK_SECONDS = 60.0
 
     def _on_end_session(self, event):
@@ -7407,10 +7525,11 @@ class MainWindow(wx.Frame):
         WM_ENDSESSION can arrive while a local quit or an IPC "quit" from
         another account is already mid-teardown, and without this both would
         call _stop_wpp_server() concurrently. When teardown already started
-        elsewhere, this only releases the shutdown-block-reason and gets out
-        of the way — it does not arm its own unstick timer, since resetting
-        _shutting_down while the other path is still tearing down would
-        reopen the self-inflicted-logout window.
+        elsewhere, this waits (bounded by _WINDOWS_SHUTDOWN_BUDGET) for that
+        path's _teardown_complete_event before releasing the
+        shutdown-block-reason — it does not arm its own unstick timer, since
+        resetting _shutting_down while the other path is still tearing down
+        would reopen the self-inflicted-logout window.
         """
         logging.warning("[_on_end_session] Windows is ending the session — stopping WPPConnect.")
         with self._teardown_started_lock:
@@ -7418,6 +7537,24 @@ class MainWindow(wx.Frame):
             self._shutting_down = True
 
         if already_tearing_down:
+            # Do NOT just get out of the way: returning here hands control
+            # straight back to Windows, which terminates the process at once
+            # - potentially two seconds into a teardown whose flush wait
+            # alone is budgeted at _SHUTDOWN_FLUSH_TIMEOUT. That kills the
+            # session mid-write and leaves the profile unusable, which is the
+            # STARTUP-with-no-_stop_wpp_server corruption pattern this whole
+            # area exists to prevent. Hold the shutdown block open for the
+            # same budget the owning path would have got here, and let
+            # _teardown_complete_event release us the moment it is genuinely
+            # done (usually well inside it).
+            logging.warning("[_on_end_session] teardown already owned elsewhere - "
+                            "waiting up to %ss for it to finish.",
+                            self._WINDOWS_SHUTDOWN_BUDGET)
+            finished = self._teardown_complete_event.wait(
+                timeout=self._WINDOWS_SHUTDOWN_BUDGET)
+            if not finished:
+                logging.warning("[_on_end_session] the owning teardown did not "
+                                "finish within the Windows budget - going anyway.")
             try:
                 import ctypes
                 ctypes.windll.user32.ShutdownBlockReasonDestroy(self.GetHandle())
@@ -7427,10 +7564,19 @@ class MainWindow(wx.Frame):
             return
 
         def _unstick_if_still_running():
-            self._shutting_down = False
-            # Left set, a later genuinely-new teardown's loser would see this
-            # abandoned attempt's event and wrongly assume it finished.
-            self._teardown_complete_event.clear()
+            # Under the same lock as every other mutation of these two: an
+            # unlocked reset can land between a genuinely-new teardown taking
+            # the flag and its finally setting the event, clearing an event
+            # that belongs to a teardown which really did finish and leaving
+            # that teardown's loser blocked for its whole timeout.
+            with self._teardown_started_lock:
+                if not getattr(self, "_shutting_down", False):
+                    return  # somebody already reset it
+                self._shutting_down = False
+                # Left set, a later genuinely-new teardown's loser would see
+                # this abandoned attempt's event and wrongly assume it
+                # finished.
+                self._teardown_complete_event.clear()
 
         try:
             t = threading.Timer(self._END_SESSION_UNSTICK_SECONDS, _unstick_if_still_running)
@@ -7587,10 +7733,13 @@ class MainWindow(wx.Frame):
 
         Should not be called on the wx main thread when avoidable: step 1 can
         block for the whole grace budget, and a blocked main thread stops the
-        message loop from pumping (Windows tags it "Not Responding"). One
-        caller does anyway — _update_wpp_server(), which needs to show a
-        modal dialog immediately after — an accepted tradeoff, not an
-        oversight. Every other caller runs this off the main thread.
+        message loop from pumping (Windows tags it "Not Responding"). Exactly
+        two callers do anyway, both deliberately: _update_wpp_server(), which
+        needs to show a modal dialog immediately after, and _on_end_session(),
+        where returning from the handler is what lets Windows kill us — and
+        that one passes an explicit `budget` to cap the wait. Every other
+        caller (real_exit's teardown thread, _ipc_quit's own thread) runs
+        this off the main thread; check that before adding a new one.
         """
         if budget is None:
             # Skipped under a budget: this wait sits outside it, so honoring
@@ -8736,7 +8885,17 @@ class MainWindow(wx.Frame):
             existing = getattr(self, "_settings_save_timer", None)
             if existing is not None:
                 existing.cancel()
-            t = threading.Timer(2.0, self.save_settings)
+            def _fire():
+                # Clear the handle FIRST: left dangling after the timer
+                # fired, _flush_pending_debounced_saves() reads it as a
+                # still-pending write and re-saves settings.json on every
+                # single shutdown from the first settings change onwards.
+                with self._save_timer_lock:
+                    if self._settings_save_timer is t:
+                        self._settings_save_timer = None
+                self.save_settings()
+
+            t = threading.Timer(2.0, _fire)
             t.daemon = True
             self._settings_save_timer = t
             t.start()

--- a/client/ui/dialogs/api_setup.py
+++ b/client/ui/dialogs/api_setup.py
@@ -197,6 +197,7 @@ _CUSTOM_SRC_FILES = [
     "src/util/createSessionUtil.ts",
     "src/util/sessionUtil.ts",
     "src/util/functions.ts",
+    "src/util/tokenStore/fileTokenStory.ts",
     "src/middleware/statusConnection.ts",
     "src/middleware/auth.ts",
     "src/dto/sync.ts",

--- a/client/ui/dialogs/connect.py
+++ b/client/ui/dialogs/connect.py
@@ -1458,8 +1458,73 @@ class Connect:
                                   redact_api_error(e))
             threading.Thread(target=_close_api_session, daemon=True).start()
 
+    # Bounded grace given to a JUST-STARTED pairing attempt before honoring
+    # a Quit/close that lands while Chrome is still opening WhatsApp Web for
+    # the first time. Without this, closing a few seconds after clicking
+    # "Conectar com QR code" (or entering a phone number) killed Chrome
+    # mid-launch, before it produced anything to scan/type. Chrome's first
+    # real page load routinely takes 10-25s; 30s covers that without
+    # stalling a user who wants out anywhere near the pairing flow's own
+    # ~90s wait.
+    _PAIRING_STARTUP_GRACE_SECONDS = 30.0
+    _PAIRING_STARTUP_POLL_SECONDS = 0.5
+
+    def _wait_for_pairing_startup_settled(self):
+        """Block (briefly, boundedly) so Chrome finishes its FIRST attempt at
+        producing a QR/pairing code before we close on the user's way out.
+
+        No-op unless a pairing attempt is actually in flight AND has not yet
+        produced anything — an attempt that never started, or one that
+        already has its QR/code on screen, returns immediately. Must be
+        called BEFORE the caller disconnects the WebSocket or clears
+        _pairing_in_progress, since both are read here.
+        """
+        if not getattr(self.main_window, "_pairing_in_progress", False):
+            return
+        mode = getattr(self, "connection_mode", None)
+        deadline = time.monotonic() + self._PAIRING_STARTUP_GRACE_SECONDS
+        if mode == "phone":
+            ws = getattr(self.main_window, "ws", None)
+            event = getattr(ws, "_phone_code_event", None) if ws else None
+            if event is None or event.is_set():
+                return
+            logging.info("[_wait_for_pairing_startup_settled] phone pairing in flight, "
+                         "waiting up to %.0fs for a code before closing",
+                         self._PAIRING_STARTUP_GRACE_SECONDS)
+            # Blocks the wx main thread with no repaint/accessibility events
+            # pumped — silent dead air looks like a hang and invites a
+            # force-kill mid-wait, the outcome this method exists to
+            # prevent. Reuses the existing "connecting" string.
+            self.main_window.output(self.i18n.t("connecting") or "Conectando...")
+            event.wait(timeout=max(0.0, deadline - time.monotonic()))
+            return
+        if mode == "qrcode":
+            token = getattr(self.main_window, "token", "") or getattr(self, "_last_started_qr_token", "")
+            if not token:
+                return
+            logging.info("[_wait_for_pairing_startup_settled] QR pairing in flight, "
+                         "waiting up to %.0fs for a QR before closing",
+                         self._PAIRING_STARTUP_GRACE_SECONDS)
+            self.main_window.output(self.i18n.t("connecting") or "Conectando...")
+            url = f"{self.main_window.wpp_server}:{self.main_window.wpp_port}/api/{token}/status-session"
+            headers = self._wpp_headers()
+            while time.monotonic() < deadline:
+                try:
+                    resp = api_get(url, headers=headers, timeout=5)
+                    if resp.status_code in (200, 201):
+                        data = resp.json()
+                        payload = data.get("response") if isinstance(data.get("response"), dict) else data
+                        qr = data.get("qrcode") or (payload or {}).get("qrcode")
+                        status = data.get("status") or (payload or {}).get("status")
+                        if qr or status in ("CONNECTED", "qrReadSuccess", "inChat"):
+                            return
+                except Exception:
+                    pass
+                time.sleep(self._PAIRING_STARTUP_POLL_SECONDS)
+
     def on_dialog_close(self, event):
         logging.info("[on_dialog_close] Dialog close event triggered.")
+        self._wait_for_pairing_startup_settled()
         # Invalidate any in-flight _bg_pairing_flow() — see on_continue().
         self._pairing_attempt_id += 1
         self.main_window._pairing_in_progress = False
@@ -1477,6 +1542,7 @@ class Connect:
 
     def on_quit_from_connect(self, event):
         logging.info("[on_quit_from_connect] Quit requested from connection dialog.")
+        self._wait_for_pairing_startup_settled()
         self._pairing_attempt_id += 1
         self.main_window._pairing_in_progress = False
         if hasattr(self.main_window, 'ws') and self.main_window.ws:

--- a/client/ui/dialogs/connect.py
+++ b/client/ui/dialogs/connect.py
@@ -28,6 +28,38 @@ _WEBSOCKET_EVENTS = [
 ]
 
 
+# Terminal status-session readings: no session is coming up at all, so there
+# is nothing for the pairing startup grace to wait for. Without this the
+# common "start-session failed, user hits Quit" case burned the whole 30s
+# budget polling a session that answers CLOSED on every single poll.
+_PAIRING_STARTUP_DEAD_STATUSES = frozenset({"CLOSED", "DESTROYED", ""})
+
+# Readings that mean the attempt already produced what the user needs (or
+# does not need one any more).
+_PAIRING_STARTUP_READY_STATUSES = frozenset({"CONNECTED", "qrReadSuccess", "inChat"})
+
+
+def pairing_startup_settled(data) -> bool:
+    """True when a status-session payload means the pairing startup grace has
+    nothing left to wait for - either a QR/code exists, the session is
+    already connected, or no session is coming up at all.
+
+    Module-level and payload-only so the classification can be tested
+    without a Connect instance (which needs main_window, a WebSocket, HTTP
+    and wx just to exist). WPPConnect answers this endpoint both flat and
+    wrapped in "response", so both shapes are read.
+    """
+    if not isinstance(data, dict):
+        return False
+    payload = data.get("response") if isinstance(data.get("response"), dict) else data
+    qr = data.get("qrcode") or (payload or {}).get("qrcode")
+    status = data.get("status") or (payload or {}).get("status") or ""
+    if qr:
+        return True
+    return (status in _PAIRING_STARTUP_READY_STATUSES
+            or status in _PAIRING_STARTUP_DEAD_STATUSES)
+
+
 class Connect:
     def __init__(self, main_window):
         self.main_window = main_window
@@ -1474,10 +1506,18 @@ class Connect:
         producing a QR/pairing code before we close on the user's way out.
 
         No-op unless a pairing attempt is actually in flight AND has not yet
-        produced anything — an attempt that never started, or one that
-        already has its QR/code on screen, returns immediately. Must be
-        called BEFORE the caller disconnects the WebSocket or clears
-        _pairing_in_progress, since both are read here.
+        produced anything - an attempt that never started, one that already
+        has its QR/code on screen, and one whose session is definitively not
+        coming up all return immediately. Must be called BEFORE the caller
+        disconnects the WebSocket or clears _pairing_in_progress, since both
+        are read here.
+
+        NEVER call this on the wx main thread - it blocks for up to
+        _PAIRING_STARTUP_GRACE_SECONDS with no repaint and no accessibility
+        events pumped, which for a screen-reader user is 30 seconds of
+        silence on a window Windows has already tagged "Not Responding", and
+        whose most likely next move is the force-kill this whole method
+        exists to prevent. Go through _defer_close_for_pairing_startup().
         """
         if not getattr(self.main_window, "_pairing_in_progress", False):
             return
@@ -1491,11 +1531,6 @@ class Connect:
             logging.info("[_wait_for_pairing_startup_settled] phone pairing in flight, "
                          "waiting up to %.0fs for a code before closing",
                          self._PAIRING_STARTUP_GRACE_SECONDS)
-            # Blocks the wx main thread with no repaint/accessibility events
-            # pumped — silent dead air looks like a hang and invites a
-            # force-kill mid-wait, the outcome this method exists to
-            # prevent. Reuses the existing "connecting" string.
-            self.main_window.output(self.i18n.t("connecting") or "Conectando...")
             event.wait(timeout=max(0.0, deadline - time.monotonic()))
             return
         if mode == "qrcode":
@@ -1505,26 +1540,65 @@ class Connect:
             logging.info("[_wait_for_pairing_startup_settled] QR pairing in flight, "
                          "waiting up to %.0fs for a QR before closing",
                          self._PAIRING_STARTUP_GRACE_SECONDS)
-            self.main_window.output(self.i18n.t("connecting") or "Conectando...")
             url = f"{self.main_window.wpp_server}:{self.main_window.wpp_port}/api/{token}/status-session"
             headers = self._wpp_headers()
             while time.monotonic() < deadline:
                 try:
                     resp = api_get(url, headers=headers, timeout=5)
                     if resp.status_code in (200, 201):
-                        data = resp.json()
-                        payload = data.get("response") if isinstance(data.get("response"), dict) else data
-                        qr = data.get("qrcode") or (payload or {}).get("qrcode")
-                        status = data.get("status") or (payload or {}).get("status")
-                        if qr or status in ("CONNECTED", "qrReadSuccess", "inChat"):
+                        if pairing_startup_settled(resp.json()):
                             return
                 except Exception:
                     pass
                 time.sleep(self._PAIRING_STARTUP_POLL_SECONDS)
 
+    def _defer_close_for_pairing_startup(self, resume) -> bool:
+        """Run the startup grace OFF the wx thread and re-issue the close.
+
+        Returns True if the caller must back off right now - the wait was
+        handed to a worker thread and `resume` will be invoked on the wx
+        thread once it settles (or the grace runs out). Returns False when
+        there is nothing to wait for, or when the wait has already been done
+        (or refused) once, in which case the caller just proceeds.
+
+        Waiting only ONCE per dialog is the point of the flag: a user who
+        closes again while the grace is running is telling us plainly that
+        they want out, and the second attempt goes straight through.
+        """
+        if getattr(self, "_pairing_startup_wait_done", False):
+            return False
+        if not getattr(self.main_window, "_pairing_in_progress", False):
+            return False
+        self._pairing_startup_wait_done = True
+        # Spoken on the wx thread, before the wait starts, so the dialog is
+        # never silent while it is held open. Reuses the existing key.
+        try:
+            self.main_window.output(self.i18n.t("connecting") or "Conectando...")
+        except Exception:
+            pass
+
+        def _worker():
+            try:
+                self._wait_for_pairing_startup_settled()
+            except Exception:
+                logging.exception("[_defer_close_for_pairing_startup] wait failed")
+            finally:
+                wx.CallAfter(resume)
+
+        threading.Thread(target=_worker, daemon=True,
+                         name="winzapp-pairing-grace").start()
+        return True
+
     def on_dialog_close(self, event):
         logging.info("[on_dialog_close] Dialog close event triggered.")
-        self._wait_for_pairing_startup_settled()
+        if event.CanVeto() and self._defer_close_for_pairing_startup(
+                lambda: self.connection_dial.Close()):
+            # Held open, not frozen: the grace runs on a worker thread and
+            # re-issues this close when it settles. A close that cannot be
+            # vetoed (the app is going down around us) is honored at once -
+            # blocking here would be the freeze this avoids.
+            event.Veto()
+            return
         # Invalidate any in-flight _bg_pairing_flow() — see on_continue().
         self._pairing_attempt_id += 1
         self.main_window._pairing_in_progress = False
@@ -1542,7 +1616,9 @@ class Connect:
 
     def on_quit_from_connect(self, event):
         logging.info("[on_quit_from_connect] Quit requested from connection dialog.")
-        self._wait_for_pairing_startup_settled()
+        if self._defer_close_for_pairing_startup(
+                lambda: self.on_quit_from_connect(event)):
+            return
         self._pairing_attempt_id += 1
         self.main_window._pairing_in_progress = False
         if hasattr(self.main_window, 'ws') and self.main_window.ws:

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ testpaths = tests
 pythonpath = client
 asyncio_mode = auto
 markers =
+    wxgui: creates a real top-level wx window (see below)
     slow: tests that run migration on large datasets
     integration: tests that require a real wx.App
     load: synthetic load tests with configurable scenario size

--- a/setup_api.py
+++ b/setup_api.py
@@ -76,6 +76,7 @@ CUSTOM_SRC_FILES = [
     "src/util/createSessionUtil.ts",
     "src/util/sessionUtil.ts",
     "src/util/functions.ts",
+    "src/util/tokenStore/fileTokenStory.ts",
     "src/middleware/statusConnection.ts",
     "src/middleware/auth.ts",
     "src/dto/sync.ts",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,6 +260,39 @@ def set_clipboard_data(make_data_object, attempts=10, delay=0.05):
     return False
 
 
+
+def hidden_frame(**kwargs):
+    """A real wx.Frame for tests that need a live parent window, created so
+    the DESKTOP never sees it.
+
+    A plain `wx.Frame(None)` is a normal top-level window: Windows gives it a
+    taskbar button and, as it is created and destroyed, moves the foreground
+    around. A screen reader reacts to that. Running the suite on a machine
+    with NVDA active crashed NVDA repeatedly, and its traceback named the
+    mechanism exactly - event_gainFocus -> reportFocus -> getDialogText ->
+    IAccessible _get_children -> oleacc.AccessibleObjectFromEvent: NVDA got
+    focus on one of these windows and was still enumerating its children over
+    COM when the test destroyed it, so the object it was reading vanished
+    mid-call. Dozens of these windows appear and disappear within a single
+    pytest run, which makes that race very easy to lose.
+
+    Off-screen (well outside any real monitor), WS_EX_TOOLWINDOW and no
+    taskbar button: the window is fully real - it has an HWND, children lay
+    out and size normally, and every test that needs a parent still works -
+    but it never becomes the foreground window, so no focus event is ever
+    raised for a screen reader to chase.
+
+    Tests must still Destroy() what they create; this only stops the window
+    being visible to the desktop while it lives.
+    """
+    import wx
+
+    kwargs.setdefault("pos", (-32000, -32000))
+    kwargs.setdefault(
+        "style", wx.FRAME_TOOL_WINDOW | wx.FRAME_NO_TASKBAR | wx.DEFAULT_FRAME_STYLE
+    )
+    return wx.Frame(None, **kwargs)
+
 def set_clipboard_text(text):
     """Write plain text to the clipboard, with the same retry guarantee."""
     import wx

--- a/tests/test_account_manager_button_visibility.py
+++ b/tests/test_account_manager_button_visibility.py
@@ -18,6 +18,7 @@ tests/test_contact_action_buttons.py).
 import wx
 
 from account_ui import AccountManagerDialog
+from tests.conftest import hidden_frame
 
 
 def _acc(aid, state="paired"):
@@ -54,7 +55,7 @@ class _Stub:
 
 class TestAccountManagerButtonVisibility:
     def test_current_account_hides_open_and_pair(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame, [_acc(CURRENT)], 0)
             stub._update_button_visibility()
@@ -64,7 +65,7 @@ class TestAccountManagerButtonVisibility:
             frame.Destroy()
 
     def test_other_paired_account_shows_open_but_not_pair_or_restore(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame, [_acc(OTHER_PAIRED)], 0)
             stub._update_button_visibility()
@@ -76,7 +77,7 @@ class TestAccountManagerButtonVisibility:
             frame.Destroy()
 
     def test_other_pending_account_shows_open_and_pair(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame, [_acc(OTHER_PENDING, state="pending")], 0)
             stub._update_button_visibility()
@@ -87,7 +88,7 @@ class TestAccountManagerButtonVisibility:
             frame.Destroy()
 
     def test_archived_account_shows_restore_but_not_archive(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame, [_acc(OTHER_ARCHIVED, state="archived")], 0)
             stub._update_button_visibility()
@@ -97,7 +98,7 @@ class TestAccountManagerButtonVisibility:
             frame.Destroy()
 
     def test_no_selection_hides_every_conditional_button(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame, [_acc(OTHER_PAIRED)], -1)
             stub._update_button_visibility()

--- a/tests/test_add_member_contact_filter.py
+++ b/tests/test_add_member_contact_filter.py
@@ -17,6 +17,7 @@ wx.ListCtrl — same approach as the rest of this test suite.
 import wx
 
 from ui.dialogs.add_member_dialog import AddMemberDialog
+from tests.conftest import hidden_frame
 
 
 class _Stub:
@@ -33,7 +34,7 @@ class TestAddMemberContactFilter:
     def test_group_participant_only_entry_is_excluded(self, wx_app):
         """No isMyContact/isSaved, no 1:1 chat — just a name learned from
         some other group's presence updates."""
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             jid = "5511999999999@s.whatsapp.net"
             stub = _Stub(frame, {jid: {"name": "Alice", "pushName": "Alice"}})
@@ -44,7 +45,7 @@ class TestAddMemberContactFilter:
 
     def test_genuine_whatsapp_contact_is_included(self, wx_app):
         jid = "5511999999999@s.whatsapp.net"
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame, {jid: {"name": "Alice", "isMyContact": True}})
             stub._populate_contacts()
@@ -54,7 +55,7 @@ class TestAddMemberContactFilter:
 
     def test_locally_added_contact_is_included(self, wx_app):
         jid = "5511999999999@s.whatsapp.net"
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame, {jid: {"name": "Alice", "isSaved": True}})
             stub._populate_contacts()
@@ -67,7 +68,7 @@ class TestAddMemberContactFilter:
         address book — WhatsApp may never flag them isMyContact, but the
         user clearly already has a real conversation with them."""
         jid = "5511999999999@s.whatsapp.net"
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(
                 frame,
@@ -81,7 +82,7 @@ class TestAddMemberContactFilter:
 
     def test_groups_are_always_excluded_regardless_of_flags(self, wx_app):
         jid = "123456789-987654321@g.us"
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame, {jid: {"name": "Some Group", "isMyContact": True}})
             stub._populate_contacts()
@@ -92,7 +93,7 @@ class TestAddMemberContactFilter:
     def test_mixed_list_keeps_only_the_legitimate_ones(self, wx_app):
         real = "5511111111111@s.whatsapp.net"
         leaked = "5522222222222@s.whatsapp.net"
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame, {
                 real:   {"name": "Real Contact", "isMyContact": True},

--- a/tests/test_api_patches_in_sync.py
+++ b/tests/test_api_patches_in_sync.py
@@ -68,6 +68,7 @@ MIRRORED_FILES = [
     "src/util/createSessionUtil.ts",
     "src/util/sessionUtil.ts",
     "src/util/functions.ts",
+    "src/util/tokenStore/fileTokenStory.ts",
     "src/middleware/statusConnection.ts",
     "src/middleware/auth.ts",
     "src/dto/sync.ts",

--- a/tests/test_contact_action_buttons.py
+++ b/tests/test_contact_action_buttons.py
@@ -15,6 +15,7 @@ same approach as tests/test_group_data_dialog_admin_ui.py.
 import wx
 
 from ui.dialogs.conversation_data_dialog import ConversationDataDialog
+from tests.conftest import hidden_frame
 
 
 class _FakeI18n:
@@ -95,7 +96,7 @@ class TestLocalContactEntry:
 
 class TestPopulateContactActionButtons:
     def test_shows_only_add_when_no_local_contact_exists(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub("5511999999999@s.whatsapp.net", frame)
             stub._populate_contact_action_buttons()
@@ -107,7 +108,7 @@ class TestPopulateContactActionButtons:
             frame.Destroy()
 
     def test_shows_edit_and_delete_when_a_local_contact_exists(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             jid = "5511999999999@s.whatsapp.net"
             stub = _Stub(jid, frame)
@@ -124,7 +125,7 @@ class TestPopulateContactActionButtons:
         """Simulates what _on_add_contact() does after a successful add:
         re-running this must swap the button set without leaving stale
         widgets from the previous state around."""
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             jid = "5511999999999@s.whatsapp.net"
             stub = _Stub(jid, frame)

--- a/tests/test_emoji_picker.py
+++ b/tests/test_emoji_picker.py
@@ -6,6 +6,10 @@ from ui.dialogs.emoji_picker import (
     filter_emojis,
     insert_emoji,
 )
+import pytest
+
+# Constructs a REAL top-level wx dialog - see the wxgui marker in pytest.ini.
+pytestmark = pytest.mark.wxgui
 
 
 class _TextCtrl:

--- a/tests/test_end_session_unstick.py
+++ b/tests/test_end_session_unstick.py
@@ -1,0 +1,175 @@
+"""Tests for MainWindow._on_end_session()'s self-healing _shutting_down reset.
+
+_shutting_down is never reset anywhere else in the codebase, and every
+logout-detection guard added against the self-inflicted-close bug
+(on_connection_update's "close" branch, on_wpp_status_find,
+check_wa_connection_http's CLOSED auto-start) now trusts it permanently for
+the rest of the process's life once set. _on_end_session() sets it on
+WM_ENDSESSION (Windows telling the app the machine is shutting down) --  but
+per Windows' own documented semantics WM_ENDSESSION's bEnding can in
+principle still be FALSE (another app vetoed a shutdown this one already
+got as far as receiving notice of). If that ever happens and the process
+keeps running, _shutting_down would otherwise stay True forever, silently
+disabling real logout detection for the rest of the session.
+
+WebSocketClient/MainWindow are not directly involved here; only
+_on_end_session and the timer it arms are exercised, bound onto a stub (no
+wx.App / real Windows session needed).
+"""
+
+import threading
+import time
+
+from main import MainWindow
+
+
+class _Stub:
+    _on_end_session = MainWindow._on_end_session
+    _END_SESSION_UNSTICK_SECONDS = 0.05
+    _WINDOWS_SHUTDOWN_BUDGET = MainWindow._WINDOWS_SHUTDOWN_BUDGET
+
+    def __init__(self, already_shutting_down=False):
+        self._shutting_down = already_shutting_down
+        self._teardown_started_lock = threading.Lock()
+        self._teardown_complete_event = threading.Event()
+        self.stop_wpp_server_calls = 0
+        self.flush_calls = 0
+
+    def _shutdown_audit(self, msg):
+        pass
+
+    def _stop_wpp_server(self, budget=None):
+        self.stop_wpp_server_calls += 1
+
+    def _flush_pending_debounced_saves(self):
+        self.flush_calls += 1
+
+    def GetHandle(self):
+        return 0
+
+
+class _FakeEvent:
+    def __init__(self):
+        self.skipped = False
+
+    def Skip(self):
+        self.skipped = True
+
+
+class TestShuttingDownIsSetImmediately:
+    def test_flag_set_and_stop_wpp_server_called(self):
+        s = _Stub()
+        event = _FakeEvent()
+
+        s._on_end_session(event)
+
+        assert s._shutting_down is True
+        assert s.stop_wpp_server_calls == 1
+        assert event.skipped is True
+
+    def test_signals_teardown_complete_when_it_owns_teardown(self):
+        """A real_exit()/_ipc_quit() call that lost the lock race waits on
+        this event before self-terminating -- if this path never sets it,
+        that caller sits out its full 60-85s bound instead of noticing this
+        one already finished in a few milliseconds."""
+        s = _Stub()
+
+        s._on_end_session(_FakeEvent())
+
+        assert s._teardown_complete_event.is_set()
+
+
+class TestDoesNotDoubleTeardownWhenAlreadyInProgress:
+    """The gap found by re-reviewing this method against _perform_shutdown():
+    both used to set/check _shutting_down without any shared lock, so a
+    local quit (real_exit()'s background thread) racing a WM_ENDSESSION (or
+    an IPC "quit" from another account, also delivered on the wx main
+    thread) could see _shutting_down still False on both sides and BOTH
+    call _stop_wpp_server() concurrently -- two threads racing on the same
+    self.wpp_process and taskkill target. _teardown_started_lock closes
+    that: whichever caller wins the lock proceeds normally, the other
+    (finding _shutting_down already True inside the lock) must not repeat
+    the teardown or arm a second unstick timer."""
+
+    def test_stop_wpp_server_is_not_called_again_when_teardown_already_started(self):
+        s = _Stub(already_shutting_down=True)
+        event = _FakeEvent()
+
+        s._on_end_session(event)
+
+        assert s.stop_wpp_server_calls == 0
+        assert s.flush_calls == 0
+        assert event.skipped is True
+
+    def test_does_not_signal_completion_for_teardown_it_does_not_own(self):
+        """This path only skips out of the way -- the OTHER path (still
+        genuinely running) is the one whose own finish should set the event,
+        not this early return."""
+        s = _Stub(already_shutting_down=True)
+
+        s._on_end_session(_FakeEvent())
+
+        assert not s._teardown_complete_event.is_set()
+
+    def test_shutting_down_stays_true_and_no_unstick_timer_is_armed(self):
+        """Arming a second unstick timer here would, after
+        _END_SESSION_UNSTICK_SECONDS, reset _shutting_down back to False
+        while the OTHER path's teardown might still genuinely be running --
+        reopening the exact self-inflicted-logout window this flag exists
+        to close."""
+        s = _Stub(already_shutting_down=True)
+        s._END_SESSION_UNSTICK_SECONDS = 0.05
+
+        s._on_end_session(_FakeEvent())
+        assert s._shutting_down is True
+
+        time.sleep(0.3)  # well past the (would-be) unstick window
+
+        assert s._shutting_down is True, (
+            "no second unstick timer should have been armed by this call"
+        )
+
+
+class TestSelfHealingUnstick:
+    def test_flag_clears_itself_if_process_is_still_running_later(self):
+        s = _Stub()
+        s._on_end_session(_FakeEvent())
+        assert s._shutting_down is True
+
+        # Give the background threading.Timer time to fire (armed for
+        # _END_SESSION_UNSTICK_SECONDS = 0.05s on the stub).
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and s._shutting_down:
+            time.sleep(0.01)
+
+        assert s._shutting_down is False, (
+            "a Windows shutdown that never actually completed must not leave "
+            "logout detection permanently disabled for the rest of the session"
+        )
+
+    def test_unstick_also_clears_the_stale_completion_signal(self):
+        """Left set, a LATER genuinely-new teardown's loser would see this
+        abandoned attempt's event already set and self-terminate immediately,
+        believing that teardown finished when it may still be mid
+        _stop_wpp_server()."""
+        s = _Stub()
+        s._on_end_session(_FakeEvent())
+        assert s._teardown_complete_event.is_set()
+
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and s._shutting_down:
+            time.sleep(0.01)
+
+        assert not s._teardown_complete_event.is_set()
+
+    def test_a_normal_real_exit_never_needs_the_unstick(self):
+        """Sanity check on the assumption the unstick relies on: a real
+        shutdown's own teardown budget is nowhere near the 60s production
+        default, so in the ordinary case the process is long gone before
+        this would ever fire. Guards the constant itself from silently
+        shrinking below what a legitimate slow close-session flush needs."""
+        assert MainWindow._END_SESSION_UNSTICK_SECONDS >= (
+            MainWindow._WPP_GRACEFUL_STOP_SECONDS
+            + MainWindow._SHUTDOWN_FLUSH_TIMEOUT
+            + MainWindow._TOKEN_PERSIST_GRACE_SECONDS
+        )

--- a/tests/test_end_session_waits_for_owned_teardown.py
+++ b/tests/test_end_session_waits_for_owned_teardown.py
@@ -1,0 +1,119 @@
+"""WM_ENDSESSION must not hand the process to Windows mid-teardown.
+
+PR #141 correctly locked the _shutting_down check-and-set so a local quit, an
+IPC quit and WM_ENDSESSION can no longer run _stop_wpp_server() concurrently.
+But its losing branch — "teardown already started elsewhere" — destroyed the
+shutdown block reason and returned at once, which is precisely what tells
+Windows it may terminate now.
+
+The damage that causes is documented in CLAUDE.md: a run whose
+shutdown_audit.log shows STARTUP with no _stop_wpp_server before it was killed
+rather than closed, WhatsApp's auth state never reached userDataDir, and the
+profile comes back unusable — the session-loss symptom this whole PR is about.
+
+The old code at least ran its own budgeted _stop_wpp_server() and flushed
+something. The fix is to wait on the winning path's _teardown_complete_event,
+bounded by the same Windows budget.
+"""
+
+import inspect
+import threading
+
+import pytest
+
+from main import MainWindow
+
+
+class _Event:
+    """Records what it was asked to wait for."""
+
+    def __init__(self, result=True):
+        self._result = result
+        self.waited_with = None
+
+    def wait(self, timeout=None):
+        self.waited_with = timeout
+        return self._result
+
+    def set(self):
+        pass
+
+    def clear(self):
+        pass
+
+
+class _Stub:
+    _WINDOWS_SHUTDOWN_BUDGET = 4
+    _END_SESSION_UNSTICK_SECONDS = 60.0
+    _TEARDOWN_OWNED_ELSEWHERE_WAIT_SECONDS = 80.0
+    stopped_with = None
+
+    def __init__(self, already_tearing_down):
+        self._teardown_started_lock = threading.Lock()
+        self._teardown_complete_event = _Event()
+        self._shutting_down = already_tearing_down
+        self._audits = []
+
+    def GetHandle(self):
+        raise RuntimeError("no real window in a test")
+
+    def _shutdown_audit(self, msg):
+        self._audits.append(msg)
+
+    def _stop_wpp_server(self, budget=None):
+        self.stopped_with = budget
+
+    def _flush_pending_debounced_saves(self):
+        pass
+
+
+class _Evt:
+    def __init__(self):
+        self.skipped = False
+
+    def Skip(self):
+        self.skipped = True
+
+
+class TestTeardownOwnedElsewhere:
+    def test_it_waits_for_the_owning_teardown_before_letting_windows_kill_us(self):
+        stub = _Stub(already_tearing_down=True)
+        evt = _Evt()
+
+        MainWindow._on_end_session(stub, evt)
+
+        assert stub._teardown_complete_event.waited_with == stub._WINDOWS_SHUTDOWN_BUDGET, (
+            "the losing branch returned immediately — Windows then terminates "
+            "the process while the owning path is still mid _stop_wpp_server()"
+        )
+        assert evt.skipped
+        # It must NOT start a competing teardown of its own; that is exactly
+        # what the lock is there to prevent.
+        assert stub.stopped_with is None
+
+    def test_the_owner_still_does_its_own_budgeted_teardown(self):
+        stub = _Stub(already_tearing_down=False)
+        evt = _Evt()
+
+        MainWindow._on_end_session(stub, evt)
+
+        assert stub.stopped_with == stub._WINDOWS_SHUTDOWN_BUDGET
+        assert stub._shutting_down is True
+        assert evt.skipped
+
+
+class TestUnstickTimer:
+    def test_it_mutates_the_shutdown_flags_under_the_lock(self):
+        """_shutting_down and _teardown_complete_event are mutated under
+        _teardown_started_lock everywhere else. Unlocked, this timer can clear
+        an event belonging to a LATER teardown that genuinely finished,
+        stranding that teardown's loser for its whole 80s wait."""
+        src = inspect.getsource(MainWindow._on_end_session)
+        unstick = src[src.index("def _unstick_if_still_running"):]
+        assert "with self._teardown_started_lock:" in unstick.split("try:")[0]
+
+    def test_the_unstick_window_is_shorter_than_the_wait_it_frees(self):
+        """A loser blocked on the event must never outlive the timer that
+        would have freed it."""
+        assert (MainWindow._END_SESSION_UNSTICK_SECONDS
+                < MainWindow._TEARDOWN_OWNED_ELSEWHERE_WAIT_SECONDS)

--- a/tests/test_flush_pending_debounced_saves.py
+++ b/tests/test_flush_pending_debounced_saves.py
@@ -1,0 +1,129 @@
+"""Tests for MainWindow._flush_pending_debounced_saves().
+
+Reported gap (found by re-reviewing the shutdown path end to end, not from a
+live report): _schedule_save() debounces chat/contacts persistence by 0.15s
+and _schedule_save_settings() debounces settings.json by 2s, each on its own
+daemon threading.Timer. _perform_shutdown() never cancelled or flushed
+either before closing the DB and exiting -- so a save that was pending at
+the exact moment of shutdown could be lost two different ways: db.close()
+starts rejecting calls the instant it flips _closing (and _do_save() clears
+_dirty_jids_for_save *before* attempting the write, so there is nothing
+left to retry even if it were called again), or os._exit() simply kills the
+daemon timer thread before it ever fires at all, since it does not wait for
+other threads.
+
+_flush_pending_debounced_saves() cancels both timers and runs their
+callbacks synchronously, right in the shutdown path, before either of those
+can cut them off. Called from both _perform_shutdown() (normal/IPC quit)
+and _on_end_session() (WM_ENDSESSION) -- the latter never goes through
+_perform_shutdown() at all.
+"""
+
+import threading
+
+from main import MainWindow
+
+
+class _Stub:
+    _flush_pending_debounced_saves = MainWindow._flush_pending_debounced_saves
+
+    def __init__(self):
+        self._save_timer_lock = threading.Lock()
+        self._save_timer = None
+        self._settings_save_timer = None
+        self.do_save_calls = 0
+        self.save_settings_calls = 0
+        self.do_save_raises = False
+        self.save_settings_raises = False
+
+    def _do_save(self):
+        self.do_save_calls += 1
+        if self.do_save_raises:
+            raise RuntimeError("boom")
+
+    def save_settings(self):
+        self.save_settings_calls += 1
+        if self.save_settings_raises:
+            raise RuntimeError("boom")
+
+
+class TestNoPendingTimers:
+    def test_does_nothing_when_neither_timer_is_pending(self):
+        s = _Stub()
+        s._flush_pending_debounced_saves()
+        assert s.do_save_calls == 0
+        assert s.save_settings_calls == 0
+
+
+class TestPendingChatSaveIsFlushed:
+    def test_pending_chat_timer_is_cancelled_and_run_synchronously(self):
+        s = _Stub()
+        fired = threading.Event()
+        t = threading.Timer(999, fired.set)  # long enough it would never fire on its own
+        t.daemon = True
+        t.start()
+        s._save_timer = t
+
+        s._flush_pending_debounced_saves()
+
+        assert s.do_save_calls == 1
+        assert s._save_timer is None
+        assert not fired.is_set(), "the original timer callback must never fire"
+
+    def test_an_exception_in_do_save_does_not_propagate(self):
+        """A flush failure must not abort the rest of shutdown (settings
+        flush, db.close(), process exit)."""
+        s = _Stub()
+        s.do_save_raises = True
+        t = threading.Timer(999, lambda: None)
+        t.daemon = True
+        t.start()
+        s._save_timer = t
+
+        s._flush_pending_debounced_saves()  # must not raise
+
+        assert s.do_save_calls == 1
+
+
+class TestPendingSettingsSaveIsFlushed:
+    def test_pending_settings_timer_is_cancelled_and_run_synchronously(self):
+        s = _Stub()
+        t = threading.Timer(999, lambda: None)
+        t.daemon = True
+        t.start()
+        s._settings_save_timer = t
+
+        s._flush_pending_debounced_saves()
+
+        assert s.save_settings_calls == 1
+        assert s._settings_save_timer is None
+
+    def test_an_exception_in_save_settings_does_not_propagate(self):
+        s = _Stub()
+        s.save_settings_raises = True
+        t = threading.Timer(999, lambda: None)
+        t.daemon = True
+        t.start()
+        s._settings_save_timer = t
+
+        s._flush_pending_debounced_saves()  # must not raise
+
+        assert s.save_settings_calls == 1
+
+
+class TestBothPendingAtOnce:
+    def test_both_timers_flushed_independently(self):
+        s = _Stub()
+        t1 = threading.Timer(999, lambda: None)
+        t1.daemon = True
+        t1.start()
+        s._save_timer = t1
+        t2 = threading.Timer(999, lambda: None)
+        t2.daemon = True
+        t2.start()
+        s._settings_save_timer = t2
+
+        s._flush_pending_debounced_saves()
+
+        assert s.do_save_calls == 1
+        assert s.save_settings_calls == 1

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -155,10 +155,11 @@ def test_queue_before_window_then_flush(tmp_path):
 
 def test_a_concurrent_activate_is_not_blocked_by_an_in_flight_quit(tmp_path):
     """Regression: handling "quit" used to happen inline in the accept loop,
-    including its up-to-10s wait for released_predicate() — so any other
-    request sent while a quit was in flight had nowhere to connect to until
-    that wait finished. Each connection is now handed to its own thread so
-    the accept loop is free to pick up the next one immediately."""
+    including its up-to-_QUIT_RELEASE_POLL_SECONDS wait for
+    released_predicate() — so any other request sent while a quit was in
+    flight had nowhere to connect to until that wait finished. Each
+    connection is now handed to its own thread so the accept loop is free
+    to pick up the next one immediately."""
     gd = _gd(tmp_path)
     acc = "d" * 32
     released = threading.Event()

--- a/tests/test_legacy_api_state_migration.py
+++ b/tests/test_legacy_api_state_migration.py
@@ -1,0 +1,136 @@
+"""The one-time move of a paired session out of the install dir.
+
+PR #141 pointed WPPConnect's Chrome profile (customUserDataDir) and its file
+token store at <global_dir>/api/... via WINZAPP_USER_DATA_DIR /
+WINZAPP_TOKEN_STORE_DIR, because the previous cwd-relative defaults land in
+PyInstaller's per-launch extraction temp dir in a --onefile build and are
+orphaned on every exit.
+
+That is right, but on its own it also aims every ALREADY PAIRED install — all
+of which keep a working profile at <install>/api/userDataDir/<session> — at a
+folder that does not exist. Chrome would start on a virgin profile and
+WhatsApp would ask for a fresh QR: the exact "closed WinZapp, relaunched, told
+the device was disconnected" report the new path exists to remove, delivered
+once to everybody as the fix for itself.
+
+migrate_legacy_api_state() closes that. It runs against a real paired session,
+so the tests below are mostly about what it must refuse to do.
+"""
+
+import os
+
+from main import (
+    LEGACY_API_STATE_MARKER,
+    migrate_legacy_api_state,
+)
+
+
+def _make_legacy_install(root, session="422e4a19812cc15a4c84219ff2eac63d"):
+    """A pre-migration install: a Chrome profile and a token file where the
+    cwd-relative defaults used to put them."""
+    legacy = os.path.join(root, "install", "api")
+    profile = os.path.join(legacy, "userDataDir", session)
+    os.makedirs(profile)
+    with open(os.path.join(profile, "Cookies"), "w", encoding="utf-8") as fh:
+        fh.write("credentials")
+    tokens = os.path.join(legacy, "tokens")
+    os.makedirs(tokens)
+    with open(os.path.join(tokens, f"{session}.data.json"), "w", encoding="utf-8") as fh:
+        fh.write('{"WABrowserId":"x"}')
+    return legacy, session
+
+
+class TestMigration:
+    def test_an_existing_paired_session_is_carried_over(self, tmp_path):
+        root = str(tmp_path)
+        legacy, session = _make_legacy_install(root)
+        new = os.path.join(root, "data", "global", "api")
+
+        moved = migrate_legacy_api_state(legacy, new)
+
+        assert sorted(moved) == ["tokens", "userDataDir"]
+        # The profile — the real credential store — is what must survive.
+        assert os.path.isfile(os.path.join(new, "userDataDir", session, "Cookies"))
+        assert os.path.isfile(os.path.join(new, "tokens", f"{session}.data.json"))
+        # And it must be gone from the old place, so nothing keeps reading it.
+        assert not os.path.exists(os.path.join(legacy, "userDataDir"))
+
+    def test_it_runs_only_once(self, tmp_path):
+        """The marker stops the scan repeating on every launch (and stops two
+        accounts' processes fighting over the same folders at startup)."""
+        root = str(tmp_path)
+        legacy, _ = _make_legacy_install(root)
+        new = os.path.join(root, "data", "global", "api")
+
+        assert migrate_legacy_api_state(legacy, new)
+        assert os.path.isfile(os.path.join(new, LEGACY_API_STATE_MARKER))
+
+        # A profile reappearing at the old path later is NOT a migration
+        # candidate any more — by then the new location is the live one.
+        _make_legacy_install(root + "_ignored")
+        os.makedirs(os.path.join(legacy, "userDataDir", "later"))
+        assert migrate_legacy_api_state(legacy, new) == []
+        assert not os.path.exists(os.path.join(new, "userDataDir", "later"))
+
+    def test_it_never_overwrites_a_session_already_at_the_new_path(self, tmp_path):
+        """A folder already at the destination means this install is paired
+        under the new layout. Clobbering it with a stale copy from the install
+        dir would destroy a working session to restore a dead one."""
+        root = str(tmp_path)
+        legacy, session = _make_legacy_install(root)
+        new = os.path.join(root, "data", "global", "api")
+        live = os.path.join(new, "userDataDir", session)
+        os.makedirs(live)
+        with open(os.path.join(live, "Cookies"), "w", encoding="utf-8") as fh:
+            fh.write("the live one")
+
+        moved = migrate_legacy_api_state(legacy, new)
+
+        assert "userDataDir" not in moved
+        with open(os.path.join(live, "Cookies"), encoding="utf-8") as fh:
+            assert fh.read() == "the live one"
+        # The unrelated tokens/ folder still migrates — per folder, not all
+        # or nothing, so a half-done previous attempt completes.
+        assert "tokens" in moved
+
+    def test_a_fresh_install_is_a_no_op_but_still_stops_scanning(self, tmp_path):
+        root = str(tmp_path)
+        legacy = os.path.join(root, "install", "api")
+        os.makedirs(legacy)
+        new = os.path.join(root, "data", "global", "api")
+
+        assert migrate_legacy_api_state(legacy, new) == []
+        assert os.path.isfile(os.path.join(new, LEGACY_API_STATE_MARKER))
+
+    def test_same_source_and_destination_is_refused(self, tmp_path):
+        """A dev checkout can legitimately resolve both to the same folder;
+        shutil.move onto itself would raise."""
+        root = str(tmp_path)
+        legacy, _ = _make_legacy_install(root)
+
+        assert migrate_legacy_api_state(legacy, legacy) == []
+        assert not os.path.exists(os.path.join(legacy, LEGACY_API_STATE_MARKER))
+
+    def test_missing_paths_are_refused(self, tmp_path):
+        assert migrate_legacy_api_state("", str(tmp_path)) == []
+        assert migrate_legacy_api_state(str(tmp_path), "") == []
+
+
+class TestItIsWiredIntoStartup:
+    def test_start_wpp_background_migrates_before_spawning_node(self):
+        """Order matters twice over: the move must happen before Popen (moving
+        a userDataDir out from under a live Chrome corrupts exactly what this
+        protects), and it must happen at all — the env vars alone are the
+        regression."""
+        import inspect
+
+        from main import MainWindow
+
+        src = inspect.getsource(MainWindow._start_wpp_background)
+        assert "migrate_legacy_api_state(" in src, (
+            "_start_wpp_background() sets WINZAPP_USER_DATA_DIR but never "
+            "migrates an existing install's session to it"
+        )
+        assert src.index("migrate_legacy_api_state(") < src.index("subprocess.Popen("), (
+            "the migration must run before Node is spawned"
+        )

--- a/tests/test_line_separator_normalization.py
+++ b/tests/test_line_separator_normalization.py
@@ -22,7 +22,7 @@ import pytest
 import wx
 
 from core.utils import normalize_line_separators
-from tests.conftest import set_clipboard_text
+from tests.conftest import hidden_frame, set_clipboard_text
 from ui.conversations import ConversationsPanel
 
 
@@ -112,7 +112,7 @@ class _Stub:
 
 class TestPasteNormalization:
     def test_paste_of_paragraph_separator_text_is_normalized(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame)
             if not set_clipboard_text("A\u2029B\u2029C"):
@@ -126,7 +126,7 @@ class TestPasteNormalization:
             frame.Destroy()
 
     def test_paste_of_plain_text_is_left_alone(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame)
             if not set_clipboard_text("hello\nworld"):
@@ -188,7 +188,7 @@ class TestPasteHandlerIsGeneric:
         """The generalization that lets one handler serve every field: the
         text goes to the control the paste came from, not to a hardcoded
         message_field."""
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame)
             if not set_clipboard_text("A\u2029B"):

--- a/tests/test_message_queue_stop_drains_in_flight.py
+++ b/tests/test_message_queue_stop_drains_in_flight.py
@@ -1,0 +1,119 @@
+"""Tests for MessageQueue.stop() waiting (briefly, boundedly) for an
+in-flight send to finish before returning.
+
+Reported gap (found by re-reviewing the shutdown path, not from a live
+report): _perform_shutdown() calls message_queue.stop() BEFORE
+_stop_wpp_server(), which goes on to close-session and eventually taskkill
+the same Node process a worker thread might be mid-HTTP-request to. Before
+this fix, stop() only signalled the workers and returned immediately --
+so a send that was seconds from succeeding could get its connection cut by
+the session close/kill that follows right after, turning a legitimate send
+into an ambiguous/lost one for no reason. Bounded (not indefinite) so a
+stuck/huge upload can never block Ctrl+Alt+Shift+Q forever.
+"""
+
+import pathlib
+import sys
+import threading
+import time
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "client"))
+
+import core.message_queue as message_queue
+from core.message_queue import MessageQueue, PendingMessage
+
+
+@pytest.fixture(autouse=True)
+def direct_call_after(monkeypatch):
+    monkeypatch.setattr(
+        message_queue.wx, "CallAfter",
+        lambda callback, *args: callback(*args), raising=False,
+    )
+
+
+class _MainWindow:
+    offline_mode = False
+    _wa_connected = True
+
+    def __init__(self):
+        self._own_sent_ids_lock = threading.Lock()
+        self._own_sent_ids = set()
+        self.send_started = threading.Event()
+        self.release_send = threading.Event()
+
+    def send_text_message(self, *_args, **_kwargs):
+        self.send_started.set()
+        self.release_send.wait(timeout=5)
+        return "text-id"
+
+    def _on_message_sent(self, *_args):
+        pass
+
+    def _on_message_failed(self, *_args):
+        pass
+
+    def _on_message_unconfirmed(self, *_args):
+        pass
+
+    def _on_cancelled_message_dropped(self, *_args):
+        pass
+
+
+class TestStopWaitsForInFlightSend:
+    def test_stop_blocks_until_the_in_flight_send_actually_finishes(self):
+        main_window = _MainWindow()
+        queue = MessageQueue(main_window)
+        queue._STOP_DRAIN_SECONDS = 2.0
+        queue._STOP_DRAIN_POLL_SECONDS = 0.02
+        try:
+            queue.enqueue(PendingMessage("t1", "chat-a", text="hello"))
+            assert main_window.send_started.wait(timeout=1)
+
+            # Release the in-flight send a little after stop() is called, so a
+            # stop() that returned immediately (the old behaviour) would win
+            # the race and this assertion would catch it.
+            def _release_soon():
+                time.sleep(0.3)
+                main_window.release_send.set()
+            threading.Thread(target=_release_soon, daemon=True).start()
+
+            started = time.monotonic()
+            queue.stop()
+            elapsed = time.monotonic() - started
+
+            assert elapsed >= 0.25, "stop() must not return before the send finished"
+            assert elapsed < queue._STOP_DRAIN_SECONDS, "must return as soon as drained, not wait out the whole budget"
+        finally:
+            main_window.release_send.set()
+
+    def test_stop_gives_up_after_the_bound_and_still_returns(self):
+        """A send that never finishes (stuck upload) must not block shutdown
+        forever -- stop() must return once the bound elapses regardless."""
+        main_window = _MainWindow()
+        queue = MessageQueue(main_window)
+        queue._STOP_DRAIN_SECONDS = 0.3
+        queue._STOP_DRAIN_POLL_SECONDS = 0.02
+        try:
+            queue.enqueue(PendingMessage("t1", "chat-a", text="hello"))
+            assert main_window.send_started.wait(timeout=1)
+
+            started = time.monotonic()
+            queue.stop()  # release_send is never set
+            elapsed = time.monotonic() - started
+
+            assert elapsed >= queue._STOP_DRAIN_SECONDS
+            assert elapsed < queue._STOP_DRAIN_SECONDS + 1.0, "must not overshoot the bound by much"
+        finally:
+            main_window.release_send.set()
+
+    def test_stop_returns_immediately_when_nothing_is_in_flight(self):
+        main_window = _MainWindow()
+        queue = MessageQueue(main_window)
+        queue._STOP_DRAIN_SECONDS = 5.0
+        started = time.monotonic()
+        queue.stop()
+        elapsed = time.monotonic() - started
+        assert elapsed < 0.2

--- a/tests/test_no_desktop_visible_windows.py
+++ b/tests/test_no_desktop_visible_windows.py
@@ -1,0 +1,89 @@
+"""The suite must not put focusable windows on the desktop.
+
+Running the tests on a machine with NVDA active crashed NVDA repeatedly. Its
+own traceback named the mechanism precisely:
+
+    event_gainFocus -> reportFocus -> getObjectPropertiesSpeech
+      -> behaviors.getDialogText -> IAccessible._get_children
+      -> oleacc.AccessibleObjectFromEvent
+
+NVDA took focus on one of the suite's throwaway wx windows and was still
+enumerating its children over COM when the test destroyed it, so the object it
+was reading vanished mid-call. A single run creates and destroys dozens of
+these windows, which makes that race very easy to lose — and it hits a user
+who is not even running the tests, since focus is global.
+
+Frames now go through conftest.hidden_frame(): real windows, fully functional
+as parents, but off-screen tool windows with no taskbar button, so they never
+become foreground and no focus event is raised for a screen reader to chase.
+This test keeps them that way.
+
+Dialog subclasses own their own construction and cannot be positioned from the
+outside, so the handful of modules that build one carry the `wxgui` marker
+instead — deselect them (`-m "not wxgui"`) when running this suite on a
+machine somebody is actually using.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+TESTS = pathlib.Path(__file__).resolve().parent
+
+# This file's own docstring quotes the call, and conftest explains it.
+_EXEMPT = {"test_no_desktop_visible_windows.py", "conftest.py"}
+
+
+def _test_modules():
+    return sorted(p for p in TESTS.glob("test_*.py") if p.name not in _EXEMPT)
+
+
+@pytest.mark.parametrize("path", _test_modules(), ids=lambda p: p.name)
+def test_no_module_builds_a_bare_top_level_frame(path):
+    """`wx.Frame(None)` is a normal top-level window — taskbar button, real
+    foreground transitions, and a focus event a screen reader will chase.
+    Use conftest.hidden_frame() instead."""
+    source = path.read_text(encoding="utf-8")
+    assert "wx.Frame(None)" not in source, (
+        f"{path.name} constructs a bare top-level wx.Frame. Use "
+        f"hidden_frame() from tests.conftest — a plain wx.Frame(None) steals "
+        f"focus from whoever is using the machine and can crash their screen "
+        f"reader when the test destroys it."
+    )
+
+
+class TestTheMarkerIsRegisteredAndUsed:
+    def test_pytest_ini_declares_the_marker(self):
+        ini = (TESTS.parent / "pytest.ini").read_text(encoding="utf-8")
+        assert "wxgui:" in ini, "the wxgui marker must be declared in pytest.ini"
+
+    def test_every_module_building_a_real_dialog_carries_it(self):
+        """A new module that constructs a real Dialog subclass without the
+        marker silently reintroduces the crash for anyone running the full
+        suite locally."""
+        unmarked = []
+        for path in _test_modules():
+            source = path.read_text(encoding="utf-8")
+            if "pytest.mark.wxgui" in source:
+                continue
+            try:
+                tree = ast.parse(source)
+            except SyntaxError:  # pragma: no cover - caught elsewhere
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = getattr(func, "id", None) or getattr(func, "attr", None)
+                if not name or not name.endswith("Dialog"):
+                    continue
+                # A local stub/fake is not a real window.
+                if f"class {name}" in source:
+                    continue
+                unmarked.append(f"{path.name}: {name}(...)")
+                break
+        assert not unmarked, (
+            "these modules construct a real wx dialog but are not marked "
+            f"`wxgui`: {unmarked}"
+        )

--- a/tests/test_no_offline_during_wpp_update.py
+++ b/tests/test_no_offline_during_wpp_update.py
@@ -72,6 +72,7 @@ class _Queue:
 
 class _Stub:
     _set_wa_connected = MainWindow._set_wa_connected
+    _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
     _reset_startup_probe = MainWindow._reset_startup_probe
     # The real recompute, not a spy: self.offline_mode is precisely what
     # MessageQueue._run reads before sending, so the tests assert the thing

--- a/tests/test_pairing_startup_grace.py
+++ b/tests/test_pairing_startup_grace.py
@@ -1,0 +1,250 @@
+"""Tests for MainWindow._wait_for_pairing_startup_settled() (Connect class,
+client/ui/dialogs/connect.py).
+
+Reported: "the QR code never shows up" / "the pairing code never shows up so
+I could not type it on the phone". The connection dialog's Quit/close handlers
+used to call _close_active_session() and exit immediately, no matter how
+recently the user had clicked "Conectar com QR code" or "Continuar" — killing
+Chrome mid-launch, before WhatsApp Web had ever finished loading enough to
+produce a QR/pairing code. A first-time Chrome launch here routinely takes
+10-25s; someone who clicked the button and gave up a few seconds later was
+closing a session that was seconds away from actually showing something.
+
+_wait_for_pairing_startup_settled() gives that in-flight attempt a short,
+bounded grace window before the close proceeds — narrowing the race, not
+adding an unconditional delay: an attempt that never started, or one that
+already produced its QR/code, returns immediately.
+
+Connect is a plain class (no wx.Dialog needed for this method), so it is
+exercised directly against a stub main_window.
+"""
+
+import threading
+
+import pytest
+
+import ui.dialogs.connect as connect_module
+from ui.dialogs.connect import Connect
+
+
+class _FakeEvent:
+    """Stand-in for WebSocketClient._phone_code_event (a real threading.Event
+    would also work, but this lets tests control is_set()/wait() precisely)."""
+
+    def __init__(self, already_set=False):
+        self._set = already_set
+        self.wait_calls = []
+
+    def is_set(self):
+        return self._set
+
+    def wait(self, timeout=None):
+        self.wait_calls.append(timeout)
+        return self._set
+
+    def set(self):
+        self._set = True
+
+
+class _FakeWs:
+    def __init__(self, already_set=False):
+        self._phone_code_event = _FakeEvent(already_set)
+
+
+class _FakeMainWindow:
+    def __init__(self, pairing_in_progress=True, token="sess:hash", ws=None):
+        self._pairing_in_progress = pairing_in_progress
+        self.token = token
+        self.wpp_server = "http://127.0.0.1"
+        self.wpp_port = 6300
+        self.wpp_api_key = "api-key"
+        self.ws = ws
+        self.settings = {"general": {"language": "pt-BR"}}
+        self.spoken = []
+
+    def output(self, text, **kwargs):
+        self.spoken.append(text)
+
+
+def _clock(values):
+    """A monotonic() stand-in that walks a fixed sequence, then holds."""
+    seq = list(values)
+
+    def _now():
+        return seq.pop(0) if len(seq) > 1 else seq[0]
+
+    return _now
+
+
+class _Response:
+    def __init__(self, status_code=200, body=None):
+        self.status_code = status_code
+        self._body = body or {}
+
+    def json(self):
+        return self._body
+
+
+class TestNoPairingInFlight:
+    def test_returns_immediately_when_nothing_is_in_progress(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(connect_module, "api_get", lambda *a, **kw: calls.append(1))
+        mw = _FakeMainWindow(pairing_in_progress=False)
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+
+        c._wait_for_pairing_startup_settled()
+
+        assert calls == []
+
+
+class TestPhoneMode:
+    def test_returns_immediately_if_the_code_already_arrived(self):
+        ws = _FakeWs(already_set=True)
+        mw = _FakeMainWindow(ws=ws)
+        c = Connect(mw)
+        c.connection_mode = "phone"
+
+        c._wait_for_pairing_startup_settled()
+
+        assert ws._phone_code_event.wait_calls == []
+
+    def test_waits_on_the_real_phone_code_event_when_not_yet_set(self):
+        ws = _FakeWs(already_set=False)
+        mw = _FakeMainWindow(ws=ws)
+        c = Connect(mw)
+        c.connection_mode = "phone"
+
+        c._wait_for_pairing_startup_settled()
+
+        assert len(ws._phone_code_event.wait_calls) == 1
+        assert ws._phone_code_event.wait_calls[0] > 0
+
+    def test_no_ws_is_a_no_op(self):
+        mw = _FakeMainWindow(ws=None)
+        c = Connect(mw)
+        c.connection_mode = "phone"
+
+        c._wait_for_pairing_startup_settled()  # must not raise
+
+
+class TestQrCodeMode:
+    def test_returns_at_once_when_the_first_poll_already_has_a_qr(self, monkeypatch):
+        polls = []
+
+        def fake_get(url, headers=None, timeout=None):
+            polls.append(url)
+            return _Response(200, {"qrcode": "data:image/png;base64,abc"})
+
+        monkeypatch.setattr(connect_module, "api_get", fake_get)
+        monkeypatch.setattr(connect_module.time, "sleep", lambda _s: None)
+        mw = _FakeMainWindow()
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+
+        c._wait_for_pairing_startup_settled()
+
+        assert len(polls) == 1
+
+    def test_keeps_polling_until_the_qr_appears(self, monkeypatch):
+        responses = iter([
+            _Response(200, {"status": "INITIALIZING"}),
+            _Response(200, {"status": "INITIALIZING"}),
+            _Response(200, {"qrcode": "abc"}),
+        ])
+        monkeypatch.setattr(connect_module, "api_get", lambda *a, **kw: next(responses))
+        monkeypatch.setattr(connect_module.time, "sleep", lambda _s: None)
+        mw = _FakeMainWindow()
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+
+        c._wait_for_pairing_startup_settled()  # must not raise StopIteration
+
+    def test_a_connected_status_also_ends_the_wait(self, monkeypatch):
+        monkeypatch.setattr(connect_module, "api_get",
+                             lambda *a, **kw: _Response(200, {"status": "CONNECTED"}))
+        monkeypatch.setattr(connect_module.time, "sleep", lambda _s: None)
+        mw = _FakeMainWindow()
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+
+        c._wait_for_pairing_startup_settled()
+
+    def test_no_token_at_all_is_a_no_op(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(connect_module, "api_get", lambda *a, **kw: calls.append(1))
+        mw = _FakeMainWindow(token="")
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+        c._last_started_qr_token = ""
+
+        c._wait_for_pairing_startup_settled()
+
+        assert calls == []
+
+    def test_is_bounded_when_no_qr_ever_arrives(self, monkeypatch):
+        """Never blocks a genuine quit forever: a pairing attempt that keeps
+        failing to produce anything must still let the close proceed."""
+        monkeypatch.setattr(connect_module, "api_get",
+                             lambda *a, **kw: _Response(200, {"status": "INITIALIZING"}))
+        monkeypatch.setattr(connect_module.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(
+            connect_module.time, "monotonic",
+            _clock([0] + [i * Connect._PAIRING_STARTUP_POLL_SECONDS for i in range(1, 200)])
+        )
+        mw = _FakeMainWindow()
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+
+        c._wait_for_pairing_startup_settled()  # returns instead of looping forever
+
+    def test_an_exception_on_a_poll_does_not_abort_the_wait(self, monkeypatch):
+        calls = {"n": 0}
+
+        def flaky_get(*a, **kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ConnectionError("boom")
+            return _Response(200, {"qrcode": "abc"})
+
+        monkeypatch.setattr(connect_module, "api_get", flaky_get)
+        monkeypatch.setattr(connect_module.time, "sleep", lambda _s: None)
+        mw = _FakeMainWindow()
+        c = Connect(mw)
+        c.connection_mode = "qrcode"
+
+        c._wait_for_pairing_startup_settled()
+
+        assert calls["n"] == 2
+
+
+class TestUnknownMode:
+    def test_an_unrecognized_mode_is_a_no_op(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(connect_module, "api_get", lambda *a, **kw: calls.append(1))
+        mw = _FakeMainWindow()
+        c = Connect(mw)
+        c.connection_mode = None
+
+        c._wait_for_pairing_startup_settled()
+
+        assert calls == []
+
+
+class TestWiredIntoTheQuitHandlers:
+    """The gate is only useful if the handlers actually call it, before they
+    tear down the state it reads."""
+
+    def test_on_quit_from_connect_calls_it_before_clearing_pairing_state(self):
+        import inspect
+        source = inspect.getsource(Connect.on_quit_from_connect)
+        wait_at = source.index("_wait_for_pairing_startup_settled")
+        cleared_at = source.index("_pairing_in_progress = False")
+        assert wait_at < cleared_at
+
+    def test_on_dialog_close_calls_it_before_clearing_pairing_state(self):
+        import inspect
+        source = inspect.getsource(Connect.on_dialog_close)
+        wait_at = source.index("_wait_for_pairing_startup_settled")
+        cleared_at = source.index("_pairing_in_progress = False")
+        assert wait_at < cleared_at

--- a/tests/test_pairing_startup_grace.py
+++ b/tests/test_pairing_startup_grace.py
@@ -232,19 +232,33 @@ class TestUnknownMode:
 
 
 class TestWiredIntoTheQuitHandlers:
-    """The gate is only useful if the handlers actually call it, before they
-    tear down the state it reads."""
+    """The gate is only useful if the handlers actually go through it, before
+    they tear down the state it reads.
 
-    def test_on_quit_from_connect_calls_it_before_clearing_pairing_state(self):
+    They now do that via _defer_close_for_pairing_startup(), which runs the
+    wait on a worker thread and re-issues the close afterwards, rather than
+    calling _wait_for_pairing_startup_settled() inline: on the wx main thread
+    that wait is up to 30 seconds of frozen window and total screen-reader
+    silence — see tests/test_pairing_startup_settled_classifier.py.
+    """
+
+    def test_on_quit_from_connect_defers_before_clearing_pairing_state(self):
         import inspect
         source = inspect.getsource(Connect.on_quit_from_connect)
-        wait_at = source.index("_wait_for_pairing_startup_settled")
+        wait_at = source.index("_defer_close_for_pairing_startup")
         cleared_at = source.index("_pairing_in_progress = False")
         assert wait_at < cleared_at
 
-    def test_on_dialog_close_calls_it_before_clearing_pairing_state(self):
+    def test_on_dialog_close_defers_before_clearing_pairing_state(self):
         import inspect
         source = inspect.getsource(Connect.on_dialog_close)
-        wait_at = source.index("_wait_for_pairing_startup_settled")
+        wait_at = source.index("_defer_close_for_pairing_startup")
         cleared_at = source.index("_pairing_in_progress = False")
         assert wait_at < cleared_at
+
+    def test_the_deferral_reads_the_pairing_state_it_gates_on(self):
+        """Moving the wait behind a helper must not lose the precondition:
+        the helper is what now decides there is anything to wait for."""
+        import inspect
+        source = inspect.getsource(Connect._defer_close_for_pairing_startup)
+        assert "_pairing_in_progress" in source

--- a/tests/test_pairing_startup_settled_classifier.py
+++ b/tests/test_pairing_startup_settled_classifier.py
@@ -1,0 +1,94 @@
+"""The pairing startup grace must not burn its whole budget on a dead session.
+
+PR #141 added a 30s grace so closing the connection dialog moments after
+clicking "Conectar" does not kill Chrome before it has produced a QR/pairing
+code. The QR branch polls status-session until a QR appears — but a session
+whose start-session never came up answers CLOSED on every poll, matching no
+exit condition, so the most common failure case ("nothing appeared, so I quit")
+was the one that waited the full 30 seconds.
+
+The classification is pulled out to module level so it can be tested without a
+Connect instance, which needs main_window, a WebSocket, HTTP and wx just to
+exist.
+"""
+
+import inspect
+
+import pytest
+
+from ui.dialogs.connect import Connect, pairing_startup_settled
+
+
+class TestSettled:
+    @pytest.mark.parametrize("payload", [
+        {"status": "CLOSED"},
+        {"status": "DESTROYED"},
+        {"status": ""},
+        {},
+        {"response": {"status": "CLOSED"}},
+    ])
+    def test_a_session_that_is_not_coming_up_settles_immediately(self, payload):
+        """This is the regression: each of these used to keep polling for the
+        whole grace window."""
+        assert pairing_startup_settled(payload) is True
+
+    @pytest.mark.parametrize("payload", [
+        {"qrcode": "data:image/png;base64,iVBOR"},
+        {"response": {"qrcode": "data:image/png;base64,iVBOR"}},
+        {"status": "CONNECTED"},
+        {"status": "qrReadSuccess"},
+        {"status": "inChat"},
+    ])
+    def test_an_attempt_that_already_produced_something_settles(self, payload):
+        assert pairing_startup_settled(payload) is True
+
+    @pytest.mark.parametrize("payload", [
+        {"status": "INITIALIZING"},
+        {"status": "STARTING"},
+        {"response": {"status": "INITIALIZING"}},
+        {"status": "QRCODE", "qrcode": None},
+    ])
+    def test_a_session_still_starting_is_worth_waiting_for(self, payload):
+        """The whole point of the grace: Chrome's first page load takes
+        10-25s and killing it here is what produced 'no QR ever appeared'."""
+        assert pairing_startup_settled(payload) is False
+
+    def test_a_non_dict_payload_is_not_treated_as_settled(self):
+        assert pairing_startup_settled(None) is False
+        assert pairing_startup_settled("CLOSED") is False
+
+
+class TestTheWaitIsOffTheWxThread:
+    def test_the_close_handlers_defer_instead_of_blocking(self):
+        for name in ("on_dialog_close", "on_quit_from_connect"):
+            src = inspect.getsource(getattr(Connect, name))
+            assert "_defer_close_for_pairing_startup(" in src, (
+                f"{name}() calls the 30s wait inline on the wx main thread"
+            )
+            assert "self._wait_for_pairing_startup_settled()" not in src
+
+    def test_the_deferral_hands_the_wait_to_a_worker_thread(self):
+        src = inspect.getsource(Connect._defer_close_for_pairing_startup)
+        assert "threading.Thread(target=" in src
+        assert "wx.CallAfter(resume)" in src, (
+            "the close must be re-issued on the wx thread once the wait settles"
+        )
+
+    def test_closing_a_second_time_is_honored_immediately(self):
+        """A user closing again during the grace is telling us they want out;
+        a second wait would read as the app ignoring them."""
+        class _Stub:
+            _pairing_startup_wait_done = True
+
+        assert Connect._defer_close_for_pairing_startup(_Stub(), lambda: None) is False
+
+    def test_no_wait_when_no_pairing_is_in_flight(self):
+        class _MW:
+            _pairing_in_progress = False
+
+        class _Stub:
+            main_window = _MW()
+
+        assert Connect._defer_close_for_pairing_startup(_Stub(), lambda: None) is False
+        # ...and the "already waited" flag must not be set by a no-op call.
+        assert getattr(_Stub, "_pairing_startup_wait_done", False) is False

--- a/tests/test_perform_shutdown_reentrancy.py
+++ b/tests/test_perform_shutdown_reentrancy.py
@@ -1,0 +1,101 @@
+"""Tests for _perform_shutdown()'s return value and _teardown_complete_event.
+
+The gap found by re-reviewing real_exit()'s _teardown() and _ipc_quit()
+against the new _teardown_started_lock (added to fix a separate TOCTOU race
+between _perform_shutdown() and _on_end_session()): both callers used to
+call self._terminate_process() unconditionally in a `finally`, regardless
+of whether _perform_shutdown() actually did the teardown work or found it
+already owned by another concurrent caller (a second call into this same
+method, or _on_end_session() running on another thread). Self-terminating
+in that second case could os._exit() the process while the OTHER, WINNING
+call was still genuinely mid _stop_wpp_server() -- killing Chrome before it
+finished flushing, the exact LevelDB-corruption failure mode this whole
+mechanism exists to prevent.
+
+_perform_shutdown() now returns True only when THIS call performed the
+teardown, and always sets _teardown_complete_event in a `finally` (even on
+an unexpected exception) so a caller that got False back has something
+bounded to wait on before it is safe to terminate.
+
+MainWindow is a wx.Frame and cannot be instantiated without a running
+wx.App, so _perform_shutdown() is exercised as a plain function against a
+minimal stub -- same approach as tests/test_shutdown_suppresses_offline.py.
+Every attribute _perform_shutdown() touches through hasattr()/getattr() is
+simply omitted from the stub so those branches no-op; only the
+unconditionally-called ones (_stop_wpp_server, _flush_pending_debounced_saves)
+need a stand-in.
+"""
+
+import threading
+
+import pytest
+
+from main import MainWindow
+
+
+class _Stub:
+    _perform_shutdown = MainWindow._perform_shutdown
+
+    def __init__(self, raise_in_stop_wpp_server=False):
+        self._teardown_started_lock = threading.Lock()
+        self._teardown_complete_event = threading.Event()
+        self._shutting_down = False
+        self.stop_wpp_server_calls = 0
+        self.flush_calls = 0
+        self._raise_in_stop_wpp_server = raise_in_stop_wpp_server
+
+    def _stop_wpp_server(self):
+        self.stop_wpp_server_calls += 1
+        if self._raise_in_stop_wpp_server:
+            raise RuntimeError("boom")
+
+    def _flush_pending_debounced_saves(self):
+        self.flush_calls += 1
+
+
+class TestFirstCallOwnsTeardown:
+    def test_returns_true_and_does_the_work(self):
+        s = _Stub()
+        assert s._perform_shutdown() is True
+        assert s.stop_wpp_server_calls == 1
+        assert s.flush_calls == 1
+        assert s._shutting_down is True
+
+    def test_sets_the_completion_event(self):
+        s = _Stub()
+        s._perform_shutdown()
+        assert s._teardown_complete_event.is_set()
+
+
+class TestSecondCallDefersToTheFirst:
+    def test_returns_false_and_does_not_repeat_the_work(self):
+        s = _Stub()
+        s._shutting_down = True  # simulates another path having already started
+
+        result = s._perform_shutdown()
+
+        assert result is False
+        assert s.stop_wpp_server_calls == 0
+        assert s.flush_calls == 0
+
+    def test_does_not_set_the_completion_event_itself(self):
+        """The deferring call must not fake-signal completion -- only the
+        call that actually did the work may set it."""
+        s = _Stub()
+        s._shutting_down = True
+
+        s._perform_shutdown()
+
+        assert not s._teardown_complete_event.is_set()
+
+
+class TestCompletionEventIsSetEvenOnException:
+    def test_an_exception_inside_teardown_still_sets_the_event(self):
+        """A caller waiting on _teardown_complete_event must not be stranded
+        for its full timeout just because something inside teardown raised."""
+        s = _Stub(raise_in_stop_wpp_server=True)
+
+        with pytest.raises(RuntimeError):
+            s._perform_shutdown()
+
+        assert s._teardown_complete_event.is_set()

--- a/tests/test_preserve_typed_text_as_caption.py
+++ b/tests/test_preserve_typed_text_as_caption.py
@@ -8,6 +8,7 @@ import pytest
 import wx
 
 from ui.conversations import ConversationsPanel
+from tests.conftest import hidden_frame
 
 
 class _SettingsStub(dict):
@@ -33,7 +34,7 @@ class _Stub:
 
 class TestPreserveTypedTextAsCaption:
     def test_moves_typed_text_into_caption(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame)
             stub.message_field.SetValue("oi tudo bem")
@@ -46,7 +47,7 @@ class TestPreserveTypedTextAsCaption:
             frame.Destroy()
 
     def test_does_nothing_when_message_field_is_empty(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame)
 
@@ -57,7 +58,7 @@ class TestPreserveTypedTextAsCaption:
             frame.Destroy()
 
     def test_does_not_clobber_an_existing_caption(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame)
             stub._caption_field.SetValue("legenda já digitada")
@@ -72,7 +73,7 @@ class TestPreserveTypedTextAsCaption:
             frame.Destroy()
 
     def test_disabled_by_setting_leaves_both_fields_alone(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame, preserve=False)
             stub.message_field.SetValue("oi tudo bem")
@@ -85,7 +86,7 @@ class TestPreserveTypedTextAsCaption:
             frame.Destroy()
 
     def test_whitespace_only_text_is_not_moved(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame)
             stub.message_field.SetValue("   ")
@@ -97,7 +98,7 @@ class TestPreserveTypedTextAsCaption:
             frame.Destroy()
 
     def test_unicode_separators_are_normalized_when_moved(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame)
             stub.message_field.SetValue("A B")

--- a/tests/test_private_chat_data_dialog.py
+++ b/tests/test_private_chat_data_dialog.py
@@ -25,6 +25,9 @@ from core.i18n import I18n
 from core.sound_system import DEFAULT_PACK_ID
 from ui.dialogs.conversation_data_dialog import ConversationDataDialog
 
+# Constructs a REAL top-level wx dialog - see the wxgui marker in pytest.ini.
+pytestmark = pytest.mark.wxgui
+
 PRIVATE_JID = "5511900000000@s.whatsapp.net"
 GROUP_JID = "120363000000000000@g.us"
 

--- a/tests/test_self_inflicted_teardown_expected.py
+++ b/tests/test_self_inflicted_teardown_expected.py
@@ -1,0 +1,124 @@
+"""Direct tests for MainWindow._self_inflicted_teardown_expected().
+
+This helper consolidates four independent "we did this to ourselves, not
+WhatsApp" flags into one check shared by every logout-detection guard
+(on_connection_update's "close" branch, on_wpp_status_find,
+check_wa_connection_http's CLOSED auto-start guard):
+
+  - _shutting_down       (real_exit -> _perform_shutdown)
+  - _wpp_updating        (_update_wpp_server(), which replaces a running
+                           WPPConnect Server build without the app closing)
+  - _recovery_restart_active (_run_recovery_attempts() /
+                           _restart_session_once(), the wake-from-sleep
+                           zombie-session close/kill/start cycle)
+  - _restarting_wpp_session (_restart_wpp_session(), the detached-Puppeteer-
+                           page in-place restart -- also a wake-from-sleep
+                           trigger, a *different* one from the one above)
+
+Each was added one at a time, found only by re-checking every OTHER caller
+of a close-session-triggering method against the same question, not from a
+live report pointing at it: with only _shutting_down checked, a
+close/logout-shaped signal arriving during an update (not a shutdown) was
+misread as a real WhatsApp unlink; with those two, the same signal arriving
+during a zombie-session recovery cycle was ALSO misread the same way; with
+all three, _restart_wpp_session()'s own close-session call was STILL
+unguarded here even though that function's own docstring already documents
+a real incident from exactly this mechanism -- the fix that shipped then
+only covered check_wa_connection_http()'s slower strike-based path, never
+on_connection_update()'s immediate single-event close branch. Two of the
+four triggers are both wake-from-sleep paths, arguably the most common
+real-world trigger of all of them, since a laptop sleeps far more often
+than WinZapp is quit or WPPConnect updated. Same bug, reached through a
+different trigger each time.
+"""
+
+from main import MainWindow
+
+
+class _Stub:
+    _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
+
+
+def test_false_when_no_flag_set():
+    s = _Stub()
+    s._shutting_down = False
+    s._wpp_updating = False
+    s._recovery_restart_active = False
+    s._restarting_wpp_session = False
+
+    assert s._self_inflicted_teardown_expected() is False
+
+
+def test_true_during_shutdown_only():
+    s = _Stub()
+    s._shutting_down = True
+    s._wpp_updating = False
+    s._recovery_restart_active = False
+    s._restarting_wpp_session = False
+
+    assert s._self_inflicted_teardown_expected() is True
+
+
+def test_true_during_update_only():
+    s = _Stub()
+    s._shutting_down = False
+    s._wpp_updating = True
+    s._recovery_restart_active = False
+    s._restarting_wpp_session = False
+
+    assert s._self_inflicted_teardown_expected() is True
+
+
+def test_true_during_recovery_restart_only():
+    """The gap found by re-reviewing _restart_session_once() (the
+    power-resume zombie-session recovery cycle) against the same question
+    already asked of the shutdown and update paths: it too posts
+    /close-session on this account's own session while the WebSocket stays
+    connected, and was previously guarded only inside
+    check_wa_connection_http()'s own CLOSED auto-start branch -- not in
+    on_connection_update()'s close branch or on_wpp_status_find(), leaving
+    the exact same self-inflicted-logout bug reachable through an ordinary
+    sleep/wake cycle."""
+    s = _Stub()
+    s._shutting_down = False
+    s._wpp_updating = False
+    s._recovery_restart_active = True
+
+    assert s._self_inflicted_teardown_expected() is True
+
+
+def test_true_during_restarting_wpp_session_only():
+    """The gap found by re-checking every OTHER close-session caller against
+    the same question one more time: _restart_wpp_session() (the
+    detached-Puppeteer-page in-place restart, a DIFFERENT wake-from-sleep
+    trigger than _recovery_restart_active) posts /close-session on this
+    account's own session too, and was not guarded here at all -- only
+    check_wa_connection_http()'s slower strike-based path had a (different,
+    narrower) mitigation for it."""
+    s = _Stub()
+    s._shutting_down = False
+    s._wpp_updating = False
+    s._recovery_restart_active = False
+    s._restarting_wpp_session = True
+
+    assert s._self_inflicted_teardown_expected() is True
+
+
+def test_true_when_all_set():
+    s = _Stub()
+    s._shutting_down = True
+    s._wpp_updating = True
+    s._recovery_restart_active = True
+    s._restarting_wpp_session = True
+
+    assert s._self_inflicted_teardown_expected() is True
+
+
+def test_missing_attributes_default_to_false():
+    """None of the four flags is guaranteed to exist yet this early (e.g. a
+    live event arriving before __init__ has set any of them) -- must
+    degrade to "not self-inflicted", not raise, since _live_events_ready()
+    is the gate that decides whether processing happens at all this early."""
+    s = _Stub()
+
+    assert s._self_inflicted_teardown_expected() is False

--- a/tests/test_settings_dialog_apply_button.py
+++ b/tests/test_settings_dialog_apply_button.py
@@ -30,6 +30,10 @@ import pytest
 from core.i18n import I18n
 from core.sound_system import DEFAULT_PACK_ID
 from ui.dialogs.settings_dialog import SettingsDialog
+from tests.conftest import hidden_frame
+
+# Creates a REAL top-level wx dialog - see the wxgui marker in pytest.ini.
+pytestmark = pytest.mark.wxgui
 
 
 class _FakeSoundSystem:
@@ -48,7 +52,7 @@ class _FakeSoundSystem:
 
 @pytest.fixture
 def dialog(wx_app):
-    frame = wx.Frame(None)
+    frame = hidden_frame()
     frame.settings = {}
     frame.app_name = "WinZapp"
     frame.i18n = I18n(frame)

--- a/tests/test_settings_files_saving_tab.py
+++ b/tests/test_settings_files_saving_tab.py
@@ -18,6 +18,10 @@ from core import save_location
 from core.i18n import I18n
 from core.sound_system import DEFAULT_PACK_ID
 from ui.dialogs.settings_dialog import SettingsDialog
+from tests.conftest import hidden_frame
+
+# Creates a REAL top-level wx dialog - see the wxgui marker in pytest.ini.
+pytestmark = pytest.mark.wxgui
 
 
 class _FakeSoundSystem:
@@ -35,7 +39,7 @@ class _FakeSoundSystem:
 
 
 def _make_frame(settings):
-    frame = wx.Frame(None)
+    frame = hidden_frame()
     frame.settings = settings
     frame.app_name = "WinZapp"
     frame.i18n = I18n(frame)

--- a/tests/test_shift_enter_newline.py
+++ b/tests/test_shift_enter_newline.py
@@ -15,6 +15,7 @@ correctly) — same approach as tests/test_conversation_video_playback.py.
 import wx
 
 from ui.conversations import ConversationsPanel
+from tests.conftest import hidden_frame
 
 
 class _FakeKeyEvent:
@@ -61,7 +62,7 @@ class _Stub:
 
 class TestShiftEnterInsertsNewline:
     def test_shift_enter_inserts_newline_at_cursor(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame)
             stub.message_field.SetValue("hello world")
@@ -86,7 +87,7 @@ class TestShiftEnterInsertsNewline:
     def test_plain_enter_is_left_alone_to_send(self, wx_app):
         """Plain Enter must not be consumed here — EVT_TEXT_ENTER (send)
         depends on the event propagating normally."""
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame)
             stub.message_field.SetValue("hello")
@@ -109,7 +110,7 @@ class TestShiftEnterInsertsNewline:
         only checked the value WE fed back into SetInsertionPoint(), so it
         never caught this — it needs a second WriteText() simulating the
         user's next keystrokes to actually observe where they land."""
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame)
             stub.message_field.SetValue("hello world")
@@ -124,7 +125,7 @@ class TestShiftEnterInsertsNewline:
             frame.Destroy()
 
     def test_shift_enter_also_works_with_numpad_enter(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         try:
             stub = _Stub(frame)
             stub.message_field.SetValue("ab")

--- a/tests/test_shutdown_close_not_treated_as_logout.py
+++ b/tests/test_shutdown_close_not_treated_as_logout.py
@@ -1,0 +1,280 @@
+"""Tests for WebSocketClient.on_connection_update()'s "close" branch during
+our own deliberate shutdown.
+
+The bug: real_exit() -> _perform_shutdown() -> _stop_wpp_server() posts
+/close-session itself and then polls for the flush, all while the WebSocket
+is deliberately left connected (see _perform_shutdown()'s own comment on
+_shutting_down, which already exists specifically to stop this exact kind of
+self-inflicted event from being misread -- but was only ever wired into
+_set_wa_connected(), not into the destructive logout-detection branch here).
+
+Baileys/WPPConnect reports a session WE closed ourselves via /close-session
+the same way it reports a real phone-side logout: connection.update fires
+with state="close" and loggedOut=True or statusCode=401. Before this fix,
+on_connection_update() could not tell the two apart, so an entirely ordinary
+quit (Ctrl+Alt+Shift+Q or any other exit path) could wipe the token, drop
+`paired`, and run clear_local_data() -- all persisted to disk before the
+process finished exiting. The next launch then found an empty token and
+showed "Your device has been disconnected" for a device that was never
+actually disconnected. This is the exact "closed WinZapp, relaunched, told
+the device was disconnected" report.
+
+WebSocketClient is exercised as a plain function bound onto a small stub (no
+real socketio/wx.App needed) -- same approach as
+tests/test_qrcode_auto_repair_dialog.py uses for on_qrcode_update.
+"""
+
+import pytest
+
+from core.websocket_client import WebSocketClient
+from main import MainWindow
+
+
+class _FakeI18n:
+    def t(self, key):
+        return key
+
+
+class _FakeSound:
+    def play(self):
+        pass
+
+
+class _FakeMainWindow:
+    # Bound for real (not re-implemented) so this test exercises the exact
+    # same helper on_connection_update()/on_wpp_status_find() call in
+    # production -- a hand-rolled stub method here would silently stop
+    # catching a future regression where the two drift apart again.
+    _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
+
+    def __init__(self, *, shutting_down=False, wpp_updating=False,
+                 recovery_restart_active=False, restarting_wpp_session=False,
+                 paired=True, pairing_in_progress=False,
+                 messages_set_completed=True, wa_connected=True):
+        self.settings = {"privateinfo": {"paired": paired}}
+        self._shutting_down = shutting_down
+        self._wpp_updating = wpp_updating
+        self._recovery_restart_active = recovery_restart_active
+        self._restarting_wpp_session = restarting_wpp_session
+        self._pairing_in_progress = pairing_in_progress
+        self.messages_set_completed = messages_set_completed
+        self._wa_connected = wa_connected
+        self.error_sound = _FakeSound()
+        self.app_name = "WinZapp"
+        self.wa_connected_calls = []
+
+    def _set_wa_connected(self, connected, reason, *a, **kw):
+        self.wa_connected_calls.append((connected, reason))
+
+    def output(self, text, interrupt=False):
+        pass
+
+    def _set_status(self, text):
+        pass
+
+
+class _Stub:
+    on_connection_update = WebSocketClient.on_connection_update
+    on_wpp_status_find = WebSocketClient.on_wpp_status_find
+
+    def __init__(self, main_window):
+        self.main_window = main_window
+        self.i18n = _FakeI18n()
+        self.logout_calls = 0
+        self.pairing_failed_calls = 0
+        self._logout_handled = False
+
+    def _handle_logout(self):
+        self.logout_calls += 1
+
+    def _handle_pairing_failed(self):
+        self.pairing_failed_calls += 1
+
+
+@pytest.fixture(autouse=True)
+def _synchronous_call_after(monkeypatch):
+    monkeypatch.setattr("core.websocket_client.wx.CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+    monkeypatch.setattr("core.websocket_client.wx.MessageBox", lambda *a, **kw: None)
+
+
+def _close_event(*, logged_out=True, status_code=None):
+    data = {"state": "close"}
+    if logged_out:
+        data["loggedOut"] = True
+    if status_code is not None:
+        data["statusCode"] = status_code
+    return {"data": data}
+
+
+class TestCloseDuringOwnShutdownIsNeverALogout:
+    def test_logged_out_flag_during_shutdown_does_not_wipe(self):
+        mw = _FakeMainWindow(shutting_down=True)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=True))
+
+        assert s.logout_calls == 0
+        assert s.pairing_failed_calls == 0
+
+    def test_statuscode_401_during_shutdown_does_not_wipe(self):
+        mw = _FakeMainWindow(shutting_down=True)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=False, status_code=401))
+
+        assert s.logout_calls == 0
+
+    def test_failed_pairing_during_shutdown_is_also_ignored(self):
+        """A close mid-shutdown must never fire ANY destructive branch, not
+        just the logout one."""
+        mw = _FakeMainWindow(shutting_down=True, pairing_in_progress=True,
+                             messages_set_completed=False)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=False, status_code=None))
+
+        assert s.pairing_failed_calls == 0
+        assert s.logout_calls == 0
+
+    def test_status_find_during_shutdown_also_does_not_wipe(self):
+        mw = _FakeMainWindow(shutting_down=True, wa_connected=True, paired=True)
+        s = _Stub(mw)
+
+        s.on_wpp_status_find({"status": "notLogged", "session": None})
+
+        assert s.logout_calls == 0
+
+
+class TestCloseDuringOwnUpdateIsAlsoNeverALogout:
+    """The gap found by re-reviewing every _stop_wpp_server() caller, not
+    just the one already fixed: _update_wpp_server() sets _wpp_updating
+    (not _shutting_down) and calls _stop_wpp_server() directly to replace a
+    running WPPConnect Server build. Before _self_inflicted_teardown_expected()
+    consolidated both flags, a close/notLogged signal arriving during an
+    ordinary auto-update was indistinguishable from the shutdown case this
+    file already covers, and would have wiped the token exactly the same way.
+    """
+
+    def test_logged_out_flag_during_update_does_not_wipe(self):
+        mw = _FakeMainWindow(wpp_updating=True)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=True))
+
+        assert s.logout_calls == 0
+
+    def test_status_find_during_update_does_not_wipe(self):
+        mw = _FakeMainWindow(wpp_updating=True, wa_connected=True, paired=True)
+        s = _Stub(mw)
+
+        s.on_wpp_status_find({"status": "notLogged", "session": None})
+
+        assert s.logout_calls == 0
+
+
+class TestCloseDuringRecoveryRestartIsAlsoNeverALogout:
+    """The gap found by re-reviewing every close-session-triggering method,
+    not just the two already fixed: _restart_session_once() (called from
+    _run_recovery_attempts(), the power-resume zombie-session recovery
+    cycle) sets _recovery_restart_active (not _shutting_down or
+    _wpp_updating) and posts /close-session on this account's own session
+    directly. Previously guarded only inside check_wa_connection_http()'s
+    own CLOSED auto-start branch -- not here -- so an ordinary sleep/wake
+    cycle could wipe a perfectly good session's token the exact same way as
+    the shutdown and update cases above."""
+
+    def test_logged_out_flag_during_recovery_restart_does_not_wipe(self):
+        mw = _FakeMainWindow(recovery_restart_active=True)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=True))
+
+        assert s.logout_calls == 0
+
+    def test_status_find_during_recovery_restart_does_not_wipe(self):
+        mw = _FakeMainWindow(recovery_restart_active=True, wa_connected=True, paired=True)
+        s = _Stub(mw)
+
+        s.on_wpp_status_find({"status": "notLogged", "session": None})
+
+        assert s.logout_calls == 0
+
+
+class TestCloseDuringInPlaceSessionRestartIsAlsoNeverALogout:
+    """The gap found by re-checking every OTHER close-session-triggering
+    method one more time, after the shutdown/update/recovery-restart cases
+    above were already fixed: _restart_wpp_session() (the detached-
+    Puppeteer-page in-place restart -- a DIFFERENT wake-from-sleep trigger
+    than the recovery-restart case) sets _restarting_wpp_session and posts
+    /close-session on this account's own session directly. That function's
+    own docstring documents a real incident from exactly this mechanism,
+    but the fix that shipped then only covered check_wa_connection_http()'s
+    slower strike-based path -- this immediate, single-event close branch
+    stayed completely unguarded against it."""
+
+    def test_logged_out_flag_during_restart_does_not_wipe(self):
+        mw = _FakeMainWindow(restarting_wpp_session=True)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=True))
+
+        assert s.logout_calls == 0
+
+    def test_status_find_during_restart_does_not_wipe(self):
+        mw = _FakeMainWindow(restarting_wpp_session=True, wa_connected=True, paired=True)
+        s = _Stub(mw)
+
+        s.on_wpp_status_find({"status": "notLogged", "session": None})
+
+        assert s.logout_calls == 0
+
+
+class TestCloseOutsideShutdownStillDetectsARealLogout:
+    """The guard must not swallow a genuine logout that happens to arrive
+    while _shutting_down is False (the overwhelmingly common case: the app
+    is just running normally and WhatsApp actually unlinks the device)."""
+
+    def test_logged_out_flag_not_shutting_down_still_wipes(self):
+        mw = _FakeMainWindow(shutting_down=False)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=True))
+
+        assert s.logout_calls == 1
+
+    def test_statuscode_401_not_shutting_down_still_wipes(self):
+        mw = _FakeMainWindow(shutting_down=False)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=False, status_code=401))
+
+        assert s.logout_calls == 1
+
+    def test_failed_pairing_not_shutting_down_still_detected(self):
+        mw = _FakeMainWindow(shutting_down=False, pairing_in_progress=True,
+                             messages_set_completed=False)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=False, status_code=None))
+
+        assert s.pairing_failed_calls == 1
+        assert s.logout_calls == 0
+
+    def test_status_find_not_shutting_down_still_detected(self):
+        mw = _FakeMainWindow(shutting_down=False, wa_connected=True, paired=True)
+        s = _Stub(mw)
+
+        s.on_wpp_status_find({"status": "notLogged", "session": None})
+
+        assert s.logout_calls == 1
+
+    def test_an_ordinary_temporary_close_never_wipes_either_way(self):
+        """Not a logout, not a failed pairing -- just a normal reconnect
+        blip. Must never touch credentials, shutting down or not."""
+        mw = _FakeMainWindow(shutting_down=False, pairing_in_progress=False)
+        s = _Stub(mw)
+
+        s.on_connection_update(_close_event(logged_out=False, status_code=None))
+
+        assert s.logout_calls == 0
+        assert s.pairing_failed_calls == 0

--- a/tests/test_shutdown_paths_off_main_thread.py
+++ b/tests/test_shutdown_paths_off_main_thread.py
@@ -1,0 +1,80 @@
+"""Nothing on a quit path may block the wx main thread.
+
+This is the accessibility invariant, not a performance nicety: a blocked
+message loop repaints nothing and pumps no accessibility events, so a
+screen-reader user gets total silence on a window Windows has already tagged
+"Not Responding" — and their reasonable next move is the force-kill that
+corrupts the session (see CLAUDE.md on shutdown_audit.log).
+
+PR #141 raised every teardown budget for good reasons — an in-flight send
+drain, a yield to a self-restart, a token-persist wait, a peer's whole
+graceful teardown — which turned three paths that were merely slow into ones
+that can freeze a window for a minute or more:
+
+  * quit_all_accounts() asks each peer account to quit SEQUENTIALLY, and
+    request_quit()'s default went from 10s to 85s. Three peers = 255s.
+  * _ipc_quit() runs the full teardown, and the IPC listener dispatched it
+    with wx.CallAfter — i.e. onto the main thread of an account that is not
+    even the one the user asked to quit.
+  * Connect._wait_for_pairing_startup_settled() polls for up to 30s and was
+    called inline from the dialog's close handlers.
+"""
+
+import inspect
+
+from main import MainWindow
+
+
+class TestQuitAllAccounts:
+    def test_the_peer_loop_runs_on_a_worker_thread(self):
+        src = inspect.getsource(MainWindow.quit_all_accounts)
+        assert "threading.Thread(target=" in src, (
+            "quit_all_accounts() runs request_quit() for every peer inline on "
+            "the wx main thread — with request_quit()'s 85s default that "
+            "freezes this window for minutes"
+        )
+        # The request itself must live inside the worker, not before it.
+        # (Compared against the nested def, not the Thread() call, so the
+        # docstring naming request_quit() doesn't decide the outcome.)
+        assert src.index("def _quit_peers_then_exit") < src.index("ipc.request_quit("), (
+            "request_quit() is called outside the worker function"
+        )
+
+    def test_it_still_exits_when_there_are_no_peers_to_ask(self):
+        """The early-out path (no account/global_dir) must reach real_exit()
+        directly — deferring it to a thread that never starts would leave the
+        app running after the user clicked Exit."""
+        src = inspect.getsource(MainWindow.quit_all_accounts)
+        assert "self.real_exit()" in src
+
+    def test_the_docstring_no_longer_promises_a_short_wait(self):
+        """It used to claim "an unresponsive peer never blocks our exit",
+        which stopped being true the moment the timeout became 85s."""
+        doc = MainWindow.quit_all_accounts.__doc__ or ""
+        assert "never blocks our exit" not in doc
+
+
+class TestIpcQuit:
+    def test_the_listener_does_not_marshal_quit_onto_the_wx_thread(self):
+        src = inspect.getsource(MainWindow._start_ipc_listener)
+        # activate() is a genuine UI action and must stay on the wx thread.
+        assert "wx.CallAfter(self._ipc_activate" in src
+        assert "wx.CallAfter(self._ipc_quit)" not in src, (
+            "_ipc_quit() runs the whole graceful teardown; on the wx thread "
+            "it freezes THIS account's window while a different account quits"
+        )
+        assert "threading.Thread(" in src
+
+    def test_real_exit_documents_the_same_rule(self):
+        doc = MainWindow.real_exit.__doc__ or ""
+        assert "_ipc_quit" in doc
+
+
+class TestStopWppServerDocstring:
+    def test_it_names_every_main_thread_caller(self):
+        """The docstring is the only thing telling the next person which
+        callers are deliberate exceptions. It claimed there was exactly one
+        while _on_end_session() was a second."""
+        doc = MainWindow._stop_wpp_server.__doc__ or ""
+        assert "_update_wpp_server" in doc
+        assert "_on_end_session" in doc

--- a/tests/test_shutdown_suppresses_auto_start.py
+++ b/tests/test_shutdown_suppresses_auto_start.py
@@ -1,0 +1,70 @@
+"""Tests for check_wa_connection_http()'s CLOSED branch skipping the
+auto-start-session call during our own deliberate shutdown.
+
+Reported live: quitting WinZapp (Ctrl+Alt+Shift+Q) hit the same class of bug
+as on_connection_update()'s self-inflicted-close guard, just on a different
+method and a different action. _stop_wpp_server() posts /close-session
+itself, which makes status-session correctly read CLOSED a moment later --
+but the health-check loop runs on its own independent thread with no idea a
+shutdown is in progress, saw that CLOSED, and "helpfully" called
+/start-session to bring the session back. That revived the browser right as
+taskkill was about to force-kill it, so the kill landed on a session that
+had just started re-initializing instead of one that had actually finished
+closing -- and it also starved _wait_for_session_flushed() of the CLOSED
+reading it needed, timing out its 15s wait. Observed live in connection.log:
+status-session read CLOSED, then INITIALIZING, then CONNECTED again, all
+inside that 15s window, followed by "flush TIMEOUT ... never saw CLOSED".
+
+check_wa_connection_http() is a large method with many dependencies (HTTP
+calls, wx, several other subsystems) that make it impractical to drive end
+to end in a unit test -- same situation test_startup_invalid_namespace_no_wipe.py
+is in for _post_ui_init, checked the same way: at source level.
+"""
+
+import inspect
+
+from main import MainWindow
+
+
+def _closed_branch_source() -> str:
+    """The CLOSED/DESTROYED/'' branch's source, isolated from the rest of
+    check_wa_connection_http so assertions can't accidentally match
+    unrelated code."""
+    src = inspect.getsource(MainWindow.check_wa_connection_http)
+    start = src.index('elif status in ("CLOSED", "DESTROYED", ""):')
+    end = src.index("Sent auto-start session command", start)
+    return src[start:end]
+
+
+class TestClosedDuringShutdownSkipsAutoStart:
+    def test_shutting_down_is_checked_before_auto_starting(self):
+        """Consolidated into _self_inflicted_teardown_expected() (covers both
+        _shutting_down and _wpp_updating -- see
+        tests/test_self_inflicted_teardown_expected.py for that helper's own
+        coverage); this branch must actually call it."""
+        branch = _closed_branch_source()
+        assert "_self_inflicted_teardown_expected" in branch
+
+    def test_the_pairing_dialog_guard_is_unaffected(self):
+        """The two pre-existing guards (pairing dialog active, an active
+        recovery-restart sequence) must still both be present -- this fix
+        adds a third condition, it does not replace either existing one."""
+        branch = _closed_branch_source()
+        assert "_is_pairing_dialog_active" in branch
+        assert "_recovery_restart_active" in branch
+
+    def test_the_shutting_down_check_actually_skips_the_start_session_call(self):
+        """Guard against the guard being present but not actually wired to
+        skip anything (e.g. a check that never reaches a `return`/skip)."""
+        branch = _closed_branch_source()
+        shutting_down_clause = branch[branch.index("_self_inflicted_teardown_expected"):]
+        # The actual api_post(start_url, ...) call must not appear between
+        # the self-inflicted-teardown check and the final `else:` that guards
+        # it -- i.e. it is reachable only in that final else, not inside the
+        # self-inflicted-teardown branch itself. Searches for the call
+        # expression specifically (not the bare words "start-session", which
+        # this branch's own explanatory comments also use in prose).
+        call_pos = shutting_down_clause.find("api_post(start_url")
+        else_pos = shutting_down_clause.find("else:")
+        assert else_pos != -1
+        assert call_pos == -1 or call_pos > else_pos

--- a/tests/test_shutdown_suppresses_offline.py
+++ b/tests/test_shutdown_suppresses_offline.py
@@ -24,6 +24,7 @@ from main import MainWindow
 
 class _Stub:
     _set_wa_connected = MainWindow._set_wa_connected
+    _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
 
     def __init__(self, shutting_down):
         self._shutting_down = shutting_down

--- a/tests/test_shutdown_wait.py
+++ b/tests/test_shutdown_wait.py
@@ -125,3 +125,32 @@ class TestGracefulStopBudgetIsBounded:
         sleep (the thing that started this whole chain of fixes, by corrupting
         the WhatsApp Web session) must not either."""
         assert 2 < MainWindow._WPP_GRACEFUL_STOP_SECONDS <= 15
+
+
+class TestPerformShutdownReentrancyIsAtomic:
+    """The gap found by re-reviewing _perform_shutdown() against
+    _on_end_session(): the original `if getattr(self, "_shutting_down",
+    False): return` / `self._shutting_down = True` pair was a plain
+    check-then-set with no lock. A local quit (real_exit()'s background
+    teardown thread) racing a WM_ENDSESSION or an IPC "quit" from another
+    account (both delivered on the wx main thread) could both observe
+    _shutting_down as still False and both proceed into a full
+    _stop_wpp_server() concurrently. _teardown_started_lock closes that."""
+
+    def test_the_check_and_set_are_inside_the_lock(self):
+        src = inspect.getsource(MainWindow._perform_shutdown)
+        lock_pos = src.index("with self._teardown_started_lock:")
+        guard_pos = src.index('getattr(self, "_shutting_down", False)')
+        set_pos = src.index("self._shutting_down = True")
+        assert lock_pos < guard_pos < set_pos, (
+            "the check-then-set must both happen inside the lock, not just "
+            "one of them"
+        )
+
+    def test_on_end_session_uses_the_same_lock(self):
+        src = inspect.getsource(MainWindow._on_end_session)
+        assert "self._teardown_started_lock" in src, (
+            "_on_end_session() must guard its own _shutting_down "
+            "check-and-set with the same lock _perform_shutdown() uses, or "
+            "the two can still race each other"
+        )

--- a/tests/test_startup_grace.py
+++ b/tests/test_startup_grace.py
@@ -56,6 +56,7 @@ class _Stub:
     _set_wa_connected = MainWindow._set_wa_connected
     _reset_startup_probe = MainWindow._reset_startup_probe
     _announce_sync_events_enabled = MainWindow._announce_sync_events_enabled
+    _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
     _WA_STARTUP_GRACE_SECONDS = MainWindow._WA_STARTUP_GRACE_SECONDS
 
     # Overridden per-test; the default keeps the grace intact.
@@ -66,6 +67,7 @@ class _Stub:
         self.network_down = network_down
         self.settings = {}
         self._shutting_down = False
+        self._wpp_updating = False
         self._wa_connected = False
         self._auto_offline = False
         self._wa_connect_announced = False

--- a/tests/test_startup_invalid_namespace_no_wipe.py
+++ b/tests/test_startup_invalid_namespace_no_wipe.py
@@ -60,7 +60,7 @@ class TestInvalidNamespaceRetries:
 class TestInvalidNamespaceNeverWipes:
     def test_the_invalid_namespace_branch_disconnects_without_wiping(self):
         step6 = _step6_source()
-        assert "self._on_disconnect(wipe=False)" in step6
+        assert "self._on_disconnect(wipe=False" in step6
 
     def test_the_default_wipe_true_disconnect_call_is_gone(self):
         """Guards against the exact old call (self._on_disconnect() with no

--- a/tests/test_status_synced_with_connected_sound.py
+++ b/tests/test_status_synced_with_connected_sound.py
@@ -44,11 +44,14 @@ class _Stub:
             MainWindow._set_preparing_status_if_idle.__get__(self))
         self._reset_startup_probe = MainWindow._reset_startup_probe.__get__(self)
         self._announce_sync_events_enabled = MainWindow._announce_sync_events_enabled.__get__(self)
+        self._self_inflicted_teardown_expected = (
+            MainWindow._self_inflicted_teardown_expected.__get__(self))
         self._WA_STARTUP_GRACE_SECONDS = MainWindow._WA_STARTUP_GRACE_SECONDS
 
         self.settings = {}
 
         self._shutting_down = False
+        self._wpp_updating = False
         self._wa_connected = False
         self._auto_offline = False
         self._wa_connect_announced = False

--- a/tests/test_stop_wpp_server_token_persist_gate.py
+++ b/tests/test_stop_wpp_server_token_persist_gate.py
@@ -1,0 +1,94 @@
+"""Tests for two gaps found by re-reviewing _stop_wpp_server()'s token-persist
+gate (main.py) after the first pass of this fix (_wait_for_token_persisted()
+itself, covered by tests/test_token_store_persistent_path.py).
+
+Gap 1 -- the wait was nested INSIDE the close-session try block, so a
+close-session request that raised (timeout, connection error -- precisely
+the case where Chrome is most likely to still be mid-write) skipped the
+token-persist wait entirely and went straight to taskkill. It must run
+unconditionally after the try/except, not only on the happy path.
+
+Gap 2 -- the decision to even bother waiting was gated on a single fresh
+HTTP probe (_raw_session_status(), called pre_status here), which returns ""
+on ANY failure of that one call (timeout, non-200, connection error). A
+transient hiccup on exactly that probe -- at the single busiest moment in
+the process's life -- would silently skip protecting a session that really
+was CONNECTED. self._wa_connected is the app's own in-memory belief,
+updated continuously all run and frozen (not clearable) the instant
+_shutting_down/_wpp_updating goes True, so it is a race-free second signal
+that costs no extra network round trip. Either signal must be enough to
+trigger the wait.
+
+_stop_wpp_server() is a large method with many dependencies (HTTP calls,
+subprocess, taskkill) that make it impractical to drive end to end in a unit
+test -- same situation check_wa_connection_http is in
+(tests/test_shutdown_suppresses_auto_start.py), checked the same way: at
+source level.
+"""
+
+import inspect
+
+from main import MainWindow
+
+
+def _body_source() -> str:
+    return inspect.getsource(MainWindow._stop_wpp_server)
+
+
+def _if_token_block() -> str:
+    """The `if token:` block through STEP 2's node-lease release, isolated so
+    assertions can't accidentally match unrelated code."""
+    src = _body_source()
+    start = src.index("if token:")
+    end = src.index("# STEP 2:", start)
+    return src[start:end]
+
+
+class TestSessionWasConnectedUsesTwoSignals:
+    def test_gate_checks_the_in_memory_flag_not_only_the_fresh_probe(self):
+        block = _if_token_block()
+        assert "session_was_connected" in block
+        assert '"_wa_connected"' in block or "_wa_connected" in block
+        assert 'pre_status in ("CONNECTED", "open")' in block
+
+    def test_session_was_connected_is_computed_before_the_try(self):
+        block = _if_token_block()
+        decl_pos = block.index("session_was_connected =")
+        try_pos = block.index("try:")
+        assert decl_pos < try_pos, (
+            "session_was_connected must be decided from pre_status/_wa_connected "
+            "BEFORE the close-session attempt, not derived from anything the "
+            "try block itself produces"
+        )
+
+
+class TestTokenPersistWaitRunsRegardlessOfException:
+    def test_wait_for_token_persisted_call_is_outside_the_try_block(self):
+        """The actual regression: this call must not be nested inside the
+        `try:` whose `except Exception:` catches a close-session timeout/
+        connection error -- otherwise that exact failure mode skips the wait
+        that matters most."""
+        block = _if_token_block()
+        try_start = block.index("try:")
+        except_start = block.index("except Exception as e:", try_start)
+        # Find the end of the except suite: the next line at the same
+        # indentation as `except` itself that isn't part of its body. The
+        # except body in this method ends where the closing dedent to the
+        # `if session_was_connected:` gate begins.
+        gate_pos = block.index("if session_was_connected:")
+        wait_pos = block.index("self._wait_for_token_persisted(token)")
+
+        assert except_start < gate_pos < wait_pos, (
+            "_wait_for_token_persisted must be called after (not nested "
+            "inside) both the try and except suites"
+        )
+
+    def test_no_early_return_between_except_and_the_wait(self):
+        """Guard against a future edit reintroducing an early return/continue
+        inside except that would once again skip the wait on that path."""
+        block = _if_token_block()
+        except_start = block.index("except Exception as e:")
+        gate_pos = block.index("if session_was_connected:")
+        except_body = block[except_start:gate_pos]
+        assert "return" not in except_body
+        assert "continue" not in except_body

--- a/tests/test_update_dialog_default_button.py
+++ b/tests/test_update_dialog_default_button.py
@@ -13,6 +13,11 @@ import wx
 
 import updater
 from updater import UpdateDialog, WppUpdateChecker
+from tests.conftest import hidden_frame
+import pytest
+
+# Creates a REAL top-level wx dialog - see the wxgui marker in pytest.ini.
+pytestmark = pytest.mark.wxgui
 
 
 class _FakeI18n:
@@ -22,7 +27,7 @@ class _FakeI18n:
 
 class TestUpdateDialogDefaultButton:
     def test_no_button_is_the_default_item(self, wx_app):
-        frame = wx.Frame(None)
+        frame = hidden_frame()
         frame.i18n = _FakeI18n()
         try:
             dlg = UpdateDialog(frame, "2026.01.01.0000", changelog="")

--- a/tests/test_video_player.py
+++ b/tests/test_video_player.py
@@ -33,6 +33,7 @@ import time
 import pytest
 
 from core.video_player import extract_jpeg_frames, fit_frame_size, VideoPlayer
+from tests.conftest import hidden_frame
 
 
 def _jpeg(payload: bytes) -> bytes:
@@ -146,7 +147,7 @@ _created_players = []
 
 def _make_player(wx_app, on_frame_size=None, box_size=None):
     import wx
-    frame = wx.Frame(None)
+    frame = hidden_frame()
     bitmap = wx.StaticBitmap(frame)
     if box_size is not None:
         # SetSize (not SetMinSize) so GetSize() reports it back

--- a/tests/test_yield_to_in_progress_self_restart.py
+++ b/tests/test_yield_to_in_progress_self_restart.py
@@ -1,0 +1,112 @@
+"""Tests for MainWindow._yield_to_in_progress_self_restart().
+
+The gap found by re-reviewing _stop_wpp_server() against the two
+wake-from-sleep self-restart cycles (_recovery_restart_active /
+_restarting_wpp_session, see _self_inflicted_teardown_expected()): neither
+holds _teardown_started_lock, because they are not teardown -- they are a
+close+start cycle running on their own thread, independent of any quit. A
+user quit landing exactly while one is in flight let _stop_wpp_server()'s
+own close-session/flush-wait race the restart's close-session/start-session
+call on the SAME session: the restart's start-session can flip status back
+to INITIALIZING mid-_wait_for_session_flushed(), starving it of the CLOSED
+reading it needs and falling through to a taskkill that risks the exact
+"Session Unpaired" corruption this whole mechanism exists to prevent.
+
+_yield_to_in_progress_self_restart() gives a short, bounded grace for an
+already-in-progress restart to finish before _stop_wpp_server() proceeds --
+narrowing this race, not eliminating it (a restart that outlasts the grace
+still races), which is the deliberate, documented tradeoff: a user who
+explicitly asked to quit should not wait anywhere near that cycle's own
+~30-60s worst case for an invisible background operation.
+"""
+
+import threading
+import time
+
+from main import MainWindow
+
+
+class _Stub:
+    _yield_to_in_progress_self_restart = MainWindow._yield_to_in_progress_self_restart
+    _SELF_RESTART_YIELD_SECONDS = 0.3
+    _SELF_RESTART_YIELD_POLL_SECONDS = 0.02
+
+    def __init__(self):
+        self._recovery_restart_active = False
+        self._restarting_wpp_session = False
+
+
+class TestNoRestartInProgress:
+    def test_returns_immediately_when_neither_flag_is_set(self):
+        s = _Stub()
+        started = time.monotonic()
+
+        s._yield_to_in_progress_self_restart()
+
+        assert time.monotonic() - started < 0.1
+
+
+class TestRestartClearsBeforeTheGraceWindow:
+    def test_recovery_restart_active_clearing_returns_early(self):
+        s = _Stub()
+        s._recovery_restart_active = True
+
+        def _clear_soon():
+            time.sleep(0.05)
+            s._recovery_restart_active = False
+        threading.Thread(target=_clear_soon, daemon=True).start()
+
+        started = time.monotonic()
+        s._yield_to_in_progress_self_restart()
+        elapsed = time.monotonic() - started
+
+        assert elapsed < s._SELF_RESTART_YIELD_SECONDS
+
+    def test_restarting_wpp_session_clearing_returns_early(self):
+        s = _Stub()
+        s._restarting_wpp_session = True
+
+        def _clear_soon():
+            time.sleep(0.05)
+            s._restarting_wpp_session = False
+        threading.Thread(target=_clear_soon, daemon=True).start()
+
+        started = time.monotonic()
+        s._yield_to_in_progress_self_restart()
+        elapsed = time.monotonic() - started
+
+        assert elapsed < s._SELF_RESTART_YIELD_SECONDS
+
+
+class TestRestartOutlivesTheGraceWindow:
+    def test_gives_up_after_the_bound_and_still_returns(self):
+        """Must never block shutdown indefinitely for an invisible
+        background recovery cycle -- proceeds anyway once the short grace
+        elapses, logging that the race was not fully closed."""
+        s = _Stub()
+        s._recovery_restart_active = True  # never cleared
+
+        started = time.monotonic()
+        s._yield_to_in_progress_self_restart()
+        elapsed = time.monotonic() - started
+
+        assert elapsed >= s._SELF_RESTART_YIELD_SECONDS
+        assert elapsed < s._SELF_RESTART_YIELD_SECONDS + 1.0
+
+
+class TestOnlyCalledWhenNothingElseOwnsTheDeadline:
+    """_stop_wpp_server(budget=...) is WM_ENDSESSION's own tightly-bounded
+    call (Windows kills an unresponsive app in ~5s). This yield's own wait
+    sits OUTSIDE that budget, so honoring it there could add its full
+    _SELF_RESTART_YIELD_SECONDS on top of a 4s budget -- comfortably past
+    what triggers a "Not Responding" kill mid-shutdown. Skipped entirely
+    when a budget is given, rather than budgeted, so a tight budget's real
+    phases (close-session, flush poll) are never starved by it."""
+
+    def test_the_call_is_guarded_on_budget_is_none(self):
+        import inspect
+        from main import MainWindow
+        source = inspect.getsource(MainWindow._stop_wpp_server)
+        call_at = source.index("_yield_to_in_progress_self_restart()")
+        guard = source[:call_at]
+        assert "if budget is None:" in guard[-500:]


### PR DESCRIPTION
Integra o [PR #141](https://github.com/gabrielhhaber/WinZapp_Python/pull/141) de @tareh7z junto com as correções apontadas na revisão. Não deve ser mesclado separadamente do #141 — e o #141 não deve ser mesclado sozinho.

## O PR original

O `_self_inflicted_teardown_expected()` está correto e não engole logout real: os quatro flags são setados/limpos em `try/finally` curtos, e o detector que toma decisões destrutivas (a máquina de strikes de `check_wa_connection_http`) deliberadamente não é gated por ele. O patch novo do Node é superset fiel do upstream e está registrado nas quatro listas obrigatórias.

## O que foi corrigido em cima

1. **Migração ausente (bloqueante).** Apontar o perfil do Chrome e o token store para `<global_dir>/api` deixava toda instalação já pareada olhando para uma pasta vazia — ou seja, entregava a todo mundo, uma vez, exatamente o "fechei e disse que o aparelho foi desconectado" que o PR existe para corrigir. Além disso, `_cleanup_abandoned_sessions()` passava a varrer só a raiz nova, deixando os perfis antigos órfãos e fora do alcance da limpeza. `migrate_legacy_api_state()` faz o move uma única vez, nunca sobrescreve o destino, move pasta a pasta e roda antes do `Popen` do Node.

2. **Espera de 30s do pareamento na thread do wx.** Congelava a janela em silêncio total para leitor de tela. Agora roda em worker, com o fechamento reemitido depois; um segundo fechamento passa direto. A classificação saiu para `pairing_startup_settled()`, que trata `CLOSED`/`DESTROYED` como "não há o que esperar" — antes o caso mais comum (nada apareceu, usuário desiste) gastava os 30s inteiros.

3. **`quit_all_accounts()`** rodava o laço sequencial de `request_quit()` (85s por conta) na thread principal. Três contas abertas = até 255s de janela travada.

4. **`_ipc_quit`** era despachado com `wx.CallAfter`, travando a janela de uma conta enquanto **outra** saía.

5. **`_on_end_session`**: o ramo "outro caminho já é dono do teardown" devolvia o processo ao Windows imediatamente, no meio do flush — o padrão de corrupção de sessão descrito no CLAUDE.md. Agora espera o `_teardown_complete_event` dentro do orçamento do Windows.

Mais a docstring do `_stop_wpp_server` (afirmava um único chamador na main thread, eram dois) e o `_settings_save_timer`, que nunca era limpo após disparar.

## Sem relação com o #141

O último commit corrige a suíte derrubando o NVDA de quem estiver usando a máquina: 31 `wx.Frame(None)` passam por `conftest.hidden_frame()` (fora da tela, sem barra de tarefas) e os 5 módulos que constroem `Dialog` real ganham a marca `wxgui`. Diagnosticado a partir do traceback do próprio NVDA (`event_gainFocus` → `getDialogText` → `oleacc.AccessibleObjectFromEvent`).

Suíte local: **5057 passed** (`-m "not wxgui"`), **66 passed** nos marcados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)