### PR TITLE
Merge PR #142 com a correção da revisão (flag de recuperação)

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -84,7 +84,7 @@ jobs:
           pip install -r requirements-dev.txt --quiet
 
       - name: Run pytest
-        run: pytest
+        run: pytest --run-wx-gui
 
   # ── ALPHA-SPECIFIC ────────────────────────────────────────────────────────
   # A job of its own because build-windows.yml takes the version as an input,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,4 @@ jobs:
       # pulam sozinhos — vide test_api_patches_in_sync.py. Isso é esperado: a
       # deriva que eles pegam só é detectável numa máquina de dev.
       - name: Run pytest
-        run: pytest
+        run: pytest --run-wx-gui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       # reject-on-test-failure below DELETES the release and its tag, and a
       # stale sentence in a Markdown file must never be able to do that.
       - name: Run pytest
-        run: pytest -m "not docs"
+        run: pytest --run-wx-gui -m "not docs"
 
       # Alpha builds (alpha-release.yml) are versioned as
       # <major>.<minor>.<patch>.<commit count>alpha off the CURRENT stable

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -72,7 +72,7 @@ jobs:
           pip install -r requirements-dev.txt --quiet
 
       - name: Run pytest
-        run: pytest
+        run: pytest --run-wx-gui
 
   build:
     # always() so the build still runs when `test` was skipped by run_tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,19 +30,32 @@ Entry point is `client/main.py`, guarded by `if __name__ == "__main__":` near th
 pytest                                   # from repo root; pytest.ini sets pythonpath=client, asyncio_mode=auto
 pytest tests/test_database.py            # single file
 pytest tests/test_database.py::TestChats::test_upsert_chat_creates_record  # single test
-pytest -m "not wxgui"                    # skip the modules that open a real dialog
+pytest --run-wx-gui                      # ...including the ones that open a real dialog
 ```
-**Run `-m "not wxgui"` whenever somebody is actually using the machine.** A
-handful of modules construct a real top-level wx dialog, and that steals focus
-from whatever the user is doing — worse, it has crashed NVDA live: NVDA takes
-focus on the throwaway window and is still enumerating its children over COM
-(`event_gainFocus` → `getDialogText` → `IAccessible._get_children` →
-`oleacc.AccessibleObjectFromEvent`) when the test destroys it. Confirmed from
-NVDA's own traceback. Everything else builds its windows through
-`tests/conftest.py`'s `hidden_frame()` — real, fully functional parents, but
+**A plain `pytest` never opens anything in the foreground, and that is a
+deliberate default, not a convenience.** WinZapp is maintained by blind
+developers: a test window taking focus does not break the test run, it breaks
+whatever they had open in another window — and it has crashed NVDA outright.
+NVDA takes focus on the throwaway window and is still enumerating its children
+over COM (`event_gainFocus` → `getDialogText` → `IAccessible._get_children` →
+`oleacc.AccessibleObjectFromEvent`) when the test destroys it; confirmed live
+from NVDA's own traceback. "Remember to pass a flag" was the wrong shape for
+that risk — forgetting costs the person least able to absorb it.
+
+So the suite stays off the desktop two ways. Frames go through
+`tests/conftest.py`'s `hidden_frame()`: real, fully functional parents, but
 off-screen tool windows with no taskbar button, so they never become
-foreground. `tests/test_no_desktop_visible_windows.py` enforces both halves;
-CI has no screen reader and runs the whole suite.
+foreground. The handful of modules that construct a real `Dialog` subclass —
+which owns its own construction and cannot be positioned from outside — carry
+the `wxgui` marker and are **skipped unless explicitly asked for**, via
+`--run-wx-gui` or `WINZAPP_RUN_WX_GUI_TESTS=1`.
+
+Every CI workflow passes `--run-wx-gui`, so the coverage is never actually
+lost — it just stops running on a human's desktop by accident.
+`tests/test_no_desktop_visible_windows.py` enforces all of it: no module may
+reintroduce a bare `wx.Frame(None)`, a new module building a real dialog must
+carry the marker, and a CI step running a bare `pytest` fails the suite rather
+than silently dropping the dialog tests.
 Tests cover `client/core/database.py` and `client/core/database_bridge.py` (async SQLite layer + its sync façade) and small islands of pure logic pulled out of `main.py`/`core/notification_manager.py`/`ui/conversations.py` (e.g. `tests/test_sender_names.py`, `tests/test_notifications.py`, `tests/test_delivery_status.py`, `tests/test_send_jid_resolution.py`, `tests/test_message_bookmarks.py`) by binding their unbound methods onto a plain stub object — `MainWindow`/`ConversationsPanel` are wx.Frame/wx.Panel and can't be instantiated without a running wx.App, so the stub carries only the attributes the method under test actually touches. There are no tests for the wx UI in bulk. Async tests use `pytest-asyncio` in `auto` mode — no `@pytest.mark.asyncio` decorator needed, just declare test functions `async def`. **New functions/features should come with a test in this style as part of the same change.**
 
 ### Building the distributable

--- a/client/api_patches/src/controller/sessionController.ts
+++ b/client/api_patches/src/controller/sessionController.ts
@@ -308,7 +308,8 @@ export async function closeSession(req: Request, res: Response): Promise<any> {
     // status honest: connection_state.session_closed_after_flush() rejects it,
     // so the poll waits for the `finally` below, which only runs once close()
     // has actually returned.
-    (clientsArray as any)[session] = { status: 'CLOSING' };
+    const closingMarker = { status: 'CLOSING' };
+    (clientsArray as any)[session] = closingMarker;
 
     try {
       if (req.client && typeof req.client.close === 'function') {
@@ -328,9 +329,16 @@ export async function closeSession(req: Request, res: Response): Promise<any> {
         //
         // Racing it keeps the slot self-clearing. WinZapp's own POST budget
         // (_WPP_GRACEFUL_STOP_SECONDS) is 10s, so this has to answer first.
-        await Promise.race([
-          req.client.close(),
-          new Promise((resolve) => setTimeout(resolve, 8000)).then(() => {
+        // Promise.race does not cancel its losing promise. The old inline
+        // setTimeout therefore still fired eight seconds after close() had
+        // already won, by which time WinZapp could have started a replacement
+        // browser under the same session name. forceKillSession(session) then
+        // killed that brand-new browser and left the session in INITIALIZING
+        // with a detached Puppeteer frame. Keep the handle and explicitly
+        // cancel the timeout as soon as close() settles.
+        let closeTimeout: ReturnType<typeof setTimeout> | undefined;
+        const closeTimeoutPromise = new Promise<void>((resolve) => {
+          closeTimeout = setTimeout(() => {
             req.logger?.warn?.(
               `[${session}] close() did not settle in 8s — force killing so ` +
                 `the session slot is not left stuck in CLOSING.`
@@ -338,8 +346,14 @@ export async function closeSession(req: Request, res: Response): Promise<any> {
             try {
               SessionUtil.forceKillSession(session, req.logger);
             } catch (e) {}
-          }),
-        ]);
+            resolve();
+          }, 8000);
+        });
+        try {
+          await Promise.race([req.client.close(), closeTimeoutPromise]);
+        } finally {
+          if (closeTimeout !== undefined) clearTimeout(closeTimeout);
+        }
       }
     } catch (closeErr) {
       req.logger?.warn?.(
@@ -349,7 +363,11 @@ export async function closeSession(req: Request, res: Response): Promise<any> {
         SessionUtil.forceKillSession(session, req.logger);
       } catch (e) {}
     } finally {
-      (clientsArray as any)[session] = undefined;
+      // Do not let an old close request erase a replacement client that may
+      // have claimed this session slot after an exceptional teardown path.
+      if ((clientsArray as any)[session] === closingMarker) {
+        (clientsArray as any)[session] = undefined;
+      }
     }
 
     req.io.emit('whatsapp-status', false);

--- a/client/main.py
+++ b/client/main.py
@@ -10141,12 +10141,21 @@ class MainWindow(wx.Frame):
         last = getattr(self, "_last_wpp_session_restart_ts", 0)
         if now - last < self._WPP_SESSION_RESTART_COOLDOWN:
             return
+        # Deliberately does NOT also set _recovery_restart_active, even though
+        # that is the flag check_wa_connection_http()'s CLOSED branch reads
+        # first: _force_whatsapp_session_restart() owns that one for the whole
+        # of _run_recovery_attempts(), and neither of this method's two call
+        # sites (the dead-browser strike escalation, and start_sync's store
+        # rebuild) checks whether a recovery is already running. Setting it
+        # here means the finally below clears a flag this method never owned,
+        # reopening the competing-start-session window mid-recovery -- and,
+        # since _self_inflicted_teardown_expected() reads it, letting the
+        # recovery's OWN close-session be handled as a real phone-side unlink.
+        # Nothing is lost: _restarting_wpp_session is itself part of
+        # _self_inflicted_teardown_expected(), so the auto-start is already
+        # suppressed by the elif immediately after that _recovery_restart_active
+        # check, for exactly this method's duration.
         self._restarting_wpp_session = True
-        # check_wa_connection_http() uses this gate to avoid issuing its own
-        # /start-session while a close/wait/start recovery sequence owns the
-        # browser. _restarting_wpp_session is only this method's re-entrancy
-        # guard and is not consulted by the health loop.
-        self._recovery_restart_active = True
         self._last_wpp_session_restart_ts = now
         try:
             logging.warning(
@@ -10180,10 +10189,18 @@ class MainWindow(wx.Frame):
                 stop_when_connected=False,
             )
             if not cs.session_closed_after_flush(closed_status):
+                # Bailing leaves the session closed-but-not-restarted, which
+                # is recoverable rather than terminal: the Node side's own 8s
+                # watchdog force-kills and clears the slot, status-session then
+                # answers CLOSED, and the next health cycle's CLOSED branch
+                # auto-starts it (that branch has no cooldown of its own). Since
+                # _RECOVERY_CLOSE_WAIT is 12s and that watchdog is 8s, reaching
+                # this at all means the Node handler itself is wedged.
                 logging.error(
                     "[_restart_wpp_session] Session did not reach CLOSED after "
                     "close-session (accepted=%s, status=%s) — refusing to start "
-                    "a replacement browser on top of the old one.",
+                    "a replacement browser on top of the old one. The health "
+                    "loop's CLOSED auto-start is what picks this up.",
                     close_accepted,
                     closed_status or "?",
                 )
@@ -10196,7 +10213,6 @@ class MainWindow(wx.Frame):
             except Exception as exc:
                 logging.warning("[_restart_wpp_session] start-session failed: %s", exc)
         finally:
-            self._recovery_restart_active = False
             self._restarting_wpp_session = False
 
     # A live WPPConnect Socket.IO event this recent is treated as direct

--- a/client/main.py
+++ b/client/main.py
@@ -9655,6 +9655,11 @@ class MainWindow(wx.Frame):
         if now - last < self._WPP_SESSION_RESTART_COOLDOWN:
             return
         self._restarting_wpp_session = True
+        # check_wa_connection_http() uses this gate to avoid issuing its own
+        # /start-session while a close/wait/start recovery sequence owns the
+        # browser. _restarting_wpp_session is only this method's re-entrancy
+        # guard and is not consulted by the health loop.
+        self._recovery_restart_active = True
         self._last_wpp_session_restart_ts = now
         try:
             logging.warning(
@@ -9664,11 +9669,39 @@ class MainWindow(wx.Frame):
             )
             headers = {"Authorization": f"Bearer {self.token}"}
             close_url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/close-session"
+            close_accepted = False
             try:
-                api_post(close_url, headers=headers, timeout=15)
+                response = api_post(close_url, headers=headers, timeout=15)
+                close_accepted = response.status_code in (200, 201)
+                if not close_accepted:
+                    logging.warning(
+                        "[_restart_wpp_session] close-session returned HTTP %s.",
+                        response.status_code,
+                    )
             except Exception as exc:
                 logging.warning("[_restart_wpp_session] close-session failed: %s", exc)
-            time.sleep(2)
+
+            # A 200 only means the controller accepted the request; it is not
+            # permission to start a new browser on top of a CLOSING slot. The
+            # old fixed sleep reproduced a field failure where the close's
+            # eight-second watchdog killed the replacement browser just after
+            # it connected. Wait for the server's honest CLOSED transition.
+            import connection_state as cs
+            closed_status = self._wait_for_status(
+                cs.session_closed_after_flush,
+                self._RECOVERY_CLOSE_WAIT,
+                stop_when_connected=False,
+            )
+            if not cs.session_closed_after_flush(closed_status):
+                logging.error(
+                    "[_restart_wpp_session] Session did not reach CLOSED after "
+                    "close-session (accepted=%s, status=%s) — refusing to start "
+                    "a replacement browser on top of the old one.",
+                    close_accepted,
+                    closed_status or "?",
+                )
+                return
+
             start_url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/start-session"
             try:
                 api_post(start_url, json={"waitQrCode": False}, headers=headers, timeout=15)
@@ -9676,6 +9709,7 @@ class MainWindow(wx.Frame):
             except Exception as exc:
                 logging.warning("[_restart_wpp_session] start-session failed: %s", exc)
         finally:
+            self._recovery_restart_active = False
             self._restarting_wpp_session = False
 
     # A live WPPConnect Socket.IO event this recent is treated as direct

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,13 @@ testpaths = tests
 pythonpath = client
 asyncio_mode = auto
 markers =
-    wxgui: creates a real top-level wx window (see below)
+    wxgui: constructs a REAL top-level wx dialog, which takes foreground focus
+        and has crashed NVDA live (event_gainFocus -> getDialogText ->
+        IAccessible._get_children -> oleacc.AccessibleObjectFromEvent, while the
+        test destroys the window it is reading). SKIPPED BY DEFAULT - pass
+        --run-wx-gui or set WINZAPP_RUN_WX_GUI_TESTS=1 to run them, which every
+        CI workflow does. Frames elsewhere go through conftest.hidden_frame()
+        and are off-screen tool windows, so only Dialog subclasses need this.
     slow: tests that run migration on large datasets
     integration: tests that require a real wx.App
     load: synthetic load tests with configurable scenario size

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,60 @@ from cryptography.fernet import Fernet
 # ── Fixtures: wx ────────────────────────────────────────────────────────────
 
 
+
+# ── wxgui: opt-in, because the default must be safe for a blind developer ────
+#
+# A plain `pytest` has to be safe to run on the machine somebody is using.
+# Tests marked `wxgui` construct a real top-level wx dialog, which takes
+# foreground focus away from whatever the developer is doing - and has crashed
+# NVDA outright: NVDA takes focus on the throwaway window and is still
+# enumerating its children over COM (event_gainFocus -> getDialogText ->
+# IAccessible._get_children -> oleacc.AccessibleObjectFromEvent) when the test
+# destroys it. Confirmed live from NVDA's own traceback.
+#
+# WinZapp exists for blind users and is maintained by blind developers, so
+# "remember to pass -m 'not wxgui'" is the wrong default: the cost of
+# forgetting falls on the person least able to absorb it, and it is not their
+# test run that breaks - it is whatever they were doing in another window.
+#
+# So these are skipped unless explicitly asked for, by `--run-wx-gui` or
+# WINZAPP_RUN_WX_GUI_TESTS=1. Every CI workflow passes the flag (enforced by
+# tests/test_no_desktop_visible_windows.py), so the coverage is never actually
+# lost - it just stops running on a human's desktop by accident.
+_WX_GUI_OPT_IN_ENV = "WINZAPP_RUN_WX_GUI_TESTS"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-wx-gui",
+        action="store_true",
+        default=False,
+        help="Run the tests marked `wxgui`, which open a real top-level wx "
+             "dialog and steal foreground focus. Safe on CI and on a machine "
+             "nobody is using; on a developer's own desktop it can crash a "
+             "running screen reader. CI passes this.",
+    )
+
+
+def _wx_gui_requested(config) -> bool:
+    return bool(
+        config.getoption("--run-wx-gui")
+        or os.environ.get(_WX_GUI_OPT_IN_ENV, "").strip() not in ("", "0", "false", "False")
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if _wx_gui_requested(config):
+        return
+    skip = pytest.mark.skip(
+        reason="opens a real top-level wx dialog and steals focus - pass "
+               "--run-wx-gui (or set WINZAPP_RUN_WX_GUI_TESTS=1) to run it"
+    )
+    for item in items:
+        if "wxgui" in item.keywords:
+            item.add_marker(skip)
+
+
 @pytest.fixture(scope="session")
 def wx_app():
     """A single wx.App shared by every test in the run that needs a real

--- a/tests/test_no_desktop_visible_windows.py
+++ b/tests/test_no_desktop_visible_windows.py
@@ -94,10 +94,18 @@ class TestTheDefaultRunIsSafe:
         for wf in workflows:
             for i, line in enumerate(wf.read_text(encoding="utf-8").splitlines(), 1):
                 stripped = line.strip()
-                if not stripped.startswith("run:"):
+                if stripped.startswith("#"):
                     continue
-                command = stripped[len("run:"):].strip()
-                if not command.startswith("pytest"):
+                # Both shapes: `run: pytest ...` on one line, and a bare
+                # `pytest ...` inside a `run: |` block. Only the first exists
+                # today, but the block form is the natural way somebody adds
+                # a second command later, and a guard that misses it fails
+                # silently in the one direction that matters.
+                if stripped.startswith("run:"):
+                    command = stripped[len("run:"):].strip()
+                else:
+                    command = stripped
+                if not (command == "pytest" or command.startswith("pytest ")):
                     continue
                 if "--run-wx-gui" not in command:
                     offenders.append(f"{wf.name}:{i}: {command}")

--- a/tests/test_no_desktop_visible_windows.py
+++ b/tests/test_no_desktop_visible_windows.py
@@ -53,6 +53,60 @@ def test_no_module_builds_a_bare_top_level_frame(path):
     )
 
 
+class TestTheDefaultRunIsSafe:
+    """`pytest` with no arguments must not open anything in the foreground.
+
+    The marker alone was not enough: it still ran by default, so staying safe
+    depended on every developer remembering `-m "not wxgui"`. WinZapp is
+    maintained by blind developers, and the cost of forgetting does not land
+    on the test run — it lands on whatever they had open in another window.
+    So the default skips these, and CI opts back in.
+    """
+
+    def test_the_marked_tests_are_skipped_without_the_opt_in(self, pytestconfig):
+        """If this ever runs unskipped in a default run, the protection is
+        gone. It asserts about its own session: with no --run-wx-gui and no
+        WINZAPP_RUN_WX_GUI_TESTS, a wxgui test must not have been collected
+        to run."""
+        import os
+
+        opted_in = (
+            pytestconfig.getoption("--run-wx-gui")
+            or os.environ.get("WINZAPP_RUN_WX_GUI_TESTS", "").strip()
+            not in ("", "0", "false", "False")
+        )
+        if opted_in:
+            pytest.skip("this session deliberately opted in")
+        # conftest must have installed the deselection hook.
+        conftest_src = (TESTS / "conftest.py").read_text(encoding="utf-8")
+        assert "def pytest_collection_modifyitems" in conftest_src
+        assert '"wxgui" in item.keywords' in conftest_src
+
+    def test_every_ci_workflow_that_runs_pytest_opts_back_in(self):
+        """The flip side: skipping by default silently loses the coverage
+        unless CI asks for it. A workflow that runs a bare `pytest` would
+        stop exercising every dialog test with nothing to show for it."""
+        workflows = sorted(
+            (TESTS.parent / ".github" / "workflows").glob("*.yml")
+        )
+        assert workflows, "no workflows found — has the path changed?"
+        offenders = []
+        for wf in workflows:
+            for i, line in enumerate(wf.read_text(encoding="utf-8").splitlines(), 1):
+                stripped = line.strip()
+                if not stripped.startswith("run:"):
+                    continue
+                command = stripped[len("run:"):].strip()
+                if not command.startswith("pytest"):
+                    continue
+                if "--run-wx-gui" not in command:
+                    offenders.append(f"{wf.name}:{i}: {command}")
+        assert not offenders, (
+            "these CI steps run pytest without --run-wx-gui, so the wxgui "
+            f"tests are skipped there too and nothing covers them: {offenders}"
+        )
+
+
 class TestTheMarkerIsRegisteredAndUsed:
     def test_pytest_ini_declares_the_marker(self):
         ini = (TESTS.parent / "pytest.ini").read_text(encoding="utf-8")

--- a/tests/test_restart_wpp_session.py
+++ b/tests/test_restart_wpp_session.py
@@ -26,18 +26,18 @@ class _Stub:
     _auto_restart_grace_active = MainWindow._auto_restart_grace_active
     _WPP_SESSION_RESTART_COOLDOWN = MainWindow._WPP_SESSION_RESTART_COOLDOWN
     _AUTO_RESTART_LOGOUT_GRACE_SECONDS = MainWindow._AUTO_RESTART_LOGOUT_GRACE_SECONDS
+    _RECOVERY_CLOSE_WAIT = MainWindow._RECOVERY_CLOSE_WAIT
 
     def __init__(self):
         self.wpp_server = "http://127.0.0.1"
         self.wpp_port = 6300
         self.token = "test-token"
+        self.waited_statuses = []
+        self.closed_status = "CLOSED"
 
-
-@pytest.fixture(autouse=True)
-def _no_real_sleep(monkeypatch):
-    """_restart_wpp_session() sleeps 2s between close and start — skip that
-    in tests."""
-    monkeypatch.setattr("main.time.sleep", lambda *_: None)
+    def _wait_for_status(self, predicate, timeout, stop_when_connected=True):
+        self.waited_statuses.append((predicate, timeout, stop_when_connected))
+        return self.closed_status
 
 
 class TestRestartWppSession:
@@ -58,8 +58,10 @@ class TestRestartWppSession:
             "http://127.0.0.1:6300/api/test-token/close-session",
             "http://127.0.0.1:6300/api/test-token/start-session",
         ]
+        assert len(s.waited_statuses) == 1
+        assert s.waited_statuses[0][1:] == (s._RECOVERY_CLOSE_WAIT, False)
 
-    def test_start_session_still_runs_if_close_session_fails(self, monkeypatch):
+    def test_start_session_runs_if_close_request_fails_but_closed_is_confirmed(self, monkeypatch):
         calls = []
 
         def _fake_post(url, **kw):
@@ -78,6 +80,36 @@ class TestRestartWppSession:
             "http://127.0.0.1:6300/api/test-token/close-session",
             "http://127.0.0.1:6300/api/test-token/start-session",
         ]
+
+    def test_does_not_start_replacement_until_closed_is_confirmed(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr("main.requests.post", lambda url, **kw: calls.append(url))
+        s = _Stub()
+        s.closed_status = "CLOSING"
+
+        s._restart_wpp_session()
+
+        assert calls == ["http://127.0.0.1:6300/api/test-token/close-session"]
+
+    def test_health_loop_restart_gate_covers_close_wait_and_start(self, monkeypatch):
+        gate_values = []
+        s = _Stub()
+
+        def _wait(*args, **kwargs):
+            gate_values.append(s._recovery_restart_active)
+            return "CLOSED"
+
+        def _post(url, **kwargs):
+            gate_values.append(s._recovery_restart_active)
+            return type("_Resp", (), {"status_code": 200})()
+
+        s._wait_for_status = _wait
+        monkeypatch.setattr("main.requests.post", _post)
+
+        s._restart_wpp_session()
+
+        assert gate_values and all(gate_values)
+        assert s._recovery_restart_active is False
 
     def test_respects_the_cooldown_between_restarts(self, monkeypatch):
         calls = []

--- a/tests/test_restart_wpp_session.py
+++ b/tests/test_restart_wpp_session.py
@@ -27,6 +27,8 @@ class _Stub:
     _WPP_SESSION_RESTART_COOLDOWN = MainWindow._WPP_SESSION_RESTART_COOLDOWN
     _AUTO_RESTART_LOGOUT_GRACE_SECONDS = MainWindow._AUTO_RESTART_LOGOUT_GRACE_SECONDS
     _RECOVERY_CLOSE_WAIT = MainWindow._RECOVERY_CLOSE_WAIT
+    # The real gate the health loop reads, not a reimplementation of it.
+    _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
 
     def __init__(self):
         self.wpp_server = "http://127.0.0.1"
@@ -34,6 +36,7 @@ class _Stub:
         self.token = "test-token"
         self.waited_statuses = []
         self.closed_status = "CLOSED"
+        self._recovery_restart_active = False
 
     def _wait_for_status(self, predicate, timeout, stop_when_connected=True):
         self.waited_statuses.append((predicate, timeout, stop_when_connected))
@@ -82,8 +85,15 @@ class TestRestartWppSession:
         ]
 
     def test_does_not_start_replacement_until_closed_is_confirmed(self, monkeypatch):
+        """A 200 from close-session only means the controller accepted the
+        request; it is not permission to put a second browser on the slot."""
         calls = []
-        monkeypatch.setattr("main.requests.post", lambda url, **kw: calls.append(url))
+
+        def _post(url, **kw):
+            calls.append(url)
+            return type("_Resp", (), {"status_code": 200})()
+
+        monkeypatch.setattr("main.requests.post", _post)
         s = _Stub()
         s.closed_status = "CLOSING"
 
@@ -91,16 +101,43 @@ class TestRestartWppSession:
 
         assert calls == ["http://127.0.0.1:6300/api/test-token/close-session"]
 
+    def test_a_refused_close_with_no_confirmed_closed_does_not_start_either(self, monkeypatch):
+        """The other new branch: close-session answered, but not with a 2xx.
+        Nothing may start until the status itself says CLOSED."""
+        calls = []
+
+        def _post(url, **kw):
+            calls.append(url)
+            return type("_Resp", (), {"status_code": 503})()
+
+        monkeypatch.setattr("main.requests.post", _post)
+        s = _Stub()
+        s.closed_status = "INITIALIZING"
+
+        s._restart_wpp_session()
+
+        assert calls == ["http://127.0.0.1:6300/api/test-token/close-session"]
+
     def test_health_loop_restart_gate_covers_close_wait_and_start(self, monkeypatch):
+        """The health loop must not fire its own start-session for the whole
+        close -> wait -> start sequence.
+
+        Asserted through _self_inflicted_teardown_expected(), which is what
+        check_wa_connection_http()'s CLOSED branch actually consults, rather
+        than through a specific flag: _restarting_wpp_session is already one
+        of the four flags that method reads, so the suppression is covered for
+        exactly this method's duration without it having to touch a flag that
+        belongs to another sequence (see the race test below).
+        """
         gate_values = []
         s = _Stub()
 
         def _wait(*args, **kwargs):
-            gate_values.append(s._recovery_restart_active)
+            gate_values.append(s._self_inflicted_teardown_expected())
             return "CLOSED"
 
         def _post(url, **kwargs):
-            gate_values.append(s._recovery_restart_active)
+            gate_values.append(s._self_inflicted_teardown_expected())
             return type("_Resp", (), {"status_code": 200})()
 
         s._wait_for_status = _wait
@@ -109,7 +146,36 @@ class TestRestartWppSession:
         s._restart_wpp_session()
 
         assert gate_values and all(gate_values)
-        assert s._recovery_restart_active is False
+        assert s._self_inflicted_teardown_expected() is False
+
+    def test_it_never_clears_a_recovery_sequence_s_own_flag(self, monkeypatch):
+        """_force_whatsapp_session_restart() owns _recovery_restart_active for
+        the whole of _run_recovery_attempts(), and neither of this method's
+        call sites (the dead-browser strike escalation, start_sync's store
+        rebuild) checks whether a recovery is already running.
+
+        A version of this method that set and then unconditionally cleared
+        that flag wiped it mid-recovery. Two things broke at once: the health
+        loop's CLOSED branch resumed firing start-session on top of the
+        recovery's in-flight browser, and — because
+        _self_inflicted_teardown_expected() reads the same flag — the
+        recovery's OWN close-session started being handled as a real
+        phone-side unlink, i.e. a false logout.
+        """
+        monkeypatch.setattr(
+            "main.requests.post",
+            lambda url, **kw: type("_Resp", (), {"status_code": 200})(),
+        )
+        s = _Stub()
+        s._recovery_restart_active = True  # a recovery already owns the browser
+
+        s._restart_wpp_session()
+
+        assert s._recovery_restart_active is True, (
+            "_restart_wpp_session() cleared a flag it does not own — the "
+            "recovery sequence is still running and has just lost its gate"
+        )
+        assert s._self_inflicted_teardown_expected() is True
 
     def test_respects_the_cooldown_between_restarts(self, monkeypatch):
         calls = []

--- a/tests/test_shutdown_closing_state.py
+++ b/tests/test_shutdown_closing_state.py
@@ -81,7 +81,8 @@ class TestTheServerParksClosingNotNull:
 
     def test_the_placeholder_is_closing(self):
         src = self._source()
-        assert "(clientsArray as any)[session] = { status: 'CLOSING' };" in src
+        assert "const closingMarker = { status: 'CLOSING' };" in src
+        assert "(clientsArray as any)[session] = closingMarker;" in src
 
     def test_the_null_placeholder_is_gone(self):
         """`{status: null}` is what getSessionState() reports as CLOSED."""
@@ -96,7 +97,7 @@ class TestTheServerParksClosingNotNull:
         # Anchor on the executable guard, not on `req.client.close()` — the
         # comment above the assignment names that call too.
         guard = "if (req.client && typeof req.client.close === 'function') {"
-        assert src.index("(clientsArray as any)[session] = { status: 'CLOSING' };") < (
+        assert src.index("(clientsArray as any)[session] = closingMarker;") < (
             src.index(guard)
         )
 
@@ -107,6 +108,7 @@ class TestTheServerParksClosingNotNull:
         src = self._source()
         finally_at = src.index("} finally {")
         assert "(clientsArray as any)[session] = undefined;" in src[finally_at:]
+        assert "(clientsArray as any)[session] === closingMarker" in src[finally_at:]
 
     def test_the_close_is_bounded(self):
         """wppconnect's close() swallows both page.close() and browser.close()
@@ -115,7 +117,18 @@ class TestTheServerParksClosingNotNull:
         src = self._source()
         assert "Promise.race([" in src
         race_at = src.index("Promise.race([")
-        assert "setTimeout" in src[race_at:race_at + 400]
+        timeout_at = src.index("const closeTimeoutPromise")
+        assert "setTimeout" in src[timeout_at:race_at]
+
+    def test_the_losing_close_timeout_is_cancelled(self):
+        """Promise.race does not cancel a losing timer. Without clearTimeout,
+        that timer force-kills a replacement browser eight seconds after the
+        old close already completed — the exact detached-frame field failure."""
+        src = self._source()
+        race_at = src.index("await Promise.race(")
+        clear_at = src.index("clearTimeout(closeTimeout)", race_at)
+        slot_clear_at = src.index("[session] = undefined", clear_at)
+        assert race_at < clear_at < slot_clear_at
 
 
 class TestTheWindowsShutdownBudget:


### PR DESCRIPTION
Integra o [PR #142](https://github.com/gabrielhhaber/WinZapp_Python/pull/142) de @mhcauduro com a correção apontada na revisão. Não deve ser mesclado separadamente do #142.

## O PR original

A causa raiz está certa e bem diagnosticada: `Promise.race()` não cancela a promise perdedora, então o watchdog de 8s do `closeSession` ainda disparava depois do `client.close()` ter vencido — e `forceKillSession` lê `clientsArray[session]` **no momento do disparo**, quando o slot já pode conter o browser substituto. Matava o browser novo e deixava a sessão em INITIALIZING com frame destacado. O `clearTimeout` é a correção de fato; os três caminhos (close vence, timeout vence, close rejeita) estão corretos. Trocar o `sleep(2)` fixo por uma espera real pelo CLOSED também está certo, e usa `stop_when_connected=False` conforme o contrato documentado do `_wait_for_status`.

## O que foi corrigido

`_restart_wpp_session()` passava a setar `_recovery_restart_active` e a zerá-lo incondicionalmente no `finally`. Só que quem é dono desse flag é o `_force_whatsapp_session_restart()`, durante todo o `_run_recovery_attempts()`, e nenhum dos dois pontos que chamam `_restart_wpp_session` (escalada por browser morto; rebuild de store do `start_sync`) checa se já há recuperação em curso. Cruzando os dois, o de dentro apaga o flag do de fora no meio da recuperação:

- o ramo CLOSED do `check_wa_connection_http` volta a disparar `start-session` em cima do browser que a recuperação ainda está subindo — a mesma janela concorrente que o flag existe para fechar;
- e, como o #141 fez o `_self_inflicted_teardown_expected()` ler esse flag, o `close-session` **da própria recuperação** passa a ser tratado como desconexão real do aparelho. Logout falso.

O flag é redundante de todo modo: `_restarting_wpp_session`, que o método já seta, também compõe o `_self_inflicted_teardown_expected()`, e o `elif` logo após a checagem de `_recovery_restart_active` já suprime o auto-start pela duração exata do método. Então ele sai, em vez de virar save-and-restore.

## Testes

- `test_health_loop_restart_gate_covers_close_wait_and_start` travava o comportamento errado (afirmava que o método seta e limpa o flag). Passa a afirmar pelo `_self_inflicted_teardown_expected()`, que é o que o health loop de fato consulta.
- Novo teste de regressão da corrida — verificado que falha com o bug reintroduzido.
- `test_does_not_start_replacement_until_closed_is_confirmed` passava por acidente: o `post` falso retornava `None`, então `response.status_code` estourava no `except` e o ramo novo nunca era exercido.
- Cobertura do `close-session` não-2xx.

`setup_api.py` re-executado para propagar o patch do `sessionController.ts`. Suíte: **5062 passed** (`-m "not wxgui"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)