### PR TITLE
Localize the language pickers and pairing dialog, fix Windows region/language detection, and unify multi-letter type-ahead across all ComboBoxes

### DIFF
--- a/client/core/combo_search.py
+++ b/client/core/combo_search.py
@@ -1,0 +1,150 @@
+"""Multi-character type-ahead search for read-only wx.ComboBox controls.
+
+wx.ComboBox(style=wx.CB_READONLY) already jumps to an item on a single
+keystroke (native Win32 CBS_DROPDOWNLIST behavior — same as the country and
+language ComboBoxes already relied on before this module existed), but a
+SECOND letter typed shortly after the first restarts the search from
+scratch instead of narrowing it: pressing "B" then "A" quickly lands on the
+first entry starting with "A" (treating the "A" as a brand new search), not
+on the first entry starting with "Ba". Reported live against the pairing
+dialog's country selector.
+
+WinZapp's own conversation/message/contact lists don't have this problem
+and need no code of their own for it: the main conversation list
+(ui/conversations.py's self.conversations_list, a wx.ListCtrl/SysListView32)
+and the "forward message" contact picker (a wx.ListBox — see
+ui/accessible.py's CompatListBoxMessagesCtrl docstring) both fall through to
+plain event.Skip() for an unmodified letter keystroke, because a native
+Win32 SysListView32 or LISTBOX genuinely does accumulate consecutive
+keystrokes into one search string on Windows. wx.ComboBox's dropdown list,
+despite being backed by a similar native control, does not do this: it
+re-searches from scratch on every keystroke — which is the ONE place in
+this codebase that needs the accumulation reimplemented by hand, here, and
+nowhere else.
+
+bind_incremental_search() reimplements the accumulation by hand: an
+EVT_CHAR handler buffers recent keystrokes (resetting after a short pause,
+exactly like a real incremental search), and an EVT_COMBOBOX handler lets
+the control's own (single-keystroke-only) native jump happen and then
+immediately corrects it — via SetSelection() — to whichever entry actually
+matches the accumulated buffer, before notifying *on_select*. Correcting
+after the fact, rather than trying to keep the native jump from happening
+in the first place, sidesteps a real trap: wx invokes every handler bound
+to the same event on the same control regardless of Skip() (Skip() only
+controls propagation to *parent* windows) — so a second, separately-bound
+EVT_COMBOBOX handler would see the "wrong" intermediate native jump before
+this one gets a chance to correct it. Route your own reaction to a
+selection change through *on_select* instead of binding wx.EVT_COMBOBOX
+directly on a control this is attached to, so it only ever fires once, with
+the final, already-corrected selection.
+"""
+
+import time
+import wx
+
+from core.utils import normalize_for_search
+
+# How long a pause between keystrokes is allowed before the search buffer
+# resets to just the new key, instead of extending the previous search.
+# Windows' own native list/combo incremental search doesn't expose its
+# timeout to applications; this is the same rough order of magnitude.
+SEARCH_TIMEOUT_SECONDS = 1.0
+
+
+def find_incremental_match(choices, prefix: str):
+    """Index of the first entry in *choices* (an iterable of strings) whose
+    text starts with *prefix* (case-insensitive, diacritics ignored), or
+    None if *prefix* is empty or nothing matches.
+
+    Pure — no wx dependency — so it's exercised directly in tests."""
+    if not prefix:
+        return None
+    needle = normalize_for_search(prefix, mode="nfkd")
+    for idx, text in enumerate(choices):
+        if normalize_for_search(text, mode="nfkd").startswith(needle):
+            return idx
+    return None
+
+
+def next_search_buffer(
+    buffer: str, char: str, elapsed: float, timeout: float = SEARCH_TIMEOUT_SECONDS
+) -> str:
+    """The new search buffer after *char* is typed *elapsed* seconds after
+    the previous keystroke on the same control: extends *buffer* when
+    *elapsed* is within *timeout*, otherwise starts over with just *char*.
+
+    Pure — exercised directly in tests."""
+    return (buffer + char) if elapsed <= timeout else char
+
+
+def bind_incremental_search(combo: wx.ComboBox, on_select=None) -> None:
+    """Attach multi-character type-ahead search to *combo*.
+
+    *combo* must be style=wx.CB_READONLY with its choices already set.
+    Consecutive letters typed within SEARCH_TIMEOUT_SECONDS of each other
+    accumulate into one search string instead of each restarting the
+    search from scratch, e.g. "B" then "A" lands on the first entry
+    starting with "Ba" rather than jumping to the first "B" and then the
+    first "A" independently.
+
+    *on_select*, if given, is called with the new selection index every
+    time a selection change settles — whether from typing (single- or
+    multi-character), the arrow keys, or a mouse click. This is the ONLY
+    reliable way to react to a selection change made through this function:
+    see the module docstring for why binding your own wx.EVT_COMBOBOX
+    handler directly on *combo* alongside this one would see an
+    uncorrected, momentarily-wrong selection first.
+    """
+    state = {"buffer": "", "last_time": 0.0, "keystroke_pending": False}
+
+    def _notify(idx):
+        if on_select is not None:
+            on_select(idx)
+
+    def _on_char(event):
+        # Always let native handling proceed — correction happens in
+        # _on_combobox() once the (possibly wrong) native jump has
+        # actually landed, not by trying to prevent it here.
+        event.Skip()
+
+        if event.ControlDown() or event.AltDown() or event.CmdDown():
+            return
+        key = event.GetUnicodeKey()
+        char = chr(key) if key != wx.WXK_NONE else ""
+        if not char.isalpha():
+            return
+
+        now = time.monotonic()
+        elapsed = now - state["last_time"]
+        state["last_time"] = now
+        state["buffer"] = next_search_buffer(state["buffer"], char, elapsed)
+        state["keystroke_pending"] = True
+
+    def _on_combobox(event):
+        event.Skip()
+
+        if not state.pop("keystroke_pending", False):
+            # A mouse click or arrow-key navigation, not a typed search —
+            # nothing to correct, just relay the (already correct) result.
+            _notify(combo.GetSelection())
+            return
+
+        buffer = state["buffer"]
+        if len(buffer) > 1:
+            choices = [combo.GetString(i) for i in range(combo.GetCount())]
+            idx = find_incremental_match(choices, buffer)
+            if idx is None:
+                # The accumulated buffer no longer matches anything — fall
+                # back to just the latest keystroke, same as native
+                # list/combo incremental search does when a typed sequence
+                # stops matching.
+                buffer = buffer[-1]
+                state["buffer"] = buffer
+                idx = find_incremental_match(choices, buffer)
+            if idx is not None and idx != combo.GetSelection():
+                combo.SetSelection(idx)
+
+        _notify(combo.GetSelection())
+
+    combo.Bind(wx.EVT_CHAR, _on_char)
+    combo.Bind(wx.EVT_COMBOBOX, _on_combobox)

--- a/client/core/locale_format.py
+++ b/client/core/locale_format.py
@@ -26,6 +26,9 @@ LOCALE_SSHORTDATE  = 0x0000001F
 # to LOCALE_STIMEFORMAT on anything older that doesn't recognize it.
 LOCALE_SSHORTTIME  = 0x00000079
 LOCALE_STIMEFORMAT = 0x00001003
+# MUI_LANGUAGE_NAME: makes GetUserPreferredUILanguages() return BCP-47 tags
+# ("en-US") instead of LANGIDs — for get_system_ui_language() below.
+MUI_LANGUAGE_NAME = 0x8
 
 # Longest-match-first per family, so e.g. "yyyy" is consumed before "yy".
 _DATE_TOKENS = [
@@ -104,6 +107,97 @@ def _windows_time_strftime() -> str | None:
         if not pattern:
             return None
         return _translate_pattern(pattern, _TIME_TOKENS)
+    except Exception:
+        return None
+
+
+def _get_windows_geo_name() -> str | None:
+    """Raw two-letter code from GetUserDefaultGeoName (Windows 10 1709+),
+    or None off-Windows, on an older Windows build, or on API failure."""
+    try:
+        kernel32 = ctypes.windll.kernel32
+    except (AttributeError, OSError):
+        return None
+    try:
+        size = kernel32.GetUserDefaultGeoName(None, 0)
+        if size <= 0:
+            return None
+        buf = ctypes.create_unicode_buffer(size)
+        if kernel32.GetUserDefaultGeoName(buf, size) <= 0:
+            return None
+        return buf.value or None
+    except Exception:
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def get_country_or_region_iso2() -> str | None:
+    """ISO 3166-1 alpha-2 code (e.g. "US", "BA") of the user's Windows
+    "Country or region" setting — Settings > Time & Language > Language &
+    region > Country or region, the field Windows describes as "Windows and
+    apps might use your country or region to give you local content". None
+    off-Windows or on API failure.
+
+    Deliberately NOT the "Regional format" locale that get_date_format() /
+    get_time_format() below use (GetUserDefaultLocaleName, reached via
+    GetLocaleInfoEx(NULL, ...)): the two Windows settings are independent.
+    A machine can have an English "Regional format" (it defaults to
+    whatever the UI language was at install time and most people never
+    change it) while "Country or region" is set to the user's actual
+    location. Reading Regional format here — an earlier version of this
+    function did — silently ignored a correctly-configured Country or
+    region and kept resolving to the Regional format's country instead;
+    reported live as the pairing dialog's country selector defaulting to
+    the United States on a machine whose Country or region was set to
+    Bosnia and Herzegovina. GetUserDefaultGeoName reads the Country or
+    region field directly, with no dependency on any language setting."""
+    try:
+        code = _get_windows_geo_name()
+        return code.upper() if code else None
+    except Exception:
+        return None
+
+
+def _get_windows_ui_language_raw() -> str | None:
+    """Raw top-priority tag from GetUserPreferredUILanguages, or None
+    off-Windows or on API failure."""
+    try:
+        kernel32 = ctypes.windll.kernel32
+    except (AttributeError, OSError):
+        return None
+    try:
+        num_languages = ctypes.c_ulong(0)
+        buf_len = ctypes.c_ulong(0)
+        if not kernel32.GetUserPreferredUILanguages(
+            MUI_LANGUAGE_NAME, ctypes.byref(num_languages), None, ctypes.byref(buf_len)
+        ) or buf_len.value == 0:
+            return None
+        buf = ctypes.create_unicode_buffer(buf_len.value)
+        if not kernel32.GetUserPreferredUILanguages(
+            MUI_LANGUAGE_NAME, ctypes.byref(num_languages), buf, ctypes.byref(buf_len)
+        ) or num_languages.value == 0:
+            return None
+        # buf is a MULTI_SZ (a list of NUL-terminated strings, double-NUL
+        # terminated); wstring_at() with no length reads up to the first
+        # embedded NUL, i.e. just the top-priority language.
+        return ctypes.wstring_at(buf) or None
+    except Exception:
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def get_system_ui_language() -> str | None:
+    """BCP-47 tag (e.g. "en-US") of the user's top-priority Windows display
+    language (GetUserPreferredUILanguages), or None off-Windows or on API
+    failure.
+
+    Also independent of get_country_or_region_iso2() and of "Regional
+    format" above — this is the actual "Windows display language" setting.
+    Used only to pick a sensible default in the first-run language picker
+    (ui/dialogs/language_dialog.py), which has no saved language to read
+    from I18n yet."""
+    try:
+        return _get_windows_ui_language_raw()
     except Exception:
         return None
 

--- a/client/countries.py
+++ b/client/countries.py
@@ -8,15 +8,27 @@ Cada entrada de _COUNTRIES é uma tupla (chave_estável, código_discagem, nomes
   • nomes: dict {"pt": ..., "en": ..., "es": ...} com o nome do país em
     português (usado tanto para pt-BR quanto pt-PT), inglês e espanhol.
 
-get_countries(lang) devolve [(nome_exibição, código_discagem), ...] na MESMA
-ORDEM independentemente do idioma (Brasil primeiro, depois ordem alfabética
-em português) — os diálogos que consomem esta lista indexam por posição
-(ComboBox.GetSelection()), então a ordem não pode variar entre idiomas sem
-também atualizar esses call sites.
+get_countries(lang) devolve [(nome_exibição, código_discagem), ...] ordenada
+alfabeticamente pelo NOME LOCALIZADO no idioma pedido (acentos ignorados na
+comparação, para que "Áustria"/"Austrália" fiquem ao lado de outras entradas
+com "A"). A ordem portanto muda entre idiomas — nenhum país (nem Brasil, nem
+o país detectado do Windows) é fixado artificialmente no topo; a posição de
+cada item só é usada para indexar de volta na MESMA lista que populou o
+ComboBox (ver get_default_country_index()), nunca comparada entre chamadas
+com idiomas diferentes.
+
+get_default_country_index() devolve o índice, dentro de uma lista já
+devolvida por get_countries(), do país que corresponde a "Country or region"
+configurado no Windows (core.locale_format.get_country_or_region_iso2() —
+NÃO o idioma de exibição do Windows nem o "Formato regional") — ou dos
+Estados Unidos, se essa detecção falhar ou o país detectado não estiver em
+_COUNTRIES.
 
 COUNTRIES continua exportado como a lista estática em pt-BR, para código que
 só precisa dos códigos de discagem (ex.: core/utils.py) e não da tradução.
 """
+
+from core.utils import normalize_for_search
 
 _LANG_ALIASES = {
     "pt-BR": "pt",
@@ -275,17 +287,142 @@ _COUNTRIES: list[tuple[str, str, dict[str, str]]] = [
 ]
 
 
+# ISO 3166-1 alpha-2 code for every entry in _COUNTRIES, keyed by the same
+# stable key — used only to match the Windows "Regional format" country
+# (core.locale_format.get_regional_country_iso2(), an ISO 3166 alpha-2 code
+# itself) back to one of our entries in get_default_country_index(). Kept as
+# a separate table rather than a 4th tuple field so the country data above
+# stays exactly as easy to scan/edit as it was before this existed.
+_KEY_TO_ISO2: dict[str, str] = {
+    "brazil": "BR",
+    "afghanistan": "AF", "south_africa": "ZA", "albania": "AL", "germany": "DE",
+    "andorra": "AD", "angola": "AO", "antigua_and_barbuda": "AG",
+    "saudi_arabia": "SA", "algeria": "DZ", "argentina": "AR", "armenia": "AM",
+    "aruba": "AW", "australia": "AU", "austria": "AT", "azerbaijan": "AZ",
+    "bahamas": "BS", "bangladesh": "BD", "barbados": "BB", "bahrain": "BH",
+    "belgium": "BE", "belize": "BZ", "benin": "BJ", "bolivia": "BO",
+    "bosnia_and_herzegovina": "BA", "botswana": "BW", "brunei": "BN",
+    "bulgaria": "BG", "burkina_faso": "BF", "burundi": "BI", "bhutan": "BT",
+    "cape_verde": "CV", "cambodia": "KH", "cameroon": "CM", "canada": "CA",
+    "qatar": "QA", "kazakhstan": "KZ", "chad": "TD", "chile": "CL",
+    "china": "CN", "cyprus": "CY", "colombia": "CO", "comoros": "KM",
+    "congo": "CG", "north_korea": "KP", "south_korea": "KR",
+    "ivory_coast": "CI", "costa_rica": "CR", "croatia": "HR", "cuba": "CU",
+    "curacao": "CW", "denmark": "DK", "djibouti": "DJ", "dominica": "DM",
+    "egypt": "EG", "el_salvador": "SV", "united_arab_emirates": "AE",
+    "ecuador": "EC", "eritrea": "ER", "slovakia": "SK", "slovenia": "SI",
+    "spain": "ES", "united_states": "US", "estonia": "EE", "eswatini": "SZ",
+    "ethiopia": "ET", "fiji": "FJ", "philippines": "PH", "finland": "FI",
+    "france": "FR", "gabon": "GA", "gambia": "GM", "ghana": "GH",
+    "georgia": "GE", "gibraltar": "GI", "greece": "GR", "grenada": "GD",
+    "guatemala": "GT", "guyana": "GY", "guinea": "GN",
+    "guinea_bissau": "GW", "equatorial_guinea": "GQ", "haiti": "HT",
+    "honduras": "HN", "hong_kong": "HK", "hungary": "HU", "yemen": "YE",
+    "cayman_islands": "KY", "cook_islands": "CK", "faroe_islands": "FO",
+    "marshall_islands": "MH", "solomon_islands": "SB",
+    "turks_and_caicos_islands": "TC", "british_virgin_islands": "VG",
+    "us_virgin_islands": "VI", "india": "IN", "indonesia": "ID",
+    "iran": "IR", "iraq": "IQ", "ireland": "IE", "iceland": "IS",
+    "israel": "IL", "italy": "IT", "jamaica": "JM", "japan": "JP",
+    "jordan": "JO", "kuwait": "KW", "kyrgyzstan": "KG", "laos": "LA",
+    "lesotho": "LS", "latvia": "LV", "lebanon": "LB", "liberia": "LR",
+    "libya": "LY", "liechtenstein": "LI", "lithuania": "LT",
+    "luxembourg": "LU", "macau": "MO", "madagascar": "MG", "malawi": "MW",
+    "malaysia": "MY", "maldives": "MV", "mali": "ML", "malta": "MT",
+    "morocco": "MA", "mauritania": "MR", "mauritius": "MU", "mexico": "MX",
+    "micronesia": "FM", "myanmar": "MM", "mozambique": "MZ",
+    "moldova": "MD", "monaco": "MC", "mongolia": "MN", "montenegro": "ME",
+    "namibia": "NA", "nauru": "NR", "nepal": "NP", "nicaragua": "NI",
+    "niger": "NE", "nigeria": "NG", "norway": "NO", "new_zealand": "NZ",
+    "oman": "OM", "pakistan": "PK", "palau": "PW", "panama": "PA",
+    "papua_new_guinea": "PG", "paraguay": "PY", "peru": "PE",
+    "poland": "PL", "portugal": "PT", "puerto_rico": "PR",
+    "united_kingdom": "GB", "central_african_republic": "CF",
+    "democratic_republic_congo": "CD", "dominican_republic": "DO",
+    "czech_republic": "CZ", "romania": "RO", "rwanda": "RW", "russia": "RU",
+    "samoa": "WS", "san_marino": "SM", "saint_lucia": "LC",
+    "saint_kitts_and_nevis": "KN", "sao_tome_and_principe": "ST",
+    "saint_vincent_grenadines": "VC", "senegal": "SN", "sierra_leone": "SL",
+    "serbia": "RS", "seychelles": "SC", "singapore": "SG", "syria": "SY",
+    "somalia": "SO", "sri_lanka": "LK", "sudan": "SD", "south_sudan": "SS",
+    "sweden": "SE", "switzerland": "CH", "suriname": "SR", "thailand": "TH",
+    "taiwan": "TW", "tanzania": "TZ", "timor_leste": "TL", "togo": "TG",
+    "trinidad_and_tobago": "TT", "tunisia": "TN", "turkmenistan": "TM",
+    "turkey": "TR", "tuvalu": "TV", "ukraine": "UA", "uganda": "UG",
+    "uruguay": "UY", "uzbekistan": "UZ", "vanuatu": "VU",
+    "venezuela": "VE", "vietnam": "VN", "zambia": "ZM", "zimbabwe": "ZW",
+}
+_ISO2_TO_KEY: dict[str, str] = {v: k for k, v in _KEY_TO_ISO2.items()}
+
+
+def _sort_key(name: str) -> str:
+    """Diacritic-insensitive, case-insensitive sort key so e.g. "Áustria"
+    sorts next to "Austrália" instead of after every plain ASCII letter.
+    Reuses core.utils.normalize_for_search()'s "nfkd" mode (lowercase,
+    NFKD-decompose, drop combining marks) rather than duplicating that
+    logic here."""
+    return normalize_for_search(name, mode="nfkd")
+
+
+def _localized_name(names: dict[str, str], lang_key: str) -> str:
+    return names.get(lang_key) or names["pt"]
+
+
 def get_countries(lang: str = "pt-BR") -> list[tuple[str, str]]:
-    """Return [(display_name, dial_code), ...] localized for *lang*, same
-    order as _COUNTRIES regardless of language — callers index into this
-    list by ComboBox position, so the order must stay stable across
-    languages. Falls back to Portuguese for any unrecognized lang code."""
+    """Return [(display_name, dial_code), ...] localized for *lang* and
+    sorted alphabetically (start to end, diacritics ignored) by that
+    localized name. Falls back to Portuguese for any unrecognized lang code.
+
+    The order is intentionally NOT stable across languages — display names
+    differ per language, so alphabetical order does too — and no entry is
+    pinned first. Callers must index back into the SAME list this returned,
+    never assume a fixed position for a given country."""
     key = _LANG_ALIASES.get(lang, "pt")
-    result = []
-    for _, code, names in _COUNTRIES:
-        name = names.get(key) or names["pt"]
-        result.append((f"{name} (+{code})", code))
-    return result
+    entries = [
+        (_localized_name(names, key), code) for _, code, names in _COUNTRIES
+    ]
+    entries.sort(key=lambda item: _sort_key(item[0]))
+    return [(f"{name} (+{code})", code) for name, code in entries]
+
+
+def get_default_country_index(countries: list[tuple[str, str]], lang: str = "pt-BR") -> int:
+    """Index into *countries* (as returned by get_countries(lang)) of the
+    country matching the user's Windows "Country or region" setting, or of
+    the United States if that can't be detected or isn't one of our
+    entries. Falls back to index 0 if even the United States entry can't be
+    found (should not happen — it's always present in _COUNTRIES).
+
+    Deliberately based on Country or region (a location, independent of any
+    language setting) rather than the UI/display language or the "Regional
+    format" locale — see core.locale_format.get_country_or_region_iso2()'s
+    own docstring for why those would give the wrong answer here."""
+    # Imported here, not at module load, so this module (and get_countries())
+    # stays importable/testable without pulling in ctypes/Windows-only code.
+    from core.locale_format import get_country_or_region_iso2
+
+    iso2 = (get_country_or_region_iso2() or "").upper()
+    stable_key = _ISO2_TO_KEY.get(iso2, "united_states")
+    lang_key = _LANG_ALIASES.get(lang, "pt")
+
+    target = None
+    for key, code, names in _COUNTRIES:
+        if key == stable_key:
+            target = (f"{_localized_name(names, lang_key)} (+{code})", code)
+            break
+    if target is None or target not in countries:
+        # Detected country isn't one of ours (or detection failed) — fall
+        # back to the United States entry.
+        for key, code, names in _COUNTRIES:
+            if key == "united_states":
+                target = (f"{_localized_name(names, lang_key)} (+{code})", code)
+                break
+
+    if target is not None:
+        try:
+            return countries.index(target)
+        except ValueError:
+            pass
+    return 0
 
 
 # Backward-compat: static pt-BR list for code that only needs the dial codes

--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -3,7 +3,7 @@
     "connect_phone": "Connect to {app_name}",
     "enter_phone": "&Enter your phone number",
     "country_label": "Select a country:",
-    "invalid_char": "Invalid character",
+    "connect_dialog_cancel": "Cance&l",
     "continue": "&Continue",
     "connection_error": "Connection error",
     "connection_failed": "Could not connect to {app_name}. The error message displayed was:",

--- a/client/languages/es-ES.json
+++ b/client/languages/es-ES.json
@@ -3,7 +3,7 @@
     "connect_phone": "Conectar a {app_name}",
     "enter_phone": "&Introduce tu número de teléfono",
     "country_label": "Seleccionar un país:",
-    "invalid_char": "Carácter no válido",
+    "connect_dialog_cancel": "Ca&ncelar",
     "continue": "&Continuar",
     "connection_error": "Error de conexión",
     "connection_failed": "No se pudo conectar a {app_name}. El mensaje de error mostrado fue:",

--- a/client/languages/pl.json
+++ b/client/languages/pl.json
@@ -3,7 +3,7 @@
     "connect_phone": "Połącz z {app_name}",
     "enter_phone": "&Wpisz swój numer telefonu",
     "country_label": "Wybierz kraj:",
-    "invalid_char": "Nieprawidłowy znak",
+    "connect_dialog_cancel": "&Anuluj",
     "continue": "&Kontynuuj",
     "connection_error": "Błąd połączenia",
     "connection_failed": "Nie udało się połączyć z {app_name}. Wyświetlony komunikat błędu:",

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -3,7 +3,7 @@
     "connect_phone": "Conectar ao {app_name}",
     "enter_phone": "&Digite seu número de telefone",
     "country_label": "Selecionar um país:",
-    "invalid_char": "Caractere inválido",
+    "connect_dialog_cancel": "Ca&ncelar",
     "continue": "&Continuar",
     "connection_error": "Erro de conexão",
     "connection_failed": "Não foi possível conectar ao {app_name}. A mensagem de erro exibida foi:",

--- a/client/languages/pt-PT.json
+++ b/client/languages/pt-PT.json
@@ -3,7 +3,7 @@
     "connect_phone": "Ligar ao {app_name}",
     "enter_phone": "&Introduza o seu número de telefone",
     "country_label": "Selecione um país:",
-    "invalid_char": "Carácter inválido",
+    "connect_dialog_cancel": "Ca&ncelar",
     "continue": "&Continuar",
     "connection_error": "Erro de ligação",
     "connection_failed": "Não foi possível estabelecer ligação com o {app_name}. A mensagem de erro apresentada foi:",

--- a/client/ui/dialogs/connect.py
+++ b/client/ui/dialogs/connect.py
@@ -14,8 +14,50 @@ from traceback import format_exc
 import json
 import base64
 from io import BytesIO
-from countries import get_countries
+from countries import get_countries, get_default_country_index
+from core.combo_search import bind_incremental_search
 import logging
+
+
+def _resolve_protected_edit(
+    prefix_len: int,
+    insertion_point: int,
+    sel_from: int,
+    sel_to: int,
+    deleting_backward: bool = False,
+):
+    """Decide how a pending edit (typed character, forward Delete,
+    Backspace, Cut or Paste) at the given caret/selection should be allowed
+    to proceed without ever modifying the first *prefix_len* characters of
+    the phone field — the immutable "+<country code>" the user can only
+    change via the country ComboBox (see Connect.on_country_changed).
+
+    Returns:
+      - None: the edit must be swallowed entirely (a no-op) — either a
+        caret-only edit (no selection) that would touch the prefix, or a
+        selection that lies entirely inside it.
+      - (start, end): the selection the edit should actually act on. Equal
+        to (sel_from, sel_to) when the edit doesn't touch the prefix at all
+        (nothing to change). Clamped to start at prefix_len when the
+        original selection starts inside the prefix but extends past it —
+        e.g. Ctrl+A then Delete/Backspace/Paste/typing must clear the local
+        number while leaving the country code untouched, rather than being
+        blocked outright.
+
+    A pure function of primitives (no wx dependency) so it can be unit
+    tested without a running wx.App.
+    """
+    if sel_from != sel_to:
+        if sel_from >= prefix_len:
+            return (sel_from, sel_to)          # entirely past the prefix
+        if sel_to <= prefix_len:
+            return None                          # entirely inside the prefix
+        return (prefix_len, sel_to)              # spans the boundary: clamp
+    # No selection: a single-position caret edit.
+    target = (insertion_point - 1) if deleting_backward else insertion_point
+    if target < prefix_len:
+        return None
+    return (insertion_point, insertion_point)
 
 
 # Events forwarded to the WinZapp client via Socket.IO
@@ -441,8 +483,22 @@ class Connect:
             style=wx.CB_READONLY,
             choices=[c[0] for c in self._countries],
         )
-        self.country_combo.SetSelection(0)   # Brazil
-        self.country_combo.Bind(wx.EVT_COMBOBOX, self.on_country_changed)
+        # Default to the country from the user's Windows "Country or
+        # region" setting — a location, independent of the UI/display
+        # language and the separate "Regional format" locale — falling back
+        # to the United States if that can't be detected or isn't one of
+        # our entries. Never an arbitrary fixed country, and never whatever
+        # happened to sort first.
+        default_idx = get_default_country_index(self._countries, self.i18n.language)
+        self.country_combo.SetSelection(default_idx)
+        self._current_dial_code = self._countries[default_idx][1]
+        # Routed through bind_incremental_search()'s on_select rather than
+        # a direct Bind(wx.EVT_COMBOBOX, ...) — see that function's own
+        # docstring: wx calls every handler bound to the same event on the
+        # same control regardless of Skip(), so a separately-bound handler
+        # here would react to the search's momentarily-wrong native jump
+        # before it gets corrected on a multi-character search.
+        bind_incremental_search(self.country_combo, on_select=self.on_country_changed)
 
         # ── Phone number field ────────────────────────────────────────────
         self.phone_number_label = wx.StaticText(
@@ -456,6 +512,8 @@ class Connect:
         self.phone_field.Bind(wx.EVT_CHAR,       self.on_phone_char)
         self.phone_field.Bind(wx.EVT_TEXT,       self.on_phone_text_changed)
         self.phone_field.Bind(wx.EVT_TEXT_ENTER, self.on_continue)
+        self.phone_field.Bind(wx.EVT_TEXT_PASTE, self.on_phone_paste)
+        self.phone_field.Bind(wx.EVT_TEXT_CUT,   self.on_phone_cut)
         self.phone_field.SetInsertionPointEnd()
 
         self.continue_btn = wx.Button(self.phone_panel, label=self.i18n.t("continue"))
@@ -475,7 +533,9 @@ class Connect:
         self.phone_panel.SetSizer(phone_sizer)
 
         # Quit button
-        self.quit_btn = wx.Button(self.connection_dial, wx.ID_CANCEL, "&Sair")
+        self.quit_btn = wx.Button(
+            self.connection_dial, wx.ID_CANCEL, self.i18n.t("connect_dialog_cancel")
+        )
         self.quit_btn.Bind(wx.EVT_BUTTON, self.on_quit_from_connect)
 
         # Bind close event
@@ -1166,19 +1226,53 @@ class Connect:
         finally:
             self._phone_updating = False
 
+    def _protected_prefix_len(self) -> int:
+        """Length, in characters, of the immutable "+<country code>" at the
+        start of the phone field — see _resolve_protected_edit()."""
+        return len(f"+{self._current_dial_code}")
+
+    def _resolve_edit_selection(self, deleting_backward: bool = False):
+        """_resolve_protected_edit() applied to the phone field's actual
+        current caret/selection state. See that function's own docstring
+        for the return value."""
+        prefix_len = self._protected_prefix_len()
+        insertion_point = self.phone_field.GetInsertionPoint()
+        sel_from, sel_to = self.phone_field.GetSelection()
+        return _resolve_protected_edit(
+            prefix_len, insertion_point, sel_from, sel_to, deleting_backward
+        )
+
+    def _apply_protected_edit(self, resolved, event) -> None:
+        """Act on a _resolve_edit_selection() result: swallow the event if
+        the edit was entirely inside the protected prefix, clamp the
+        control's selection first if it spanned the boundary (e.g. Ctrl+A
+        then Delete clears the local number but leaves the country code
+        alone), then let the underlying operation (Skip()) proceed."""
+        if resolved is None:
+            return  # no-op: swallow, do not Skip()
+        sel_from, sel_to = self.phone_field.GetSelection()
+        if resolved != (sel_from, sel_to):
+            self.phone_field.SetSelection(*resolved)
+        event.Skip()
+
     def on_phone_char(self, event):
         """
         Filter individual keystrokes in the phone field.
 
-        Digits (0-9 and numpad), navigation keys and Ctrl+key combinations
-        pass through.  Everything else (letters, punctuation, @, _, …) is
-        consumed and the screen reader announces "Caractere inválido".
+        Digits (0-9 and numpad) and navigation/Ctrl+key combinations pass
+        through. Anything else (letters, punctuation, @, _, …) is silently
+        consumed.
+
+        Backspace, Delete and typed digits additionally never modify the
+        "+<country code>" prefix, which the user can only change via the
+        country ComboBox — see _resolve_protected_edit(). A selection that
+        spans across the prefix boundary (e.g. Ctrl+A then Delete/typing)
+        is clamped so only the local number is affected.
         """
         key = event.GetKeyCode()
 
-        # Navigation / editing keys always pass through
+        # Navigation keys that never modify text always pass through
         _NAV = {
-            wx.WXK_BACK, wx.WXK_DELETE,
             wx.WXK_LEFT, wx.WXK_RIGHT, wx.WXK_HOME, wx.WXK_END,
             wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER,
             wx.WXK_TAB, wx.WXK_ESCAPE,
@@ -1188,7 +1282,8 @@ class Connect:
             return
 
         # Any Ctrl+key or Alt+key combo (clipboard shortcuts, select-all,
-        # Alt+F4, system accelerators, …) always pass through
+        # Alt+F4, system accelerators, …) always pass through — Ctrl+V/Ctrl+X
+        # are guarded separately by on_phone_paste()/on_phone_cut().
         if event.ControlDown() or event.AltDown() or event.CmdDown():
             event.Skip()
             return
@@ -1199,43 +1294,41 @@ class Connect:
             event.Skip()
             return
 
-        # Main keyboard digits
-        if ord("0") <= key <= ord("9"):
-            event.Skip()
+        is_backspace = key == wx.WXK_BACK
+        is_delete    = key == wx.WXK_DELETE
+        is_digit     = (ord("0") <= key <= ord("9")) or (wx.WXK_NUMPAD0 <= key <= wx.WXK_NUMPAD9)
+
+        if is_backspace or is_delete or is_digit:
+            resolved = self._resolve_edit_selection(deleting_backward=is_backspace)
+            self._apply_protected_edit(resolved, event)
             return
 
-        # Numpad digits
-        if wx.WXK_NUMPAD0 <= key <= wx.WXK_NUMPAD9:
-            event.Skip()
-            return
+        # Anything else → silently consumed (do NOT call event.Skip())
 
-        # Anything else → reject and announce
-        self.main_window.speak_output.output(
-            self.main_window.i18n.t("invalid_char")
-        )
-        # Do NOT call event.Skip() — the character is swallowed
+    def on_phone_paste(self, event):
+        """Clamp a paste (Ctrl+V / context menu) to never overwrite the
+        immutable country-code prefix — see _resolve_protected_edit()."""
+        resolved = self._resolve_edit_selection()
+        self._apply_protected_edit(resolved, event)
+
+    def on_phone_cut(self, event):
+        """Clamp a Cut (Ctrl+X / context menu) to never remove the
+        immutable country-code prefix — see _resolve_protected_edit()."""
+        resolved = self._resolve_edit_selection()
+        self._apply_protected_edit(resolved, event)
 
     def on_phone_text_changed(self, event):
         """
         Reformat the phone field after every text change (including paste).
 
-        If the new text contains characters that are not digits and not our
-        formatting symbols (+, -, space), the screen reader announces
-        "Caractere inválido" and those characters are silently stripped.
+        Characters that are not digits and not our formatting symbols
+        (+, -, space) are silently stripped.
         """
         if self._phone_updating:
             return
         self._phone_updating = True
         try:
             text = self.phone_field.GetValue()
-
-            # Detect truly invalid chars coming from paste
-            _fmt = set("+- ")
-            if any(c not in _fmt and not c.isdigit() for c in text):
-                self.main_window.speak_output.output(
-                    self.main_window.i18n.t("invalid_char")
-                )
-
             digits    = "".join(c for c in text if c.isdigit())
             formatted = self._format_phone_display(digits)
             if formatted != text:

--- a/client/ui/dialogs/language_dialog.py
+++ b/client/ui/dialogs/language_dialog.py
@@ -4,18 +4,25 @@ WinZapp – Language Selection Dialog
 Shown on first launch, before any API module installation or initial setup.
 The user picks a language and clicks OK to proceed, or Cancel to exit.
 
-This dialog intentionally avoids using the I18n / settings infrastructure
-(which may not be initialised yet) and hard-codes its own UI labels
-(title, OK/Cancel) as a minimal bootstrap interface. The list of languages
-itself, however, is read from languages/language_map.json — the same file
+This dialog runs before core.i18n.I18n exists — there is no saved language
+in settings yet for it to read — so it can't call I18n.t(). Its own UI
+strings (title, prompt, OK/Cancel) are instead read straight out of the
+matching languages/<code>.json file for whichever language
+_detect_system_language() below resolves to (the user's Windows display
+language if it's one of ours, else English), rather than being hardcoded in
+one fixed language regardless of the machine's actual settings. The list of
+languages itself is read from language_map.json — the same file
 core/i18n.py's LANGUAGE_NAMES loads from — so a new locale dropped in there
-shows up here too without a rebuild.
+shows up here too without a rebuild, and is sorted alphabetically (no
+language pinned first) the same way client/countries.py sorts its own list.
 """
 
 import json
 import wx
 
 from app_paths import resource_path
+from core.utils import normalize_for_search
+from core.combo_search import bind_incremental_search
 
 # Fallback used only if languages/language_map.json is missing or unreadable.
 _FALLBACK_LANGUAGE_CHOICES = [
@@ -23,21 +30,84 @@ _FALLBACK_LANGUAGE_CHOICES = [
     ("English (United States)", "en-US"),
 ]
 
+# The handful of keys this dialog needs. Used both to validate a loaded
+# languages/<code>.json has all of them, and as the last-resort fallback if
+# even languages/en-US.json can't be read (should never happen in practice).
+_BOOTSTRAP_KEYS = ("language_select_title", "language_select_prompt", "ok", "cancel")
+_HARDCODED_BOOTSTRAP_STRINGS = {
+    "language_select_title":  "Select a language | WinZapp",
+    "language_select_prompt": "Select a language",
+    "ok":                     "&OK",
+    "cancel":                 "&Cancel",
+}
+
 
 def _load_language_choices():
-    """Return [(display_name, lang_code), ...] from language_map.json."""
+    """Return [(display_name, lang_code), ...] from language_map.json,
+    sorted alphabetically (diacritics ignored) by display name — no
+    language pinned first, same sort as client/countries.py's country
+    list."""
     try:
         with open(resource_path("languages", "language_map.json"), "r", encoding="utf-8") as f:
             data = json.load(f)
-        if isinstance(data, dict) and data:
-            return [(name, code) for code, name in data.items()]
+        choices = [(name, code) for code, name in data.items()] if isinstance(data, dict) and data else None
     except Exception:
-        pass
-    return list(_FALLBACK_LANGUAGE_CHOICES)
+        choices = None
+    if not choices:
+        choices = list(_FALLBACK_LANGUAGE_CHOICES)
+    choices.sort(key=lambda item: normalize_for_search(item[0], mode="nfkd"))
+    return choices
 
 
-# Maps human-readable name → language code (same order as LANGUAGE_NAMES in core/i18n.py)
+# Maps human-readable name → language code, alphabetically sorted.
 _LANGUAGE_CHOICES = _load_language_choices()
+
+
+def _load_bootstrap_strings(lang_code: str) -> dict:
+    """Read this dialog's own UI strings straight out of
+    languages/<lang_code>.json, bypassing core.i18n.I18n (which reads the
+    active language from settings — not written yet on a first run). Falls
+    back to languages/en-US.json, then to a hardcoded copy of the same
+    English strings, if even that can't be read."""
+    for code in (lang_code, "en-US"):
+        try:
+            with open(resource_path("languages", f"{code}.json"), "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if all(key in data for key in _BOOTSTRAP_KEYS):
+                return data
+        except Exception:
+            continue
+    return _HARDCODED_BOOTSTRAP_STRINGS
+
+
+def _detect_system_language(available_codes, fallback: str = "en-US") -> str:
+    """Best-effort match between the Windows UI/display language and one of
+    *available_codes*: an exact match (system "pt-BR" -> our "pt-BR") first,
+    then a same-language match ignoring region (system "pt-AO" -> our
+    "pt-BR", the first matching entry in *available_codes*' own order), else
+    *fallback*.
+
+    Deliberately based on core.locale_format.get_system_ui_language() — the
+    actual Windows display-language setting — and nothing else. This is the
+    one place in the app where the display language IS the right signal;
+    contrast client/countries.py's get_default_country_index(), which must
+    NOT use it (see that function's own docstring for why a display
+    language and a physical location are independent Windows settings that
+    can disagree)."""
+    try:
+        from core.locale_format import get_system_ui_language
+        detected = get_system_ui_language()
+    except Exception:
+        detected = None
+    if not detected:
+        return fallback
+    if detected in available_codes:
+        return detected
+    prefix = detected.split("-")[0].lower()
+    for code in available_codes:
+        if code.split("-")[0].lower() == prefix:
+            return code
+    return fallback
 
 
 class LanguageSelectionDialog(wx.Dialog):
@@ -52,26 +122,29 @@ class LanguageSelectionDialog(wx.Dialog):
     """
 
     def __init__(self, parent=None):
+        self._lang_codes = [code for _, code in _LANGUAGE_CHOICES]
+        default_code = _detect_system_language(self._lang_codes, fallback="en-US")
+        strings = _load_bootstrap_strings(default_code)
+
         super().__init__(
             parent,
-            title="Selecionar um idioma | WinZapp",
+            title=strings["language_select_title"],
             style=wx.DEFAULT_DIALOG_STYLE,
         )
-        self.selected_language: str = "pt-BR"
-        self._lang_codes = [code for _, code in _LANGUAGE_CHOICES]
+        self.selected_language: str = default_code
 
-        self._build_ui()
+        self._build_ui(strings, default_code)
         self.Fit()
         self.SetMinSize((360, -1))
         self.Centre()
 
     # ── UI ────────────────────────────────────────────────────────────────────
 
-    def _build_ui(self):
+    def _build_ui(self, strings, default_code):
         panel = wx.Panel(self)
         sizer = wx.BoxSizer(wx.VERTICAL)
 
-        lbl = wx.StaticText(panel, label="Selecionar um idioma")
+        lbl = wx.StaticText(panel, label=strings["language_select_prompt"])
         sizer.Add(lbl, 0, wx.LEFT | wx.TOP | wx.RIGHT, 12)
 
         self._combo = wx.ComboBox(
@@ -79,12 +152,16 @@ class LanguageSelectionDialog(wx.Dialog):
             style=wx.CB_READONLY,
             choices=[name for name, _ in _LANGUAGE_CHOICES],
         )
-        self._combo.SetSelection(0)
+        default_idx = (
+            self._lang_codes.index(default_code) if default_code in self._lang_codes else 0
+        )
+        self._combo.SetSelection(default_idx)
+        bind_incremental_search(self._combo)
         sizer.Add(self._combo, 0, wx.EXPAND | wx.ALL, 8)
 
         btn_sizer = wx.StdDialogButtonSizer()
-        ok_btn     = wx.Button(panel, wx.ID_OK,     label="OK")
-        cancel_btn = wx.Button(panel, wx.ID_CANCEL, label="Cancelar")
+        ok_btn     = wx.Button(panel, wx.ID_OK,     label=strings["ok"])
+        cancel_btn = wx.Button(panel, wx.ID_CANCEL, label=strings["cancel"])
         ok_btn.Bind(wx.EVT_BUTTON, self._on_ok)
         cancel_btn.Bind(wx.EVT_BUTTON, self._on_cancel)
         btn_sizer.AddButton(ok_btn)

--- a/client/ui/dialogs/settings_dialog.py
+++ b/client/ui/dialogs/settings_dialog.py
@@ -2,6 +2,7 @@ import ctypes
 import os
 import wx
 from core.i18n import LANGUAGE_NAMES
+from core.combo_search import bind_incremental_search
 from core.sound_system import (
     SOUND_EVENTS, discover_alert_tone_choices, resolve_alert_tone_path,
     DEFAULT_PACK_ID, import_soundpack, AlertPreviewController,
@@ -218,6 +219,13 @@ class SettingsDialog(wx.Dialog):
             style=wx.CB_READONLY,
             choices=list(LANGUAGE_NAMES.values()),
         )
+        # Same multi-character type-ahead as the pairing dialog's country
+        # combo and the first-run language picker — see
+        # core.combo_search.bind_incremental_search()'s own docstring for
+        # why a read-only wx.ComboBox needs this reimplemented by hand at
+        # all. No on_select needed: nothing reacts live to this combo, its
+        # selection is only read at Save/Apply time (_on_apply()).
+        bind_incremental_search(self._lang_combo)
         gen_sizer.Add(self._lang_combo, 0, wx.EXPAND | wx.ALL, 8)
 
         self._notifications_check = wx.CheckBox(

--- a/tests/test_combo_search.py
+++ b/tests/test_combo_search.py
@@ -1,0 +1,189 @@
+"""Tests for core.combo_search.
+
+Regression coverage: wx.ComboBox(style=wx.CB_READONLY) jumps to an item on
+a single keystroke natively, but a second letter typed shortly after the
+first used to restart the search from scratch instead of narrowing it —
+pressing "B" then "A" quickly in a list containing "Blindography" and
+"Bane" landed on the first entry starting with "A" (e.g. "Ana"), not on
+"Bane". Reported live (twice): first against the pairing dialog's country
+selector, then again after an initial fix attempt that tried to prevent the
+native jump from happening at all — TestBindIncrementalSearch below covers
+the actual bug in THAT attempt (confirmed live: wx invokes every handler
+bound to the same wx.EVT_COMBOBOX on the same control regardless of
+Skip(), and wx.ComboBox.SetSelection() does not itself fire
+wx.EVT_COMBOBOX — see combo_search.py's module docstring for the
+"let the native jump happen, then correct it" design this led to).
+
+find_incremental_match() is the "does this buffer match anything" half,
+next_search_buffer() is the "should this keystroke extend the buffer or
+start over" half. TestBindIncrementalSearch drives the real wx wiring with
+synthetic events (needs a real wx.ComboBox — see the wx_app fixture) to
+pin the actual reported bug, not just the two pure halves in isolation.
+"""
+
+import wx
+
+from core.combo_search import (
+    bind_incremental_search,
+    find_incremental_match,
+    next_search_buffer,
+    SEARCH_TIMEOUT_SECONDS,
+)
+
+
+class TestFindIncrementalMatch:
+    CHOICES = ["Bahamas", "Bolivia", "Botswana", "Croatia", "Oman"]
+
+    def test_matches_by_prefix(self):
+        assert find_incremental_match(self.CHOICES, "Bo") == 1  # "Bolivia"
+
+    def test_case_insensitive(self):
+        assert find_incremental_match(self.CHOICES, "bo") == 1
+        assert find_incremental_match(self.CHOICES, "BO") == 1
+
+    def test_single_letter_matches_first_entry_with_that_letter(self):
+        assert find_incremental_match(self.CHOICES, "B") == 0  # "Bahamas"
+        assert find_incremental_match(self.CHOICES, "O") == 4  # "Oman"
+
+    def test_diacritics_are_ignored(self):
+        choices = ["Áustria", "Austrália"]
+        assert find_incremental_match(choices, "au") == 0  # "Áustria" folds to "austria"
+
+    def test_no_match_returns_none(self):
+        assert find_incremental_match(self.CHOICES, "Zz") is None
+
+    def test_empty_prefix_returns_none(self):
+        assert find_incremental_match(self.CHOICES, "") is None
+
+    def test_empty_choices_returns_none(self):
+        assert find_incremental_match([], "B") is None
+
+
+class TestNextSearchBuffer:
+    def test_within_timeout_extends_the_buffer(self):
+        assert next_search_buffer("B", "o", elapsed=0.3) == "Bo"
+
+    def test_at_exactly_the_timeout_still_extends(self):
+        assert next_search_buffer("B", "o", elapsed=SEARCH_TIMEOUT_SECONDS) == "Bo"
+
+    def test_past_the_timeout_starts_over(self):
+        assert next_search_buffer("B", "o", elapsed=SEARCH_TIMEOUT_SECONDS + 0.01) == "o"
+
+    def test_first_keystroke_ever_with_huge_elapsed_starts_fresh(self):
+        assert next_search_buffer("", "b", elapsed=1e6) == "b"
+
+    def test_custom_timeout_is_honored(self):
+        assert next_search_buffer("B", "o", elapsed=2.0, timeout=3.0) == "Bo"
+        assert next_search_buffer("B", "o", elapsed=2.0, timeout=1.0) == "o"
+
+
+class TestBAndOScenarioEndToEnd:
+    """The exact scenario reported: type "B" then "O" quickly."""
+
+    def test_b_then_o_lands_on_first_bo_entry_not_first_o_entry(self):
+        choices = ["Bahamas", "Bolivia", "Botswana", "Croatia", "Oman"]
+        buffer = next_search_buffer("", "B", elapsed=1e6)
+        idx = find_incremental_match(choices, buffer)
+        assert choices[idx] == "Bahamas"  # first keystroke: native single-letter jump
+
+        buffer = next_search_buffer(buffer, "o", elapsed=0.2)
+        idx = find_incremental_match(choices, buffer)
+        assert choices[idx] == "Bolivia"  # accumulated "Bo": narrows, doesn't restart
+
+
+class TestBindIncrementalSearch:
+    """Drives the real wx.EVT_CHAR / wx.EVT_COMBOBOX wiring with synthetic
+    events against a real wx.ComboBox, simulating what the native control's
+    own (buggy, single-character-only) type-ahead does on each keystroke —
+    a fresh single-letter jump, ignoring anything typed before it — the
+    same way the real Win32 control does. bind_incremental_search() must
+    correct that native result using the accumulated buffer."""
+
+    CHOICES = ["Croatia", "Blindography", "Ana", "Bane", "Bojan"]
+
+    def _make_combo(self, wx_app):
+        frame = wx.Frame(None)
+        combo = wx.ComboBox(frame, style=wx.CB_READONLY, choices=self.CHOICES)
+        return frame, combo
+
+    def _type_char(self, combo, char):
+        """A keystroke landing on *combo*: fires EVT_CHAR (as the real
+        control would), then simulates the native control's own
+        single-character-only jump by selecting the first entry starting
+        with just *char* and firing EVT_COMBOBOX — exactly what the real
+        native jump does, right or wrong, on real Windows."""
+        char_event = wx.KeyEvent(wx.EVT_CHAR.typeId)
+        char_event.SetEventObject(combo)
+        char_event.SetUnicodeKey(ord(char))
+        combo.GetEventHandler().ProcessEvent(char_event)
+
+        naive_idx = find_incremental_match(self.CHOICES, char)
+        if naive_idx is not None:
+            combo.SetSelection(naive_idx)
+            combo_event = wx.CommandEvent(wx.EVT_COMBOBOX.typeId, combo.GetId())
+            combo_event.SetEventObject(combo)
+            combo_event.SetInt(naive_idx)
+            combo.GetEventHandler().ProcessEvent(combo_event)
+
+    def test_b_then_a_lands_on_bane_not_on_the_native_single_char_jump_to_ana(self, wx_app):
+        frame, combo = self._make_combo(wx_app)
+        try:
+            notifications = []
+            bind_incremental_search(combo, on_select=lambda idx: notifications.append(idx))
+
+            self._type_char(combo, "B")
+            assert combo.GetString(combo.GetSelection()) == "Blindography"
+
+            self._type_char(combo, "A")
+            # Native's own naive jump alone would have landed on "Ana" (the
+            # first entry starting with just "A") — this is the exact bug
+            # reported. The correction must override it to "Bane" ("Ba…").
+            assert combo.GetString(combo.GetSelection()) == "Bane"
+            assert notifications == [1, 3]  # Blindography, then corrected to Bane
+        finally:
+            frame.Destroy()
+
+    def test_on_select_is_not_called_twice_for_one_corrected_keystroke(self, wx_app):
+        """Regression for the first fix attempt: binding wx.EVT_COMBOBOX
+        directly (in addition to this function's own internal binding)
+        made a caller's handler see the wrong, uncorrected native jump
+        first — wx calls every handler bound to the same event on the same
+        control, regardless of Skip(). on_select must be the only channel,
+        and must fire exactly once per settled (corrected) keystroke."""
+        frame, combo = self._make_combo(wx_app)
+        try:
+            call_count = {"n": 0}
+            bind_incremental_search(combo, on_select=lambda idx: call_count.update(n=call_count["n"] + 1))
+
+            self._type_char(combo, "B")
+            self._type_char(combo, "A")
+
+            assert call_count["n"] == 2  # one per keystroke, not one per internal correction
+        finally:
+            frame.Destroy()
+
+    def test_mouse_or_arrow_driven_selection_is_relayed_unmodified(self, wx_app):
+        """A selection change with no preceding keystroke (mouse click,
+        arrow key) must be passed through as-is, never "corrected" using a
+        stale search buffer from an earlier, unrelated keystroke."""
+        frame, combo = self._make_combo(wx_app)
+        try:
+            notifications = []
+            bind_incremental_search(combo, on_select=lambda idx: notifications.append(idx))
+
+            self._type_char(combo, "B")
+            self._type_char(combo, "A")  # leaves a "BA" buffer behind
+            notifications.clear()
+
+            # Simulate a plain mouse click on "Croatia" (index 0) — no
+            # EVT_CHAR precedes this wx.EVT_COMBOBOX.
+            combo.SetSelection(0)
+            combo_event = wx.CommandEvent(wx.EVT_COMBOBOX.typeId, combo.GetId())
+            combo_event.SetEventObject(combo)
+            combo_event.SetInt(0)
+            combo.GetEventHandler().ProcessEvent(combo_event)
+
+            assert combo.GetString(combo.GetSelection()) == "Croatia"
+            assert notifications == [0]
+        finally:
+            frame.Destroy()

--- a/tests/test_countries.py
+++ b/tests/test_countries.py
@@ -1,0 +1,83 @@
+"""Tests for countries.get_countries() / get_default_country_index().
+
+Regression coverage for the pairing dialog's country selector: it used to
+hardcode Brazil as item 0 in every language and always pre-select it
+(client/ui/dialogs/connect.py), regardless of the user's actual Windows
+region or the alphabetical position of "Brazil" in the active UI language.
+get_countries() now sorts alphabetically (diacritics ignored) by the
+localized name with no country pinned first, and get_default_country_index()
+picks the entry matching the user's Windows "Country or region" setting
+(core.locale_format.get_country_or_region_iso2() — deliberately NOT the UI
+language or the separate "Regional format" locale, which can disagree with
+it entirely), falling back to the United States when that can't be detected
+or isn't one of our entries.
+"""
+
+import core.locale_format as locale_format
+from countries import get_countries, get_default_country_index, COUNTRIES, _sort_key
+
+
+class TestGetCountriesOrdering:
+    def test_sorted_alphabetically_by_localized_name(self):
+        countries = get_countries("en-US")
+        names = [name for name, _ in countries]
+        assert names == sorted(names, key=_sort_key)
+
+    def test_no_country_is_pinned_first(self):
+        # Brazil used to always be index 0 regardless of language/sorting.
+        countries_en = get_countries("en-US")
+        countries_pt = get_countries("pt-BR")
+        assert countries_en[0][0] != "Brazil (+55)"
+        assert countries_pt[0][0] != "Brasil (+55)"
+
+    def test_accented_names_sort_next_to_their_base_letter(self):
+        # "Áustria" (accented) must land near "Austrália", not after every
+        # plain-ASCII entry (naive ordinal comparison puts accented
+        # characters after 'z').
+        countries = get_countries("pt-BR")
+        names = [name for name, _ in countries]
+        austria_idx = next(i for i, n in enumerate(names) if n.startswith("Áustria"))
+        assert austria_idx < len(names) // 2
+
+    def test_same_entries_across_languages_different_order(self):
+        countries_en = {code for _, code in get_countries("en-US")}
+        countries_pt = {code for _, code in get_countries("pt-BR")}
+        assert countries_en == countries_pt
+
+    def test_backward_compat_countries_constant_still_exported(self):
+        assert ("Brasil (+55)", "55") in COUNTRIES
+
+
+class TestGetDefaultCountryIndex:
+    def _patch_region(self, monkeypatch, iso2):
+        monkeypatch.setattr(locale_format, "get_country_or_region_iso2", lambda: iso2)
+
+    def test_matches_detected_windows_region(self, monkeypatch):
+        self._patch_region(monkeypatch, "HR")
+        countries = get_countries("en-US")
+        idx = get_default_country_index(countries, "en-US")
+        assert countries[idx] == ("Croatia (+385)", "385")
+
+    def test_falls_back_to_united_states_when_detection_fails(self, monkeypatch):
+        self._patch_region(monkeypatch, None)
+        countries = get_countries("en-US")
+        idx = get_default_country_index(countries, "en-US")
+        assert countries[idx] == ("United States (+1)", "1")
+
+    def test_falls_back_to_united_states_for_unrecognized_region(self, monkeypatch):
+        self._patch_region(monkeypatch, "ZZ")
+        countries = get_countries("en-US")
+        idx = get_default_country_index(countries, "en-US")
+        assert countries[idx] == ("United States (+1)", "1")
+
+    def test_is_case_insensitive_on_the_detected_code(self, monkeypatch):
+        self._patch_region(monkeypatch, "hr")
+        countries = get_countries("en-US")
+        idx = get_default_country_index(countries, "en-US")
+        assert countries[idx] == ("Croatia (+385)", "385")
+
+    def test_index_is_valid_for_the_localized_list_passed_in(self, monkeypatch):
+        self._patch_region(monkeypatch, "BR")
+        countries = get_countries("pt-BR")
+        idx = get_default_country_index(countries, "pt-BR")
+        assert countries[idx] == ("Brasil (+55)", "55")

--- a/tests/test_language_dialog.py
+++ b/tests/test_language_dialog.py
@@ -1,0 +1,89 @@
+"""Tests for ui.dialogs.language_dialog's pure helper functions.
+
+Regression coverage for the first-run language picker
+(client/ui/dialogs/language_dialog.py): its title, prompt and OK/Cancel
+button labels used to be hardcoded in Portuguese regardless of the actual
+machine, and the language list itself was shown in language_map.json's raw
+dict order (pt-BR, pt-PT, en-US, es-ES, pl) with pt-BR always pre-selected —
+none of that had anything to do with the user's actual Windows settings.
+
+_load_bootstrap_strings() now sources this dialog's own UI text from the
+matching languages/<code>.json file (the same files core.i18n.I18n reads),
+_detect_system_language() picks that code from the real Windows UI/display
+language (falling back to English when it isn't one of ours or can't be
+detected), and _load_language_choices() sorts the picker's own list
+alphabetically with no language pinned first.
+"""
+
+import ui.dialogs.language_dialog as language_dialog
+import core.locale_format as locale_format
+from ui.dialogs.language_dialog import (
+    _detect_system_language,
+    _load_bootstrap_strings,
+    _load_language_choices,
+    _BOOTSTRAP_KEYS,
+)
+
+
+class TestLoadLanguageChoices:
+    def test_sorted_alphabetically_with_no_language_pinned_first(self):
+        choices = _load_language_choices()
+        names = [name for name, _ in choices]
+        assert names == sorted(
+            names,
+            key=lambda n: __import__(
+                "core.utils", fromlist=["normalize_for_search"]
+            ).normalize_for_search(n, mode="nfkd"),
+        )
+        # pt-BR used to always be index 0 regardless of anything else.
+        assert choices[0][1] != "pt-BR" or len(choices) == 1
+
+    def test_every_registered_locale_is_present(self):
+        codes = {code for _, code in _load_language_choices()}
+        assert {"pt-BR", "pt-PT", "en-US", "es-ES", "pl"} <= codes
+
+
+class TestDetectSystemLanguage:
+    CODES = ["en-US", "es-ES", "pl", "pt-BR", "pt-PT"]
+
+    def test_exact_match(self, monkeypatch):
+        monkeypatch.setattr(locale_format, "get_system_ui_language", lambda: "es-ES")
+        assert _detect_system_language(self.CODES) == "es-ES"
+
+    def test_same_language_different_region_falls_through_to_a_supported_variant(self, monkeypatch):
+        # System UI language is Angolan Portuguese; we don't ship "pt-AO",
+        # so this must match one of our Portuguese variants, not English.
+        monkeypatch.setattr(locale_format, "get_system_ui_language", lambda: "pt-AO")
+        assert _detect_system_language(self.CODES) in ("pt-BR", "pt-PT")
+
+    def test_unsupported_language_falls_back_to_english(self, monkeypatch):
+        monkeypatch.setattr(locale_format, "get_system_ui_language", lambda: "hr-HR")
+        assert _detect_system_language(self.CODES) == "en-US"
+
+    def test_detection_failure_falls_back_to_english(self, monkeypatch):
+        monkeypatch.setattr(locale_format, "get_system_ui_language", lambda: None)
+        assert _detect_system_language(self.CODES) == "en-US"
+
+    def test_region_less_code_matches_by_prefix(self, monkeypatch):
+        monkeypatch.setattr(locale_format, "get_system_ui_language", lambda: "pl-PL")
+        assert _detect_system_language(self.CODES) == "pl"
+
+    def test_custom_fallback_is_honored(self, monkeypatch):
+        monkeypatch.setattr(locale_format, "get_system_ui_language", lambda: "hr-HR")
+        assert _detect_system_language(self.CODES, fallback="pt-BR") == "pt-BR"
+
+
+class TestLoadBootstrapStrings:
+    def test_returns_all_required_keys_for_every_registered_locale(self):
+        for code in ("pt-BR", "pt-PT", "en-US", "es-ES", "pl"):
+            strings = _load_bootstrap_strings(code)
+            for key in _BOOTSTRAP_KEYS:
+                assert strings.get(key), f"{code}: missing/blank {key!r}"
+
+    def test_es_es_strings_are_actually_in_spanish(self):
+        strings = _load_bootstrap_strings("es-ES")
+        assert strings["language_select_prompt"] == "Seleccionar un idioma"
+
+    def test_unknown_locale_falls_back_to_english(self):
+        strings = _load_bootstrap_strings("xx-XX")
+        assert strings["language_select_prompt"] == "Select a language"

--- a/tests/test_locale_format.py
+++ b/tests/test_locale_format.py
@@ -20,14 +20,20 @@ from core import locale_format as lf
 
 @pytest.fixture(autouse=True)
 def _clear_cache():
-    """The get_*_strftime() helpers are lru_cache'd (regional settings
-    don't change mid-session) — clear between tests so monkeypatching
-    _get_windows_locale_pattern actually takes effect each time."""
+    """The get_*_strftime() / get_country_or_region_iso2() /
+    get_system_ui_language() helpers are all lru_cache'd (these Windows
+    settings don't change mid-session) — clear between tests so
+    monkeypatching their underlying raw getters actually takes effect each
+    time."""
     lf._windows_date_strftime.cache_clear()
     lf._windows_time_strftime.cache_clear()
+    lf.get_country_or_region_iso2.cache_clear()
+    lf.get_system_ui_language.cache_clear()
     yield
     lf._windows_date_strftime.cache_clear()
     lf._windows_time_strftime.cache_clear()
+    lf.get_country_or_region_iso2.cache_clear()
+    lf.get_system_ui_language.cache_clear()
 
 
 class TestTranslatePattern:
@@ -113,3 +119,58 @@ class TestGetWindowsLocalePatternItself:
                 raise AttributeError(name)
         monkeypatch.setattr(lf.ctypes, "windll", _NoWindll(), raising=False)
         assert lf._get_windows_locale_pattern(lf.LOCALE_SSHORTDATE) is None
+
+
+class TestGetCountryOrRegionIso2:
+    """Regression: this used to read the "Regional format" locale
+    (GetLocaleInfoEx(NULL, LOCALE_SISO3166CTRYNAME)) instead of the actual
+    "Country or region" setting (GetUserDefaultGeoName) — the two are
+    independent Windows settings, and a machine can have an English
+    Regional format (it defaults to the install-time UI language) while
+    Country or region is set to the user's real location. Reported live:
+    Country or region = Bosnia and Herzegovina, but the pairing dialog's
+    country selector still defaulted to the United States."""
+
+    def test_uppercases_the_detected_code(self, monkeypatch):
+        monkeypatch.setattr(lf, "_get_windows_geo_name", lambda: "ba")
+        assert lf.get_country_or_region_iso2() == "BA"
+
+    def test_falls_back_to_none_when_detection_fails(self, monkeypatch):
+        monkeypatch.setattr(lf, "_get_windows_geo_name", lambda: None)
+        assert lf.get_country_or_region_iso2() is None
+
+    def test_missing_kernel32_returns_none(self, monkeypatch):
+        class _NoWindll:
+            def __getattr__(self, name):
+                raise AttributeError(name)
+        monkeypatch.setattr(lf.ctypes, "windll", _NoWindll(), raising=False)
+        assert lf._get_windows_geo_name() is None
+
+    def test_a_raising_getter_never_propagates(self, monkeypatch):
+        def _raise():
+            raise OSError("no geo name")
+        monkeypatch.setattr(lf, "_get_windows_geo_name", _raise)
+        assert lf.get_country_or_region_iso2() is None
+
+
+class TestGetSystemUiLanguage:
+    def test_returns_the_detected_tag(self, monkeypatch):
+        monkeypatch.setattr(lf, "_get_windows_ui_language_raw", lambda: "en-US")
+        assert lf.get_system_ui_language() == "en-US"
+
+    def test_falls_back_to_none_when_detection_fails(self, monkeypatch):
+        monkeypatch.setattr(lf, "_get_windows_ui_language_raw", lambda: None)
+        assert lf.get_system_ui_language() is None
+
+    def test_missing_kernel32_returns_none(self, monkeypatch):
+        class _NoWindll:
+            def __getattr__(self, name):
+                raise AttributeError(name)
+        monkeypatch.setattr(lf.ctypes, "windll", _NoWindll(), raising=False)
+        assert lf._get_windows_ui_language_raw() is None
+
+    def test_a_raising_getter_never_propagates(self, monkeypatch):
+        def _raise():
+            raise OSError("no UI languages")
+        monkeypatch.setattr(lf, "_get_windows_ui_language_raw", _raise)
+        assert lf.get_system_ui_language() is None

--- a/tests/test_phone_country_code_protection.py
+++ b/tests/test_phone_country_code_protection.py
@@ -1,0 +1,112 @@
+"""Tests for ui.dialogs.connect._resolve_protected_edit().
+
+The pairing dialog's phone field displays "+<country code> <local number>"
+and used to let the user freely Backspace/Delete/type into the "+<country
+code>" portion. Because _format_phone_display() derives the displayed local
+number by stripping the country code off the FRONT of the digit string
+(`digits[len(cc):] if digits.startswith(cc) else digits`), corrupting even
+one of those leading digits made it stop matching the stored dial code and
+silently folded extra/missing digits into the local number instead — e.g.
+typing a stray "9" at the very start of "+55 11987654321" produced
+"+55 95511987654321" (the phone number actually being paired shifts, then
+gets sent to WhatsApp corrupted) rather than editing the local number as the
+user intended. The fix makes the "+<country code>" prefix immutable except
+through the country ComboBox (Connect.on_country_changed).
+
+A caret-only edit (no selection) that would touch the prefix is a pure
+no-op (returns None). A selection that starts inside the prefix but extends
+past it — the common case is Ctrl+A then Delete/Backspace/Paste/typing — is
+NOT blocked outright: it is clamped to start right after the prefix, so
+"select everything, delete" clears the local number and leaves the country
+code exactly as it was, which is the behaviour a user pressing Ctrl+A then
+Delete actually expects.
+"""
+
+from ui.dialogs.connect import _resolve_protected_edit
+
+# "+55" - Brazil's prefix is 3 characters: '+', '5', '5'.
+PREFIX_LEN = 3
+
+
+class TestTypedCharacterAndForwardDelete:
+    """Both act at the caret (insertion_point) with no deleting_backward."""
+
+    def test_typing_before_prefix_end_is_a_no_op(self):
+        assert _resolve_protected_edit(PREFIX_LEN, 0, 0, 0) is None
+        assert _resolve_protected_edit(PREFIX_LEN, 2, 2, 2) is None
+
+    def test_typing_exactly_at_prefix_end_is_unaffected(self):
+        assert _resolve_protected_edit(PREFIX_LEN, 3, 3, 3) == (3, 3)
+
+    def test_typing_after_prefix_is_unaffected(self):
+        assert _resolve_protected_edit(PREFIX_LEN, 7, 7, 7) == (7, 7)
+
+
+class TestBackspace:
+    """Backspace removes the character immediately before the caret."""
+
+    def test_backspace_at_prefix_end_removes_last_protected_char_is_a_no_op(self):
+        # Caret at position 3 ("+55|"): Backspace would delete index 2 ('5').
+        assert _resolve_protected_edit(
+            PREFIX_LEN, 3, 3, 3, deleting_backward=True
+        ) is None
+
+    def test_backspace_just_after_prefix_is_unaffected(self):
+        # Caret at position 4 ("+55 |"): Backspace deletes index 3 (space).
+        assert _resolve_protected_edit(
+            PREFIX_LEN, 4, 4, 4, deleting_backward=True
+        ) == (4, 4)
+
+    def test_backspace_at_start_of_field_is_a_no_op(self):
+        assert _resolve_protected_edit(
+            PREFIX_LEN, 0, 0, 0, deleting_backward=True
+        ) is None
+
+
+class TestSelectionSpanningTheBoundary:
+    """The Ctrl+A case: a selection starting inside the prefix but ending
+    past it must be CLAMPED (local number cleared, country code kept), not
+    blocked outright."""
+
+    def test_select_all_then_delete_clamps_to_just_after_prefix(self):
+        assert _resolve_protected_edit(PREFIX_LEN, 99, 0, 99) == (3, 99)
+
+    def test_select_all_then_backspace_clamps_the_same_way(self):
+        # deleting_backward is irrelevant once there's a selection — a
+        # selection-based edit always acts on the selection itself.
+        assert _resolve_protected_edit(
+            PREFIX_LEN, 99, 0, 99, deleting_backward=True
+        ) == (3, 99)
+
+    def test_selection_spanning_into_local_number_from_mid_prefix_clamps(self):
+        assert _resolve_protected_edit(PREFIX_LEN, 5, 1, 5) == (3, 5)
+
+
+class TestSelectionEntirelyInsideOrAfterThePrefix:
+    def test_selection_entirely_inside_prefix_is_a_no_op(self):
+        assert _resolve_protected_edit(PREFIX_LEN, 2, 0, 2) is None
+        # Ending exactly at the boundary still counts as "entirely inside".
+        assert _resolve_protected_edit(PREFIX_LEN, 3, 1, 3) is None
+
+    def test_selection_entirely_after_prefix_is_unaffected(self):
+        assert _resolve_protected_edit(PREFIX_LEN, 10, 4, 10) == (4, 10)
+
+    def test_selection_starting_exactly_at_prefix_end_is_unaffected(self):
+        assert _resolve_protected_edit(PREFIX_LEN, 8, 3, 8) == (3, 8)
+
+
+class TestDifferentCountryCodeLengths:
+    """prefix_len varies with the selected country ("+1" = 2 chars,
+    "+1268" (Antigua and Barbuda) = 5 chars) — not hardcoded to Brazil."""
+
+    def test_short_dial_code(self):
+        # "+1" — protects positions 0-1.
+        assert _resolve_protected_edit(2, 1, 1, 1) is None
+        assert _resolve_protected_edit(2, 2, 2, 2) == (2, 2)
+
+    def test_long_dial_code(self):
+        # "+1268" — protects positions 0-4.
+        assert _resolve_protected_edit(5, 4, 4, 4) is None
+        assert _resolve_protected_edit(5, 5, 5, 5) == (5, 5)
+        # Ctrl+A then Delete with the longer prefix clamps to 5, not 3.
+        assert _resolve_protected_edit(5, 20, 0, 20) == (5, 20)


### PR DESCRIPTION
Pairing dialog and first-run language picker now use the correct Windows region/display language, with alphabetically sorted lists and proper localization. Phone country codes are protected from editing, and all read-only ComboBoxes now share improved multi-letter type-ahead search.