### PR TITLE
fix(pareamento): QR e codigo de 8 caracteres voltam a aparecer

### DIFF
--- a/client/api_patches/start.js
+++ b/client/api_patches/start.js
@@ -441,6 +441,36 @@ const WA_CHECK_UPDATE = 'https://web.whatsapp.com/check-update';
 
 async function installPinnedPageInterception(page, body, log) {
   const cdp = await page.createCDPSession();
+  // Breadcrumbs for the reload loop reported live (both pairing routes show
+  // nothing on screen, wppconnect.log shows "Execution context was destroyed,
+  // most likely because of a navigation" every ~10s until the session is force
+  // killed at notLogged). Without these there is no way to tell from a user's
+  // log whether a reload was re-served the pinned document or escaped the
+  // interception entirely and got WhatsApp's current build — which decides
+  // whether the bug is in this pattern or upstream of it.
+  let documentsServed = 0;
+  page.on('framenavigated', (frame) => {
+    if (frame === page.mainFrame()) {
+      console.log(`[WinZapp] main frame navigated -> ${frame.url()}`);
+    }
+  });
+  // The exact-match urlPattern is deliberate — do NOT widen it.
+  //
+  // On a fresh unpaired profile WhatsApp Web navigates itself to
+  // `https://web.whatsapp.com/?post_logout=1&logout_reason=0`, which this
+  // pattern does not match. That looks like a bug (the pin covers the first
+  // load and nothing after) and was "fixed" once by matching every Document
+  // navigation on the origin — `urlPattern: WA_WEB_URL + '*'` with
+  // `resourceType: 'Document'`. That made pairing WORSE, not better: forcing
+  // the pinned document onto the post_logout navigation too means the page can
+  // never complete the logout/fresh-start cycle it is asking for, so it loops
+  // roughly every 10s until WPPConnect force-kills the session at notLogged,
+  // and neither the QR nor the pairing code is ever produced.
+  //
+  // Letting that one navigation through is what allows WhatsApp Web to settle;
+  // measured on the real app, the QR then arrives about 12s after
+  // start-session. The pin's job is to decide which build BOOTS, not to hold
+  // the page hostage to it.
   await cdp.send('Fetch.enable', {
     patterns: [
       { urlPattern: WA_WEB_URL, requestStage: 'Request' },
@@ -451,8 +481,13 @@ async function installPinnedPageInterception(page, body, log) {
     const { requestId, request } = event;
     try {
       if (request.url.startsWith(WA_CHECK_UPDATE)) {
+        console.log('[WinZapp] check-update aborted by the interception.');
         await cdp.send('Fetch.failRequest', { requestId, errorReason: 'Aborted' });
       } else if (request.url === WA_WEB_URL) {
+        documentsServed += 1;
+        console.log(
+          `[WinZapp] pinned document served (#${documentsServed}) for ${request.url}`
+        );
         await cdp.send('Fetch.fulfillRequest', {
           requestId,
           responseCode: 200,

--- a/client/core/wppconnect_host_layer_patch.py
+++ b/client/core/wppconnect_host_layer_patch.py
@@ -31,6 +31,31 @@ History:
   the latch never got reset — the displayed code silently froze forever.
   Reported live: "esperei 10 minutos e o código não atualizou nenhuma vez."
 
+* v6 — both pairing routes were dead at once, for two unrelated reasons that
+  presented identically ("nothing ever appears on screen"), which is why this
+  took a full instrumented bisect rather than a reading of the code.
+
+  The pairing code hit `Invariant Violation: Minified invariant #56367`
+  inside WhatsApp Web. Cause: v1..v5 hoisted the phoneNumber branch above
+  `await this.getQrCode()` to fix the rotation problem in v0, and that line
+  was load-bearing for a reason nobody had written down — reaching
+  loginByCode() only after a urlCode existed also guaranteed WhatsApp Web's
+  user-prefs storage was initialised. Without it, wa-js walks setADVSecretKey
+  -> allUserPrefsIdb -> getUserPrefsTable -> getStorage into an uninitialised
+  table. v6 restores the gate explicitly. See PATCHED_CHECK_QR_CODE for the
+  three measured timings that isolate it.
+
+  The QR emitted no event at all, because upstream's scrapeImg() reads the DOM
+  and current WhatsApp Web no longer renders the QR into a <canvas> whose
+  nearest data-ref ancestor is the code. v6 reads WPP.conn.getAuthCode()
+  instead and renders the PNG itself. See PATCHED_GET_QR_CODE.
+
+  Neither failure is a WinZapp regression in the ordinary sense — WhatsApp Web
+  changed under a DOM scraper, and the storage gate was dropped five patches
+  earlier without symptom until WhatsApp started asserting on it. Both are
+  worth keeping in mind the next time a patch here "simplifies" an upstream
+  ordering: the ordering may be the guard.
+
 """
 
 ORIGINAL_CHECK_QR_CODE = (
@@ -254,7 +279,7 @@ V4_CHECK_QR_CODE = (
 )
 
 
-PATCHED_CHECK_QR_CODE = (
+V5_CHECK_QR_CODE = (
     "    async checkQrCode() {\n"
     "        const needScan = await (0, auth_1.needsToScan)(this.page).catch(() => null);\n"
     "        this.isLogged = !needScan;\n"
@@ -321,6 +346,270 @@ PATCHED_CHECK_QR_CODE = (
     "            this.log('verbose', `Waiting for QRCode Scan: Attempt ${this.attempt}`);\n"
     "        }\n"
     "        this.catchQR?.(result.base64Image, qr, this.attempt, result.urlCode);\n"
+    "    }\n"
+)
+
+
+# v6 — the phoneNumber branch waits for the auth state to exist before it
+# calls into the link-device API.
+#
+# v1..v5 all hoisted this branch ABOVE the `await this.getQrCode()` line to fix
+# the rotation problem, and in doing so silently dropped the only thing that
+# made the call safe. Upstream reaches loginByCode() only after getQrCode()
+# has returned a urlCode — i.e. only once WhatsApp Web has an auth code, which
+# means its user-prefs storage is initialised. Calling the link-device API
+# before that point makes wa-js walk setADVSecretKey -> allUserPrefsIdb ->
+# getUserPrefsTable -> getStorage into an uninitialised table, and WhatsApp
+# Web throws `Invariant Violation: Minified invariant #56367`. Measured
+# directly against the pinned build, one variable at a time:
+#
+#   WPP present, not isReady yet   -> TypeError: Cannot read properties of
+#                                     undefined (reading 'm')
+#   isReady, auth code not yet up  -> Invariant Violation #56367   <-- shipped
+#   auth code available            -> no invariant
+#
+# So the gate is restored, but expressed against the rewritten getQrCode()
+# below, which reads WPP.conn.getAuthCode() instead of scraping the DOM. That
+# makes it a cheap, side-effect-free readiness probe (verified: gating on it
+# and merely sleeping the same duration produce the identical outcome, so
+# reading the auth code does not itself disturb the link-device flow), and it
+# keeps the v5 cooldown/backoff bookkeeping untouched.
+PATCHED_CHECK_QR_CODE = (
+    "    async checkQrCode() {\n"
+    "        const needScan = await (0, auth_1.needsToScan)(this.page).catch(() => null);\n"
+    "        this.isLogged = !needScan;\n"
+    "        if (!needScan) {\n"
+    "            this.attempt = 0;\n"
+    "            this.linkCodeIssuedAt = 0;\n"
+    "            this.linkCodeFailures = 0;\n"
+    "            this.linkCodeRetryAfter = 0;\n"
+    "            return;\n"
+    "        }\n"
+    "        if (typeof this.options.phoneNumber === 'string') {\n"
+    "            if (this.linkCodeInFlight) {\n"
+    "                return;\n"
+    "            }\n"
+    "            const now = Date.now();\n"
+    "            if (this.linkCodeIssuedAt && (now - this.linkCodeIssuedAt) < 60000) {\n"
+    "                return;\n"
+    "            }\n"
+    "            if (this.linkCodeRetryAfter && now < this.linkCodeRetryAfter) {\n"
+    "                return;\n"
+    "            }\n"
+    "            const ready = await this.getQrCode();\n"
+    "            if (!ready?.urlCode) {\n"
+    "                this.log('verbose', 'Auth state not ready yet — deferring the pairing code.');\n"
+    "                return;\n"
+    "            }\n"
+    "            this.linkCodeInFlight = true;\n"
+    "            try {\n"
+    "                await this.loginByCode(this.options.phoneNumber);\n"
+    "                this.linkCodeIssuedAt = Date.now();\n"
+    "                this.linkCodeFailures = 0;\n"
+    "                this.linkCodeRetryAfter = 0;\n"
+    "            }\n"
+    "            catch (error) {\n"
+    "                this.linkCodeFailures = (this.linkCodeFailures || 0) + 1;\n"
+    "                const backoff = Math.min(20000 * Math.pow(2, this.linkCodeFailures - 1), 300000);\n"
+    "                this.linkCodeRetryAfter = Date.now() + backoff;\n"
+    "                const retryInSeconds = Math.round(backoff / 1000);\n"
+    "                this.log('error', `Could not generate the pairing code (attempt ${this.linkCodeFailures}, next retry in ${retryInSeconds}s): ${error?.name || 'Error'}: ${error?.message || error}`);\n"
+    "                this.options.catchLinkCodeError?.({\n"
+    "                    name: String(error?.name || 'Error'),\n"
+    "                    message: String(error?.message || error),\n"
+    "                    session: this.session,\n"
+    "                    attempt: this.linkCodeFailures,\n"
+    "                    retryInSeconds: retryInSeconds,\n"
+    "                    stack: String(error?.stack || ''),\n"
+    "                    details: error?.winzappDetails || {},\n"
+    "                });\n"
+    "            }\n"
+    "            finally {\n"
+    "                this.linkCodeInFlight = false;\n"
+    "            }\n"
+    "            return;\n"
+    "        }\n"
+    "        const result = await this.getQrCode();\n"
+    "        if (!result?.urlCode || this.urlCode === result.urlCode) {\n"
+    "            return;\n"
+    "        }\n"
+    "        this.urlCode = result.urlCode;\n"
+    "        this.attempt++;\n"
+    "        let qr = '';\n"
+    "        if (this.options.logQR || this.catchQR) {\n"
+    "            qr = await (0, auth_1.asciiQr)(this.urlCode);\n"
+    "        }\n"
+    "        if (this.options.logQR) {\n"
+    "            this.log('info', `Waiting for QRCode Scan (Attempt ${this.attempt})...:\\n${qr}`, { code: this.urlCode });\n"
+    "        }\n"
+    "        else {\n"
+    "            this.log('verbose', `Waiting for QRCode Scan: Attempt ${this.attempt}`);\n"
+    "        }\n"
+    "        this.catchQR?.(result.base64Image, qr, this.attempt, result.urlCode);\n"
+    "    }\n"
+)
+
+
+# getQrCode() — read the auth code from wa-js instead of scraping the DOM.
+#
+# Upstream's helper walks `document.querySelector('canvas').closest('[data-ref]')`
+# and reads that element's data-ref as the QR payload. Current WhatsApp Web
+# breaks both halves of that: at the moment the helper runs there is often no
+# <canvas> at all, and once one exists the nearest ancestor carrying a data-ref
+# is the "Link with phone number instead" / download banner, whose data-ref is
+# a `https://wa.me/settings/...` URL. Measured against the pinned build:
+#
+#   scrapeImg()             -> urlCode "https://wa.me/settings/l..."
+#   WPP.conn.getAuthCode()  -> fullCode 237 chars, starts with "2@",
+#                              type "multidevice"
+#
+# A real WhatsApp login payload starts with `2@`, so what upstream emits is not
+# a login QR at all — a phone pointed at it can never pair. Every failure is
+# swallowed by scrapeImg's own `.catch(() => undefined)`, so this surfaced only
+# as a QR that never appeared, or one that appeared and was silently refused.
+#
+# wa-js exposes the payload directly, so the DOM is out of the loop entirely.
+# The PNG is rendered here with `qrcode` (already present in node_modules,
+# resolvable from this file) at margin 0, deliberately: connect.py's
+# display_qrcode_image() adds its own quiet zone and then magnifies by a whole
+# integer factor with nearest-neighbour, and it documents that it is fed a
+# borderless image. Emitting one with a margin would double the quiet zone and
+# shrink the modules.
+ORIGINAL_GET_QR_CODE = (
+    "    async getQrCode() {\n"
+    "        let qrResult;\n"
+    "        qrResult = await (0, helpers_1.scrapeImg)(this.page).catch(() => undefined);\n"
+    "        return qrResult;\n"
+    "    }\n"
+)
+
+
+# The first cut of the wa-js rewrite, before it logged the "no auth code yet"
+# case. Kept only so a machine patched from this branch mid-investigation is
+# upgraded rather than reported as DID NOT MATCH.
+V1_GET_QR_CODE = (
+    "    async getQrCode() {\n"
+    "        const auth = await (0, helpers_1.evaluateAndReturn)(this.page, async () => {\n"
+    "            try {\n"
+    "                const code = await WPP.conn.getAuthCode();\n"
+    "                if (!code || !code.fullCode) {\n"
+    "                    return null;\n"
+    "                }\n"
+    "                return { fullCode: String(code.fullCode), type: String(code.type || '') };\n"
+    "            }\n"
+    "            catch (error) {\n"
+    "                return null;\n"
+    "            }\n"
+    "        }).catch(() => null);\n"
+    "        if (!auth?.fullCode) {\n"
+    "            return undefined;\n"
+    "        }\n"
+    "        let base64Image = '';\n"
+    "        try {\n"
+    "            base64Image = await require('qrcode').toDataURL(auth.fullCode, { margin: 0, scale: 4 });\n"
+    "        }\n"
+    "        catch (error) {\n"
+    "            this.log('warn', `Could not render the QR image: ${error?.message || error}`);\n"
+    "        }\n"
+    "        return { base64Image, urlCode: auth.fullCode };\n"
+    "    }\n"
+)
+
+
+PATCHED_GET_QR_CODE = (
+    "    async getQrCode() {\n"
+    "        const auth = await (0, helpers_1.evaluateAndReturn)(this.page, async () => {\n"
+    "            try {\n"
+    "                const code = await WPP.conn.getAuthCode();\n"
+    "                if (!code || !code.fullCode) {\n"
+    "                    return null;\n"
+    "                }\n"
+    "                return { fullCode: String(code.fullCode), type: String(code.type || '') };\n"
+    "            }\n"
+    "            catch (error) {\n"
+    "                return null;\n"
+    "            }\n"
+    "        }).catch(() => null);\n"
+    "        if (!auth?.fullCode) {\n"
+    "            this.qrProbeMisses = (this.qrProbeMisses || 0) + 1;\n"
+    "            if (this.qrProbeMisses <= 3 || this.qrProbeMisses % 20 === 0) {\n"
+    "                this.log('verbose', `No auth code available yet (probe ${this.qrProbeMisses}).`);\n"
+    "            }\n"
+    "            return undefined;\n"
+    "        }\n"
+    "        this.qrProbeMisses = 0;\n"
+    "        let base64Image = '';\n"
+    "        try {\n"
+    "            base64Image = await require('qrcode').toDataURL(auth.fullCode, { margin: 0, scale: 4 });\n"
+    "        }\n"
+    "        catch (error) {\n"
+    "            this.log('warn', `Could not render the QR image: ${error?.message || error}`);\n"
+    "        }\n"
+    "        return { base64Image, urlCode: auth.fullCode };\n"
+    "    }\n"
+)
+
+
+# waitForQrCodeScan() — a failed auth probe must not count as "logged in".
+#
+# Upstream:
+#
+#     const needScan = await needsToScan(this.page).catch(() => null);
+#     this.isLogged = !needScan;
+#
+# needsToScan() is `page.evaluate(() => WPP.conn.isRegistered())`. When that
+# throws — a detached frame, a navigation, a page that is briefly not there —
+# the catch turns it into `null`, and `!null` is `true`. So the one thing that
+# means "we could not find out" is recorded as the strongest possible claim:
+# the user has logged in. The loop exits, waitForLogin() then calls
+# isAuthenticated() itself, gets null again, and reports `Failed to
+# authenticate` / `qrReadError` — with the actual browser-side error never
+# written down anywhere, which is why this cost a full instrumented bisect to
+# find rather than being readable from wppconnect.log.
+#
+# A probe failure is now retried (it is usually transient) and logged. Only a
+# long run of consecutive failures gives up, and it says so, leaving isLogged
+# false so the caller's own reporting stays honest.
+ORIGINAL_WAIT_FOR_QR_CODE_SCAN = (
+    "    async waitForQrCodeScan() {\n"
+    "        if (!this.isStarted) {\n"
+    "            throw new Error('waitForQrCodeScan error: Session not started');\n"
+    "        }\n"
+    "        while (!this.page.isClosed() && !this.isLogged) {\n"
+    "            await (0, sleep_1.sleep)(200);\n"
+    "            const needScan = await (0, auth_1.needsToScan)(this.page).catch(() => null);\n"
+    "            this.isLogged = !needScan;\n"
+    "        }\n"
+    "    }\n"
+)
+
+
+PATCHED_WAIT_FOR_QR_CODE_SCAN = (
+    "    async waitForQrCodeScan() {\n"
+    "        if (!this.isStarted) {\n"
+    "            throw new Error('waitForQrCodeScan error: Session not started');\n"
+    "        }\n"
+    "        let probeFailures = 0;\n"
+    "        while (!this.page.isClosed() && !this.isLogged) {\n"
+    "            await (0, sleep_1.sleep)(200);\n"
+    "            let needScan;\n"
+    "            try {\n"
+    "                needScan = await (0, auth_1.needsToScan)(this.page);\n"
+    "            }\n"
+    "            catch (error) {\n"
+    "                probeFailures++;\n"
+    "                if (probeFailures <= 3 || probeFailures % 25 === 0) {\n"
+    "                    this.log('warn', `Auth probe failed (${probeFailures} in a row, still waiting): ${error?.name || 'Error'}: ${error?.message || error}`);\n"
+    "                }\n"
+    "                if (probeFailures >= 150) {\n"
+    "                    this.log('error', 'Auth probe has failed for 30s straight — giving up on the scan wait.');\n"
+    "                    return;\n"
+    "                }\n"
+    "                continue;\n"
+    "            }\n"
+    "            probeFailures = 0;\n"
+    "            this.isLogged = !needScan;\n"
+    "        }\n"
     "    }\n"
 )
 
@@ -456,37 +745,78 @@ def patch_host_layer_source(content: str):
     notes = []
 
     if PATCHED_CHECK_QR_CODE in content:
-        notes.append("checkQrCode: already at v5.")
+        notes.append("checkQrCode: already at v6.")
+    elif V5_CHECK_QR_CODE in content:
+        content = content.replace(V5_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
+        notes.append(
+            "checkQrCode: upgraded v5 -> v6 — the pairing code now waits for "
+            "WhatsApp Web's auth state instead of throwing Invariant #56367."
+        )
     elif V4_CHECK_QR_CODE in content:
         content = content.replace(V4_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
         notes.append(
-            "checkQrCode: upgraded v4 -> v5 — repeated pairing-code failures "
-            "now back off instead of retrying every auth-code rotation."
+            "checkQrCode: upgraded v4 -> v6 — repeated pairing-code failures "
+            "now back off, and the code waits for the auth state to exist."
         )
     elif V3_CHECK_QR_CODE in content:
         content = content.replace(V3_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
         notes.append(
-            "checkQrCode: upgraded v3 -> v5 — a pairing-code failure is now "
+            "checkQrCode: upgraded v3 -> v6 — a pairing-code failure is now "
             "reported to the client, not just written to wppconnect.log."
         )
     elif V2_CHECK_QR_CODE in content:
         content = content.replace(V2_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
         notes.append(
-            "checkQrCode: upgraded v2 -> v5 — a failing loginByCode() is now "
+            "checkQrCode: upgraded v2 -> v6 — a failing loginByCode() is now "
             "caught, reported and logged instead of escaping as an unhandled "
             "rejection."
         )
     elif V1_CHECK_QR_CODE in content:
         content = content.replace(V1_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
-        notes.append("checkQrCode: upgraded v1 (unsafe, could freeze forever) -> v5.")
+        notes.append("checkQrCode: upgraded v1 (unsafe, could freeze forever) -> v6.")
     elif ORIGINAL_CHECK_QR_CODE in content:
         content = content.replace(ORIGINAL_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
         notes.append(
-            "checkQrCode: patched (v5) — pairing code no longer regenerates on "
-            "every QR rotation (60s reuse cooldown), failures are reported."
+            "checkQrCode: patched (v6) — pairing code no longer regenerates on "
+            "every QR rotation (60s reuse cooldown), waits for the auth state, "
+            "failures are reported."
         )
     else:
         notes.append("checkQrCode: DID NOT MATCH any known source text — left untouched.")
+
+    if PATCHED_WAIT_FOR_QR_CODE_SCAN in content:
+        notes.append("waitForQrCodeScan: already retries a failed auth probe.")
+    elif ORIGINAL_WAIT_FOR_QR_CODE_SCAN in content:
+        content = content.replace(
+            ORIGINAL_WAIT_FOR_QR_CODE_SCAN, PATCHED_WAIT_FOR_QR_CODE_SCAN, 1
+        )
+        notes.append(
+            "waitForQrCodeScan: patched — a failed auth probe is retried and "
+            "logged instead of being read as 'the user is logged in'."
+        )
+    else:
+        notes.append(
+            "waitForQrCodeScan: DID NOT MATCH the known source text — left untouched."
+        )
+
+    if PATCHED_GET_QR_CODE in content:
+        notes.append("getQrCode: already reading the QR from wa-js.")
+    elif V1_GET_QR_CODE in content:
+        content = content.replace(V1_GET_QR_CODE, PATCHED_GET_QR_CODE, 1)
+        notes.append(
+            "getQrCode: upgraded — a missing auth code is now logged instead "
+            "of returning silently."
+        )
+    elif ORIGINAL_GET_QR_CODE in content:
+        content = content.replace(ORIGINAL_GET_QR_CODE, PATCHED_GET_QR_CODE, 1)
+        notes.append(
+            "getQrCode: patched — reads WPP.conn.getAuthCode() instead of "
+            "scraping a <canvas> that no longer exists, so the emitted payload "
+            "is a real 2@... login code rather than the download banner's "
+            "wa.me data-ref."
+        )
+    else:
+        notes.append("getQrCode: DID NOT MATCH the known source text — left untouched.")
 
     if PATCHED_LOGIN_BY_CODE in content:
         notes.append("loginByCode: already on the managed wa-js linking API.")

--- a/client/core/wppconnect_host_layer_patch.py
+++ b/client/core/wppconnect_host_layer_patch.py
@@ -374,9 +374,108 @@ V5_CHECK_QR_CODE = (
 # and merely sleeping the same duration produce the identical outcome, so
 # reading the auth code does not itself disturb the link-device flow), and it
 # keeps the v5 cooldown/backoff bookkeeping untouched.
-PATCHED_CHECK_QR_CODE = (
+V6_CHECK_QR_CODE = (
     "    async checkQrCode() {\n"
     "        const needScan = await (0, auth_1.needsToScan)(this.page).catch(() => null);\n"
+    "        this.isLogged = !needScan;\n"
+    "        if (!needScan) {\n"
+    "            this.attempt = 0;\n"
+    "            this.linkCodeIssuedAt = 0;\n"
+    "            this.linkCodeFailures = 0;\n"
+    "            this.linkCodeRetryAfter = 0;\n"
+    "            return;\n"
+    "        }\n"
+    "        if (typeof this.options.phoneNumber === 'string') {\n"
+    "            if (this.linkCodeInFlight) {\n"
+    "                return;\n"
+    "            }\n"
+    "            const now = Date.now();\n"
+    "            if (this.linkCodeIssuedAt && (now - this.linkCodeIssuedAt) < 60000) {\n"
+    "                return;\n"
+    "            }\n"
+    "            if (this.linkCodeRetryAfter && now < this.linkCodeRetryAfter) {\n"
+    "                return;\n"
+    "            }\n"
+    "            const ready = await this.getQrCode();\n"
+    "            if (!ready?.urlCode) {\n"
+    "                this.log('verbose', 'Auth state not ready yet — deferring the pairing code.');\n"
+    "                return;\n"
+    "            }\n"
+    "            this.linkCodeInFlight = true;\n"
+    "            try {\n"
+    "                await this.loginByCode(this.options.phoneNumber);\n"
+    "                this.linkCodeIssuedAt = Date.now();\n"
+    "                this.linkCodeFailures = 0;\n"
+    "                this.linkCodeRetryAfter = 0;\n"
+    "            }\n"
+    "            catch (error) {\n"
+    "                this.linkCodeFailures = (this.linkCodeFailures || 0) + 1;\n"
+    "                const backoff = Math.min(20000 * Math.pow(2, this.linkCodeFailures - 1), 300000);\n"
+    "                this.linkCodeRetryAfter = Date.now() + backoff;\n"
+    "                const retryInSeconds = Math.round(backoff / 1000);\n"
+    "                this.log('error', `Could not generate the pairing code (attempt ${this.linkCodeFailures}, next retry in ${retryInSeconds}s): ${error?.name || 'Error'}: ${error?.message || error}`);\n"
+    "                this.options.catchLinkCodeError?.({\n"
+    "                    name: String(error?.name || 'Error'),\n"
+    "                    message: String(error?.message || error),\n"
+    "                    session: this.session,\n"
+    "                    attempt: this.linkCodeFailures,\n"
+    "                    retryInSeconds: retryInSeconds,\n"
+    "                    stack: String(error?.stack || ''),\n"
+    "                    details: error?.winzappDetails || {},\n"
+    "                });\n"
+    "            }\n"
+    "            finally {\n"
+    "                this.linkCodeInFlight = false;\n"
+    "            }\n"
+    "            return;\n"
+    "        }\n"
+    "        const result = await this.getQrCode();\n"
+    "        if (!result?.urlCode || this.urlCode === result.urlCode) {\n"
+    "            return;\n"
+    "        }\n"
+    "        this.urlCode = result.urlCode;\n"
+    "        this.attempt++;\n"
+    "        let qr = '';\n"
+    "        if (this.options.logQR || this.catchQR) {\n"
+    "            qr = await (0, auth_1.asciiQr)(this.urlCode);\n"
+    "        }\n"
+    "        if (this.options.logQR) {\n"
+    "            this.log('info', `Waiting for QRCode Scan (Attempt ${this.attempt})...:\\n${qr}`, { code: this.urlCode });\n"
+    "        }\n"
+    "        else {\n"
+    "            this.log('verbose', `Waiting for QRCode Scan: Attempt ${this.attempt}`);\n"
+    "        }\n"
+    "        this.catchQR?.(result.base64Image, qr, this.attempt, result.urlCode);\n"
+    "    }\n"
+)
+
+
+# v7 - checkQrCode must not tell the same lie waitForQrCodeScan just stopped
+# telling. Its first two lines were still
+#
+#     const needScan = await needsToScan(this.page).catch(() => null);
+#     this.isLogged = !needScan;
+#
+# and `!null` is `true`. checkQrCode is invoked from the page on every
+# `conn.auth_code_change`, so it runs CONCURRENTLY with waitForQrCodeScan: one
+# failed probe here sets isLogged, that loop's `while (!this.isLogged)` exits on
+# its next check, waitForLogin re-probes, gets null, and reports
+# `Failed to authenticate` - the same symptom, through the door left open. Not
+# theoretical: the navigation loop this patch series was written against throws
+# "Execution context was destroyed" through this exact call every few seconds.
+#
+# A probe that could not answer leaves isLogged alone and returns; the next
+# auth-code rotation re-enters for free.
+PATCHED_CHECK_QR_CODE = (
+    "    async checkQrCode() {\n"
+    "        let needScan;\n"
+    "        try {\n"
+    "            needScan = await (0, auth_1.needsToScan)(this.page);\n"
+    "        }\n"
+    "        catch (error) {\n"
+    "            this.log('verbose', `Auth probe failed inside checkQrCode - leaving isLogged untouched: ${error?.name || 'Error'}: ${error?.message || error}`);\n"
+    "            return;\n"
+    "        }\n"
     "        this.isLogged = !needScan;\n"
     "        if (!needScan) {\n"
     "            this.attempt = 0;\n"
@@ -584,7 +683,7 @@ ORIGINAL_WAIT_FOR_QR_CODE_SCAN = (
 )
 
 
-PATCHED_WAIT_FOR_QR_CODE_SCAN = (
+V1_WAIT_FOR_QR_CODE_SCAN = (
     "    async waitForQrCodeScan() {\n"
     "        if (!this.isStarted) {\n"
     "            throw new Error('waitForQrCodeScan error: Session not started');\n"
@@ -608,6 +707,44 @@ PATCHED_WAIT_FOR_QR_CODE_SCAN = (
     "                continue;\n"
     "            }\n"
     "            probeFailures = 0;\n"
+    "            this.isLogged = !needScan;\n"
+    "        }\n"
+    "    }\n"
+)
+
+
+# The first cut, bounded by an iteration count instead of the wall clock.
+# Kept only so a machine patched from this branch mid-investigation is
+# upgraded rather than reported as DID NOT MATCH.
+PATCHED_WAIT_FOR_QR_CODE_SCAN = (
+    "    async waitForQrCodeScan() {\n"
+    "        if (!this.isStarted) {\n"
+    "            throw new Error('waitForQrCodeScan error: Session not started');\n"
+    "        }\n"
+    "        let probeFailures = 0;\n"
+    "        let probeDeadline = 0;\n"
+    "        while (!this.page.isClosed() && !this.isLogged) {\n"
+    "            await (0, sleep_1.sleep)(200);\n"
+    "            let needScan;\n"
+    "            try {\n"
+    "                needScan = await (0, auth_1.needsToScan)(this.page);\n"
+    "            }\n"
+    "            catch (error) {\n"
+    "                probeFailures++;\n"
+    "                if (!probeDeadline) {\n"
+    "                    probeDeadline = Date.now() + 30000;\n"
+    "                }\n"
+    "                if (probeFailures <= 3 || probeFailures % 20 === 0) {\n"
+    "                    this.log('warn', `Auth probe failed (${probeFailures} in a row, still waiting): ${error?.name || 'Error'}: ${error?.message || error}`);\n"
+    "                }\n"
+    "                if (Date.now() >= probeDeadline) {\n"
+    "                    this.log('error', 'Auth probe has failed for 30s straight — giving up on the scan wait.');\n"
+    "                    return;\n"
+    "                }\n"
+    "                continue;\n"
+    "            }\n"
+    "            probeFailures = 0;\n"
+    "            probeDeadline = 0;\n"
     "            this.isLogged = !needScan;\n"
     "        }\n"
     "    }\n"
@@ -745,39 +882,45 @@ def patch_host_layer_source(content: str):
     notes = []
 
     if PATCHED_CHECK_QR_CODE in content:
-        notes.append("checkQrCode: already at v6.")
+        notes.append("checkQrCode: already at v7.")
+    elif V6_CHECK_QR_CODE in content:
+        content = content.replace(V6_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
+        notes.append(
+            "checkQrCode: upgraded v6 -> v7 — a failed auth probe here no "
+            "longer sets isLogged, which used to end the concurrent scan wait."
+        )
     elif V5_CHECK_QR_CODE in content:
         content = content.replace(V5_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
         notes.append(
-            "checkQrCode: upgraded v5 -> v6 — the pairing code now waits for "
+            "checkQrCode: upgraded v5 -> v7 — the pairing code now waits for "
             "WhatsApp Web's auth state instead of throwing Invariant #56367."
         )
     elif V4_CHECK_QR_CODE in content:
         content = content.replace(V4_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
         notes.append(
-            "checkQrCode: upgraded v4 -> v6 — repeated pairing-code failures "
+            "checkQrCode: upgraded v4 -> v7 — repeated pairing-code failures "
             "now back off, and the code waits for the auth state to exist."
         )
     elif V3_CHECK_QR_CODE in content:
         content = content.replace(V3_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
         notes.append(
-            "checkQrCode: upgraded v3 -> v6 — a pairing-code failure is now "
+            "checkQrCode: upgraded v3 -> v7 — a pairing-code failure is now "
             "reported to the client, not just written to wppconnect.log."
         )
     elif V2_CHECK_QR_CODE in content:
         content = content.replace(V2_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
         notes.append(
-            "checkQrCode: upgraded v2 -> v6 — a failing loginByCode() is now "
+            "checkQrCode: upgraded v2 -> v7 — a failing loginByCode() is now "
             "caught, reported and logged instead of escaping as an unhandled "
             "rejection."
         )
     elif V1_CHECK_QR_CODE in content:
         content = content.replace(V1_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
-        notes.append("checkQrCode: upgraded v1 (unsafe, could freeze forever) -> v6.")
+        notes.append("checkQrCode: upgraded v1 (unsafe, could freeze forever) -> v7.")
     elif ORIGINAL_CHECK_QR_CODE in content:
         content = content.replace(ORIGINAL_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE, 1)
         notes.append(
-            "checkQrCode: patched (v6) — pairing code no longer regenerates on "
+            "checkQrCode: patched (v7) — pairing code no longer regenerates on "
             "every QR rotation (60s reuse cooldown), waits for the auth state, "
             "failures are reported."
         )
@@ -786,6 +929,15 @@ def patch_host_layer_source(content: str):
 
     if PATCHED_WAIT_FOR_QR_CODE_SCAN in content:
         notes.append("waitForQrCodeScan: already retries a failed auth probe.")
+    elif V1_WAIT_FOR_QR_CODE_SCAN in content:
+        content = content.replace(
+            V1_WAIT_FOR_QR_CODE_SCAN, PATCHED_WAIT_FOR_QR_CODE_SCAN, 1
+        )
+        notes.append(
+            "waitForQrCodeScan: upgraded — the give-up bound is the wall "
+            "clock now, not an iteration count that a wedged renderer "
+            "stretched from 30s to hours."
+        )
     elif ORIGINAL_WAIT_FOR_QR_CODE_SCAN in content:
         content = content.replace(
             ORIGINAL_WAIT_FOR_QR_CODE_SCAN, PATCHED_WAIT_FOR_QR_CODE_SCAN, 1

--- a/client/main.py
+++ b/client/main.py
@@ -488,6 +488,72 @@ LEGACY_API_STATE_MARKER = ".migrated_from_install_dir"
 LEGACY_API_STATE_DIRS = ("userDataDir", "tokens")
 
 
+def shorten_windows_path(path: str) -> str:
+    """Return the Windows 8.3 short form of an existing directory, or `path`
+    unchanged when that is not available (non-Windows, path missing, 8.3
+    generation disabled on the volume, or the API failing for any reason).
+
+    This exists for exactly one caller: the Chrome profile root handed to
+    WPPConnect as WINZAPP_USER_DATA_DIR. Chrome builds deep paths inside a
+    profile, and the deepest of them are its Service Worker CacheStorage
+    entries — two 32-character hashed directory names plus `index-dir\\
+    the-real-index`, about 127 characters below the profile root, on top of
+    the profile's own 32-character session name.
+
+    Measured on the install this was found on:
+
+        <global_dir>/api/userDataDir/<session>   profile root 135  -> 262  OVER
+        8.3-shortened equivalent                 profile root  92  -> 219  ok
+
+    MAX_PATH is 260. Over it, Chrome cannot create the CacheStorage entries,
+    WhatsApp Web never gets the persistent storage bucket it needs, and it
+    responds by logging ITSELF out: the page navigates to
+    `/?post_logout=1&logout_reason=0`, wa-js is destroyed with it, and the
+    session loops that roughly every 10s until WPPConnect force-kills it at
+    notLogged. Neither the QR nor the pairing code is ever produced, and
+    nothing in any log says "path too long" — the only visible symptom is the
+    navigation itself.
+
+    This was found by comparing two installs that differed in nothing but
+    this path. The working one passed a cwd-RELATIVE './userDataDir/', which
+    Chrome resolved against a working directory Windows had already handed
+    back in 8.3 form (the install lives under a directory name containing a
+    space), so it was accidentally 31 characters shorter and stayed under the
+    limit. Its profile still *reports* a 262-character path when listed,
+    because Windows reports the long form — which is why measuring the
+    directory after the fact says the opposite of what Chrome experienced,
+    and cost a wrong "MAX_PATH is ruled out" along the way.
+
+    Shortening is best-effort on purpose. 8.3 generation can be turned off
+    per volume (`fsutil 8dot3name`), in which case this returns the long path
+    and the caller is no worse off than before.
+    """
+    if os.name != "nt" or not path:
+        return path
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        _GetShortPathNameW = ctypes.windll.kernel32.GetShortPathNameW
+        _GetShortPathNameW.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
+        _GetShortPathNameW.restype = wintypes.DWORD
+
+        needed = _GetShortPathNameW(path, None, 0)
+        if not needed:
+            return path
+        buf = ctypes.create_unicode_buffer(needed)
+        if not _GetShortPathNameW(path, buf, needed):
+            return path
+        short = buf.value or path
+        if short != path:
+            logging.info("[paths] shortened %s -> %s (%d -> %d chars)",
+                         path, short, len(path), len(short))
+        return short
+    except Exception:
+        logging.exception("[paths] could not shorten %s — using it as-is", path)
+        return path
+
+
 def migrate_legacy_api_state(legacy_api_dir: str, persistent_api_dir: str) -> list:
     """Move a pre-existing install's WhatsApp session state from the old,
     cwd-relative location into the new persistent one. Returns what moved.
@@ -7239,7 +7305,15 @@ class MainWindow(wx.Frame):
                 # ever changes.
                 _persistent_api_dir = os.path.join(self.global_dir, "api")
                 _token_dir = os.path.join(_persistent_api_dir, "tokens")
-                os.environ["WINZAPP_USER_DATA_DIR"] = os.path.join(_persistent_api_dir, "userDataDir") + os.sep
+                _udd = os.path.join(_persistent_api_dir, "userDataDir")
+                # The long forms go in FIRST and unconditionally. Everything
+                # below this line can raise, and a launch that reaches Node
+                # with neither variable set is the worst outcome available:
+                # config.ts falls back to './userDataDir/' relative to Node's
+                # cwd, which in a --onefile build is PyInstaller's per-launch
+                # temp dir, so the paired session is orphaned on exit. Being
+                # long is survivable; being unset is not.
+                os.environ["WINZAPP_USER_DATA_DIR"] = _udd + os.sep
                 os.environ["WINZAPP_TOKEN_STORE_DIR"] = _token_dir
                 # One-time move of an ALREADY PAIRED install's session state
                 # from the old cwd-relative location. Without it, every
@@ -7249,6 +7323,37 @@ class MainWindow(wx.Frame):
                 # Node not yet spawned, because moving a userDataDir out from
                 # under a live Chrome would corrupt it.
                 migrate_legacy_api_state(resource_path("api"), _persistent_api_dir)
+                # Only NOW may these be created. migrate_legacy_api_state()
+                # skips any folder that already exists at the destination —
+                # deliberately, since one being there means this install is
+                # already on the new location — and then writes its
+                # run-once marker even when nothing needed moving. Creating
+                # them beforehand therefore does not just skip the move, it
+                # makes the skip PERMANENT: an already-paired install is
+                # pointed at a virgin profile, asked to pair again, and the
+                # real one is stranded under resource_path("api") with the
+                # marker guaranteeing no retry. That is the exact report the
+                # migration exists to prevent, delivered by its own fix.
+                #
+                # They have to exist at all because shorten_windows_path()
+                # wraps a Win32 call that resolves a real directory entry and
+                # returns the long path untouched for one that is not there.
+                os.makedirs(_udd, exist_ok=True)
+                os.makedirs(_token_dir, exist_ok=True)
+                # Shorten only the ANCESTOR, never the whole path: 8.3
+                # rewrites every component over 8 characters, and
+                # "userDataDir" is 11. Losing that literal breaks the two
+                # places that identify a session's Chrome by matching it in a
+                # command line — chrome_cmdline_owns_session()
+                # (client/connection_state.py) and forceKillByUserDataDir()
+                # (api_patches/src/util/createSessionUtil.ts) — and both fail
+                # by matching NOTHING, so a stale Chrome holding the profile
+                # lock is never killed and the session hangs in INITIALIZING.
+                # Keeping the component costs 3 characters of the 43 saved.
+                os.environ["WINZAPP_USER_DATA_DIR"] = os.path.join(
+                    shorten_windows_path(_persistent_api_dir), "userDataDir"
+                ) + os.sep
+                os.environ["WINZAPP_TOKEN_STORE_DIR"] = shorten_windows_path(_token_dir)
             except Exception:
                 logging.exception("[startup] persistent userDataDir/token-store env injection failed (non-fatal)")
 

--- a/client/ui/dialogs/api_setup.py
+++ b/client/ui/dialogs/api_setup.py
@@ -152,6 +152,20 @@ _PATCHED_DEPENDENCY_KEYS = [
     "zod",  # runtime schema for the sync endpoints' response contracts
             # (src/dto/sync.ts). Declared here because the controllers import
             # it at runtime — it is not a build-only tool.
+    "qrcode",  # required at runtime by WinZapp's own getQrCode patch to
+               # host.layer.js (client/core/wppconnect_host_layer_patch.py),
+               # which renders the QR PNG from the payload wa-js returns
+               # instead of scraping it out of the DOM. Same shape as
+               # prom-client above: upstream wppconnect-server declares it
+               # today, but the wppconnect library whose node_modules our
+               # patched file lives in does not, so the require() only
+               # resolves via npm hoisting. (The library is deliberately not
+               # named in full here — test_wppconnect_itself_is_no_longer_pinned
+               # greps this block for it to prove nobody re-pinned it.) If
+               # upstream drops it the patch degrades silently: base64Image comes back
+               # empty, websocket_client.py discards the event as carrying
+               # nothing usable, and the user watches an empty QR box with
+               # only a log line to show for it.
     "@ffmpeg-installer/ffmpeg",  # vendors a real ffmpeg binary — WinZapp's own
                                   # Python side shells out to it directly to
                                   # encode voice messages to OGG/Opus.

--- a/setup_api.py
+++ b/setup_api.py
@@ -193,6 +193,20 @@ _PATCHED_DEPENDENCY_KEYS = [
     "zod",  # runtime schema for the sync endpoints' response contracts
             # (src/dto/sync.ts). Declared here because the controllers import
             # it at runtime — it is not a build-only tool.
+    "qrcode",  # required at runtime by WinZapp's own getQrCode patch to
+               # host.layer.js (client/core/wppconnect_host_layer_patch.py),
+               # which renders the QR PNG from the payload wa-js returns
+               # instead of scraping it out of the DOM. Same shape as
+               # prom-client above: upstream wppconnect-server declares it
+               # today, but the wppconnect library whose node_modules our
+               # patched file lives in does not, so the require() only
+               # resolves via npm hoisting. (The library is deliberately not
+               # named in full here — test_wppconnect_itself_is_no_longer_pinned
+               # greps this block for it to prove nobody re-pinned it.) If
+               # upstream drops it the patch degrades silently: base64Image comes back
+               # empty, websocket_client.py discards the event as carrying
+               # nothing usable, and the user watches an empty QR box with
+               # only a log line to show for it.
     "@ffmpeg-installer/ffmpeg",  # vendors a real ffmpeg binary via npm — WinZapp's
                                   # own Python side shells out to it directly
                                   # (main.py: _find_api_ffmpeg/_convert_wav_to_ogg)

--- a/tests/test_legacy_api_state_migration.py
+++ b/tests/test_legacy_api_state_migration.py
@@ -20,7 +20,9 @@ so the tests below are mostly about what it must refuse to do.
 import os
 
 from main import (
+    LEGACY_API_STATE_DIRS,
     LEGACY_API_STATE_MARKER,
+    MainWindow,
     migrate_legacy_api_state,
 )
 
@@ -134,3 +136,57 @@ class TestItIsWiredIntoStartup:
         assert src.index("migrate_legacy_api_state(") < src.index("subprocess.Popen("), (
             "the migration must run before Node is spawned"
         )
+
+
+class TestNothingMayPreCreateTheDestination:
+    """The migration skips any folder already present at the destination —
+    deliberately, since one being there means this install is already on the
+    new location. It then writes its run-once marker even when nothing moved.
+
+    So creating those folders before it runs does not merely skip the move,
+    it makes the skip PERMANENT. An already-paired install gets a virgin
+    Chrome profile, is asked to pair again, and its real profile is stranded
+    under the old location with the marker guaranteeing no retry — the exact
+    report this migration was written to prevent, delivered by its own fix.
+
+    This nearly shipped: two `os.makedirs` calls were added just above the
+    call, to satisfy a Win32 path-shortening helper that needs a real
+    directory entry. Ordering was the only thing wrong with them.
+    """
+
+    def test_an_empty_pre_created_destination_permanently_blocks_the_move(self, tmp_path):
+        """States the bug as a test: this is what pre-creating causes."""
+        legacy = tmp_path / "install" / "api"
+        (legacy / "userDataDir" / "session-a").mkdir(parents=True)
+        (legacy / "tokens").mkdir(parents=True)
+        persistent = tmp_path / "global" / "api"
+        for name in LEGACY_API_STATE_DIRS:
+            (persistent / name).mkdir(parents=True)
+
+        moved = migrate_legacy_api_state(str(legacy), str(persistent))
+
+        assert moved == []
+        assert (legacy / "userDataDir" / "session-a").is_dir(), "profile stranded"
+        assert (persistent / LEGACY_API_STATE_MARKER).is_file(), (
+            "and the marker is written anyway, so no launch ever retries"
+        )
+
+    def test_the_directories_are_created_only_after_the_migration(self):
+        """A source-order assertion because the failure is invisible at
+        runtime: nothing raises, nothing logs, the session simply comes up
+        unpaired once and never recovers."""
+        import inspect
+        src = inspect.getsource(MainWindow._start_wpp_background)
+        assert src.index("migrate_legacy_api_state(") < src.index("os.makedirs(_udd"), (
+            "os.makedirs(_udd) runs before migrate_legacy_api_state(), which "
+            "makes the migration skip every folder and then write its marker"
+        )
+
+    def test_the_env_vars_are_set_before_anything_that_can_raise(self):
+        """They are assigned twice on purpose: the long forms first and
+        unconditionally, the shortened ones after the directories exist. A
+        launch that reaches Node with neither set falls back to a cwd-relative
+        profile, which a --onefile build loses on every exit."""
+        import inspect
+        src = inspect.getsource(MainWindow._start_wpp_background)
+        assert src.index('os.environ["WINZAPP_USER_DATA_DIR"]') < src.index("os.makedirs(_udd")

--- a/tests/test_pairing_code_patch.py
+++ b/tests/test_pairing_code_patch.py
@@ -36,7 +36,18 @@ Timeline:
   same generic "no pairing code received" after 90 seconds. The end-to-end
   path is covered by tests/test_pairing_code_error_reporting.py.
 
-* v5 (current): a doubling backoff between consecutive failures. v2's cooldown
+* v6 (current): the phoneNumber branch waits for WhatsApp Web's auth state
+  before calling the link-device API, and getQrCode() reads the payload from
+  wa-js instead of scraping the DOM. Both pairing routes were dead at the same
+  time for unrelated reasons that looked identical from the outside (nothing
+  appears on screen): the code threw Invariant Violation #56367 because v1..v5
+  had hoisted its branch above the `await this.getQrCode()` that used to
+  guarantee the auth state existed, and the QR emitted nothing because
+  upstream's scraper looks for a <canvas> WhatsApp Web no longer renders —
+  landing instead on the download banner's `https://wa.me/...` data-ref, which
+  is not a login payload at all.
+
+* v5: a doubling backoff between consecutive failures. v2's cooldown
   only ever gates a success, so a run of failures was paced by nothing at all —
   measured live at one attempt every 20 seconds, nine and counting, which for a
   failure that is plausibly rate-limiting made the problem self-sustaining.
@@ -55,7 +66,9 @@ import pytest
 
 from core.wppconnect_host_layer_patch import (
     ORIGINAL_CHECK_QR_CODE, V1_CHECK_QR_CODE, V2_CHECK_QR_CODE,
-    V3_CHECK_QR_CODE, V4_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE,
+    V3_CHECK_QR_CODE, V4_CHECK_QR_CODE, V5_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE,
+    ORIGINAL_GET_QR_CODE, PATCHED_GET_QR_CODE,
+    ORIGINAL_WAIT_FOR_QR_CODE_SCAN, PATCHED_WAIT_FOR_QR_CODE_SCAN,
     ORIGINAL_LOGIN_BY_CODE, LEGACY_LOGIN_BY_CODE_RAW, PATCHED_LOGIN_BY_CODE,
 )
 
@@ -82,20 +95,24 @@ def fake_wppconnect_dist(tmp_path):
     return tmp_path, host_layer
 
 
-def _write(host_layer, checkqrcode_text, loginbycode_text=ORIGINAL_LOGIN_BY_CODE):
+def _write(host_layer, checkqrcode_text, loginbycode_text=ORIGINAL_LOGIN_BY_CODE,
+           getqrcode_text=ORIGINAL_GET_QR_CODE,
+           waitforscan_text=ORIGINAL_WAIT_FOR_QR_CODE_SCAN):
     """Wrap the (v0/v1/v2/v3) checkQrCode() body in enough surrounding class
     boilerplate to look like the real compiled file, without needing the
     other unrelated methods.
 
-    loginByCode() comes from the shared constants verbatim rather than being
-    paraphrased here: the patcher rewrites that method too, so an
-    approximate copy would make every test in this file see a spurious
-    "DID NOT MATCH" for a file the real patcher handles fine."""
+    loginByCode() and getQrCode() come from the shared constants verbatim
+    rather than being paraphrased here: the patcher rewrites those methods
+    too, so an approximate copy would make every test in this file see a
+    spurious "DID NOT MATCH" for a file the real patcher handles fine."""
     host_layer.write_text(
         "class HostLayer {\n"
         "    urlCode = '';\n"
         "    attempt = 0;\n"
         + checkqrcode_text
+        + getqrcode_text
+        + waitforscan_text
         + loginbycode_text +
         "}\n",
         encoding="utf-8",
@@ -690,3 +707,162 @@ class TestManagedLinkingApiMigration:
             outputs.append(host_layer.read_text(encoding="utf-8"))
 
         assert outputs[0] == outputs[1]
+
+
+class TestV6WaitsForTheAuthStateBeforeAskingForACode:
+    """v1..v5 hoisted the phoneNumber branch above `await this.getQrCode()`
+    to stop the pairing code regenerating on every rotation, and in doing so
+    dropped the only thing that kept the call safe: upstream only ever
+    reached loginByCode() once a urlCode existed, which is also when
+    WhatsApp Web's user-prefs storage is initialised. Without that, wa-js
+    walks setADVSecretKey -> getStorage into an uninitialised table and
+    WhatsApp Web throws Invariant Violation #56367 — both pairing routes
+    dead, nothing on screen, and the real error swallowed."""
+
+    def test_the_gate_runs_before_login_by_code(self):
+        gate = PATCHED_CHECK_QR_CODE.index("const ready = await this.getQrCode();")
+        login_call = PATCHED_CHECK_QR_CODE.index(
+            "await this.loginByCode(this.options.phoneNumber);"
+        )
+        assert gate < login_call
+
+    def test_a_missing_auth_code_defers_instead_of_calling(self):
+        """Returning (not throwing, not calling anyway) matters: checkQrCode is
+        bound to the auth-code rotation, so a deferral is retried for free on
+        the next tick — while calling anyway is the invariant."""
+        assert "if (!ready?.urlCode) {" in PATCHED_CHECK_QR_CODE
+        gate = PATCHED_CHECK_QR_CODE.index("if (!ready?.urlCode) {")
+        login_call = PATCHED_CHECK_QR_CODE.index(
+            "await this.loginByCode(this.options.phoneNumber);"
+        )
+        deferred_return = PATCHED_CHECK_QR_CODE.index("return;", gate)
+        assert deferred_return < login_call
+
+    def test_the_gate_does_not_cost_the_v5_cooldown(self):
+        """The cooldown/backoff checks must still run BEFORE the gate: probing
+        the auth state on every rotation while a code is already valid would
+        undo v4/v5 and hammer WhatsApp for nothing."""
+        cooldown = PATCHED_CHECK_QR_CODE.index("this.linkCodeIssuedAt && (now - this.linkCodeIssuedAt) < 60000")
+        backoff = PATCHED_CHECK_QR_CODE.index("this.linkCodeRetryAfter && now < this.linkCodeRetryAfter")
+        gate = PATCHED_CHECK_QR_CODE.index("const ready = await this.getQrCode();")
+        assert cooldown < gate
+        assert backoff < gate
+
+    def test_v5_is_recognised_and_upgraded(self, fake_wppconnect_dist):
+        setup_api = _load_setup_api()
+        api_dir, host_layer = fake_wppconnect_dist
+        _write(host_layer, V5_CHECK_QR_CODE, PATCHED_LOGIN_BY_CODE)
+
+        assert setup_api._patch_wppconnect_host_layer(str(api_dir)) is True
+        content = host_layer.read_text(encoding="utf-8")
+        assert PATCHED_CHECK_QR_CODE in content
+        assert V5_CHECK_QR_CODE not in content
+
+    def test_v5_and_v6_are_distinct(self):
+        assert V5_CHECK_QR_CODE != PATCHED_CHECK_QR_CODE
+
+
+class TestGetQrCodeReadsWaJsNotTheDom:
+    """Upstream scrapes `document.querySelector('canvas').closest('[data-ref]')`.
+    Current WhatsApp Web often has no <canvas> when that runs, and once it
+    does the nearest data-ref ancestor is the download / "link with phone
+    number instead" banner, whose data-ref is a wa.me URL — so the emitted
+    payload was not a login code at all, and a phone could never pair from
+    it. A real payload starts with `2@`."""
+
+    def test_the_dom_scraper_is_gone(self):
+        assert "scrapeImg" in ORIGINAL_GET_QR_CODE
+        assert "scrapeImg" not in PATCHED_GET_QR_CODE
+        assert "querySelector" not in PATCHED_GET_QR_CODE
+
+    def test_it_reads_the_auth_code_from_wa_js(self):
+        assert "WPP.conn.getAuthCode()" in PATCHED_GET_QR_CODE
+        assert "urlCode: auth.fullCode" in PATCHED_GET_QR_CODE
+
+    def test_the_png_carries_no_quiet_zone(self):
+        """connect.py's display_qrcode_image() adds its own quiet zone and then
+        magnifies by a whole integer factor with nearest-neighbour, and
+        documents that it is fed a borderless image. A margin here would
+        double the border and shrink the modules — the exact shape of the
+        "QR Code inválido" that scaling code already exists to prevent."""
+        assert "margin: 0" in PATCHED_GET_QR_CODE
+
+    def test_a_missing_auth_code_returns_undefined(self):
+        """checkQrCode's own `!result?.urlCode` guard — and now the v6 pairing
+        gate — both depend on this returning a falsy result rather than a
+        half-built object when the auth state is not up yet."""
+        assert "return undefined;" in PATCHED_GET_QR_CODE
+
+    def test_a_pristine_install_is_patched(self, fake_wppconnect_dist):
+        setup_api = _load_setup_api()
+        api_dir, host_layer = fake_wppconnect_dist
+        _write(host_layer, ORIGINAL_CHECK_QR_CODE, ORIGINAL_LOGIN_BY_CODE,
+               ORIGINAL_GET_QR_CODE)
+
+        assert setup_api._patch_wppconnect_host_layer(str(api_dir)) is True
+        content = host_layer.read_text(encoding="utf-8")
+        assert PATCHED_GET_QR_CODE in content
+        assert ORIGINAL_GET_QR_CODE not in content
+
+    def test_reapplying_is_idempotent(self, fake_wppconnect_dist):
+        setup_api = _load_setup_api()
+        api_dir, host_layer = fake_wppconnect_dist
+        _write(host_layer, ORIGINAL_CHECK_QR_CODE, ORIGINAL_LOGIN_BY_CODE,
+               ORIGINAL_GET_QR_CODE)
+
+        setup_api._patch_wppconnect_host_layer(str(api_dir))
+        once = host_layer.read_text(encoding="utf-8")
+        setup_api._patch_wppconnect_host_layer(str(api_dir))
+        assert host_layer.read_text(encoding="utf-8") == once
+
+
+class TestWaitForQrCodeScanDoesNotMistakeAFailedProbeForALogin:
+    """`this.isLogged = !needScan` where needScan came from
+    `.catch(() => null)` reads "we could not find out" as "the user has
+    logged in" — the strongest possible claim from the one value that
+    carries no information. The scan wait then exits early, waitForLogin()
+    re-probes, gets null again, and reports `Failed to authenticate` with
+    the actual browser-side error written down nowhere."""
+
+    def test_the_swallowing_catch_is_gone(self):
+        assert ".catch(() => null)" in ORIGINAL_WAIT_FOR_QR_CODE_SCAN
+        assert ".catch(() => null)" not in PATCHED_WAIT_FOR_QR_CODE_SCAN
+
+    def test_a_failed_probe_keeps_waiting_instead_of_declaring_a_login(self):
+        """The assignment must be unreachable from the failure path: on a
+        throw we `continue`, so isLogged is never written from a probe that
+        did not actually answer."""
+        catch_block = PATCHED_WAIT_FOR_QR_CODE_SCAN.index("catch (error) {")
+        continue_stmt = PATCHED_WAIT_FOR_QR_CODE_SCAN.index("continue;", catch_block)
+        assignment = PATCHED_WAIT_FOR_QR_CODE_SCAN.index("this.isLogged = !needScan;")
+        assert catch_block < continue_stmt < assignment
+
+    def test_the_real_error_is_logged(self):
+        assert "Auth probe failed" in PATCHED_WAIT_FOR_QR_CODE_SCAN
+        assert "error?.message" in PATCHED_WAIT_FOR_QR_CODE_SCAN
+
+    def test_a_permanently_broken_probe_still_gives_up(self):
+        """Retrying forever would replace a wrong answer with a hang, which
+        for a pairing dialog is no better. The bound is generous enough to
+        ride out a navigation but finite, and it says why it stopped."""
+        assert "probeFailures >= 150" in PATCHED_WAIT_FOR_QR_CODE_SCAN
+        assert "giving up on the scan wait" in PATCHED_WAIT_FOR_QR_CODE_SCAN
+
+    def test_a_successful_probe_resets_the_failure_run(self):
+        """Otherwise a session that hiccups once every few minutes would
+        eventually cross the give-up threshold for no reason."""
+        assert "probeFailures = 0;" in PATCHED_WAIT_FOR_QR_CODE_SCAN
+        reset = PATCHED_WAIT_FOR_QR_CODE_SCAN.rindex("probeFailures = 0;")
+        assignment = PATCHED_WAIT_FOR_QR_CODE_SCAN.index("this.isLogged = !needScan;")
+        assert reset < assignment
+
+    def test_a_pristine_install_is_patched(self, fake_wppconnect_dist):
+        setup_api = _load_setup_api()
+        api_dir, host_layer = fake_wppconnect_dist
+        _write(host_layer, ORIGINAL_CHECK_QR_CODE, ORIGINAL_LOGIN_BY_CODE,
+               ORIGINAL_GET_QR_CODE, ORIGINAL_WAIT_FOR_QR_CODE_SCAN)
+
+        assert setup_api._patch_wppconnect_host_layer(str(api_dir)) is True
+        content = host_layer.read_text(encoding="utf-8")
+        assert PATCHED_WAIT_FOR_QR_CODE_SCAN in content
+        assert ORIGINAL_WAIT_FOR_QR_CODE_SCAN not in content

--- a/tests/test_pairing_code_patch.py
+++ b/tests/test_pairing_code_patch.py
@@ -66,7 +66,8 @@ import pytest
 
 from core.wppconnect_host_layer_patch import (
     ORIGINAL_CHECK_QR_CODE, V1_CHECK_QR_CODE, V2_CHECK_QR_CODE,
-    V3_CHECK_QR_CODE, V4_CHECK_QR_CODE, V5_CHECK_QR_CODE, PATCHED_CHECK_QR_CODE,
+    V3_CHECK_QR_CODE, V4_CHECK_QR_CODE, V5_CHECK_QR_CODE, V6_CHECK_QR_CODE,
+    PATCHED_CHECK_QR_CODE,
     ORIGINAL_GET_QR_CODE, PATCHED_GET_QR_CODE,
     ORIGINAL_WAIT_FOR_QR_CODE_SCAN, PATCHED_WAIT_FOR_QR_CODE_SCAN,
     ORIGINAL_LOGIN_BY_CODE, LEGACY_LOGIN_BY_CODE_RAW, PATCHED_LOGIN_BY_CODE,
@@ -342,7 +343,9 @@ class TestV3CatchesPairingCodeFailures:
         auth_code_change tick retries."""
         issued_at = PATCHED_CHECK_QR_CODE.index("this.linkCodeIssuedAt = Date.now();")
         login_call = PATCHED_CHECK_QR_CODE.index("await this.loginByCode(this.options.phoneNumber);")
-        catch_block = PATCHED_CHECK_QR_CODE.index("catch (error) {")
+        # Anchored AFTER the call: v7 added a catch at the head of the
+        # method, so the first occurrence is no longer this branch's.
+        catch_block = PATCHED_CHECK_QR_CODE.index("catch (error) {", login_call)
         assert login_call < issued_at < catch_block
 
     def test_every_checkqrcode_generation_is_distinct(self):
@@ -388,7 +391,9 @@ class TestV4ReportsTheFailureToTheClient:
     def test_v4_still_never_permanently_latches(self):
         issued_at = PATCHED_CHECK_QR_CODE.index("this.linkCodeIssuedAt = Date.now();")
         login_call = PATCHED_CHECK_QR_CODE.index("await this.loginByCode(this.options.phoneNumber);")
-        catch_block = PATCHED_CHECK_QR_CODE.index("catch (error) {")
+        # Anchored AFTER the call: v7 added a catch at the head of the
+        # method, so the first occurrence is no longer this branch's.
+        catch_block = PATCHED_CHECK_QR_CODE.index("catch (error) {", login_call)
         assert login_call < issued_at < catch_block
 
 
@@ -560,7 +565,10 @@ class TestV5BacksOffBetweenFailures:
     def test_a_success_resets_the_failure_count_and_deadline(self):
         try_block = PATCHED_CHECK_QR_CODE[
             PATCHED_CHECK_QR_CODE.index("await this.loginByCode(this.options.phoneNumber);")
-            : PATCHED_CHECK_QR_CODE.index("catch (error) {")
+            : PATCHED_CHECK_QR_CODE.index(
+                "catch (error) {",
+                PATCHED_CHECK_QR_CODE.index("await this.loginByCode(this.options.phoneNumber);"),
+            )
         ]
         assert "this.linkCodeFailures = 0;" in try_block
         assert "this.linkCodeRetryAfter = 0;" in try_block
@@ -845,13 +853,22 @@ class TestWaitForQrCodeScanDoesNotMistakeAFailedProbeForALogin:
         """Retrying forever would replace a wrong answer with a hang, which
         for a pairing dialog is no better. The bound is generous enough to
         ride out a navigation but finite, and it says why it stopped."""
-        assert "probeFailures >= 150" in PATCHED_WAIT_FOR_QR_CODE_SCAN
         assert "giving up on the scan wait" in PATCHED_WAIT_FOR_QR_CODE_SCAN
+        # Bounded by the WALL CLOCK, not by an iteration count. Each probe
+        # goes through page.evaluate under a 300s protocolTimeout, so a
+        # wedged renderer makes "150 iterations" mean 12.5 hours while the
+        # log line claims 30 seconds.
+        assert "Date.now() >= probeDeadline" in PATCHED_WAIT_FOR_QR_CODE_SCAN
+        assert "probeFailures >= 150" not in PATCHED_WAIT_FOR_QR_CODE_SCAN
 
     def test_a_successful_probe_resets_the_failure_run(self):
         """Otherwise a session that hiccups once every few minutes would
         eventually cross the give-up threshold for no reason."""
         assert "probeFailures = 0;" in PATCHED_WAIT_FOR_QR_CODE_SCAN
+        # The deadline has to be cleared alongside the counter, or a
+        # run that recovers keeps an armed deadline and the NEXT
+        # failure gives up against a clock that started minutes ago.
+        assert "probeDeadline = 0;" in PATCHED_WAIT_FOR_QR_CODE_SCAN
         reset = PATCHED_WAIT_FOR_QR_CODE_SCAN.rindex("probeFailures = 0;")
         assignment = PATCHED_WAIT_FOR_QR_CODE_SCAN.index("this.isLogged = !needScan;")
         assert reset < assignment
@@ -866,3 +883,45 @@ class TestWaitForQrCodeScanDoesNotMistakeAFailedProbeForALogin:
         content = host_layer.read_text(encoding="utf-8")
         assert PATCHED_WAIT_FOR_QR_CODE_SCAN in content
         assert ORIGINAL_WAIT_FOR_QR_CODE_SCAN not in content
+
+
+class TestV7ClosesTheSameHoleInCheckQrCode:
+    """waitForQrCodeScan stopped reading a failed probe as "the user logged
+    in", but checkQrCode's own first two lines still did exactly that — and
+    it runs CONCURRENTLY, invoked from the page on every auth-code rotation.
+    One failed probe there set isLogged, and the scan wait this patch series
+    had just made honest exited on its very next check."""
+
+    def test_the_swallowing_catch_is_gone_from_the_head(self):
+        head = PATCHED_CHECK_QR_CODE[:PATCHED_CHECK_QR_CODE.index("if (!needScan)")]
+        assert ".catch(() => null)" in V6_CHECK_QR_CODE
+        assert ".catch(() => null)" not in head
+
+    def test_a_failed_probe_leaves_is_logged_alone(self):
+        """Returning without writing isLogged is the whole point: the next
+        rotation re-enters for free, whereas writing it ends someone else's
+        loop."""
+        # The FIRST catch is the head one v7 added — that is the one
+        # under test here, not the pairing-code branch's.
+        catch_block = PATCHED_CHECK_QR_CODE.index("catch (error) {")
+        early_return = PATCHED_CHECK_QR_CODE.index("return;", catch_block)
+        assignment = PATCHED_CHECK_QR_CODE.index("this.isLogged = !needScan;")
+        assert catch_block < early_return < assignment
+
+    def test_v6_is_recognised_and_upgraded(self, fake_wppconnect_dist):
+        setup_api = _load_setup_api()
+        api_dir, host_layer = fake_wppconnect_dist
+        _write(host_layer, V6_CHECK_QR_CODE, PATCHED_LOGIN_BY_CODE,
+               PATCHED_GET_QR_CODE, PATCHED_WAIT_FOR_QR_CODE_SCAN)
+
+        assert setup_api._patch_wppconnect_host_layer(str(api_dir)) is True
+        content = host_layer.read_text(encoding="utf-8")
+        assert PATCHED_CHECK_QR_CODE in content
+        assert V6_CHECK_QR_CODE not in content
+
+    def test_v6_and_v7_differ_only_in_that_head(self):
+        """Guards the upgrade arm: if a future edit changes the body too, the
+        v6 -> v7 replacement silently stops matching real installs."""
+        marker = "if (!needScan) {"
+        assert (V6_CHECK_QR_CODE[V6_CHECK_QR_CODE.index(marker):]
+                == PATCHED_CHECK_QR_CODE[PATCHED_CHECK_QR_CODE.index(marker):])

--- a/tests/test_pinned_page_interception.py
+++ b/tests/test_pinned_page_interception.py
@@ -61,6 +61,7 @@ const apiDir = process.argv[2];
 
 const out = {
   fetchEnableSent: false,
+  fetchPatterns: [],
   versionPassedOnward: 'INIT_WHATSAPP_NEVER_CALLED',
   error: null,
 };
@@ -92,10 +93,24 @@ browser.initWhatsapp = async function (page, token, clear, version) {
 require(path.join(apiDir, 'start.js'));
 
 const cdp = {
-  send: async (method) => { if (method === 'Fetch.enable') out.fetchEnableSent = true; },
+  send: async (method, params) => {
+    if (method === 'Fetch.enable') {
+      out.fetchEnableSent = true;
+      out.fetchPatterns = (params && params.patterns) || [];
+    }
+  },
   on: () => {},
 };
-const page = { createCDPSession: async () => cdp };
+// A real puppeteer Page is an EventEmitter that also exposes mainFrame();
+// start.js subscribes to 'framenavigated' to record reloads, so a stub
+// without these makes the interception install throw and silently fall back
+// to WPPConnect's blanket one — which is exactly what these tests exist to
+// catch, so the stub has to be faithful enough not to trigger it spuriously.
+const page = {
+  createCDPSession: async () => cdp,
+  on: () => {},
+  mainFrame: () => ({ url: () => 'https://web.whatsapp.com/' }),
+};
 
 const waVersion = require(require.resolve('@wppconnect/wa-version', { paths: [path.dirname(wppEntry)] }));
 const versions = waVersion.getAvailableVersions();
@@ -215,3 +230,48 @@ class TestTheSourceItself:
         if not (API / "start.js").exists():
             pytest.skip("client/api/ not set up here")
         assert (API / "start.js").read_bytes() == (PATCHES / "start.js").read_bytes()
+
+
+class TestTheDocumentPatternStaysAnExactMatch:
+    """Widening this pattern is a trap that has already been walked into once.
+
+    WhatsApp Web navigates itself to
+    `https://web.whatsapp.com/?post_logout=1&logout_reason=0` on a fresh
+    unpaired profile, which the exact-match pattern does not cover. Making it
+    cover that (an origin-wide glob scoped to `resourceType: 'Document'`) looks
+    like the obvious fix and breaks pairing outright: the page is force-fed the
+    pinned document on the very navigation it is using to restart itself, so it
+    loops every ~10s until WPPConnect force-kills the session at notLogged, and
+    neither the QR nor the pairing code ever appears. With the exact match, the
+    QR arrives about 12s after start-session."""
+
+    def test_the_document_pattern_is_an_exact_match(self, tmp_path):
+        result = _run_harness(tmp_path)
+        assert result["error"] is None, result["error"]
+        doc_patterns = [
+            p for p in result["fetchPatterns"]
+            if "web.whatsapp.com" in p.get("urlPattern", "")
+            and "check-update" not in p.get("urlPattern", "")
+        ]
+        assert doc_patterns, f"no document pattern at all: {result['fetchPatterns']}"
+        for pattern in doc_patterns:
+            assert not pattern["urlPattern"].endswith("*"), (
+                f"urlPattern {pattern['urlPattern']!r} is a glob. That re-serves the "
+                "pinned document on WhatsApp Web's own ?post_logout navigation and "
+                "puts the session into the reload loop. See this class's docstring."
+            )
+
+    def test_the_post_logout_url_is_deliberately_not_matched(self, tmp_path):
+        """Asserted against the real URL taken from a live log, so the intent
+        is unmistakable to whoever reads this next: that navigation is meant
+        to reach the network untouched."""
+        import fnmatch
+        result = _run_harness(tmp_path)
+        assert result["error"] is None, result["error"]
+        post_logout = "https://web.whatsapp.com/?post_logout=1&logout_reason=0"
+        for pattern in result["fetchPatterns"]:
+            if "check-update" in pattern.get("urlPattern", ""):
+                continue
+            assert not fnmatch.fnmatchcase(post_logout, pattern["urlPattern"]), (
+                f"{post_logout!r} must NOT match {pattern['urlPattern']!r}"
+            )

--- a/tests/test_windows_path_shortening.py
+++ b/tests/test_windows_path_shortening.py
@@ -1,0 +1,140 @@
+"""shorten_windows_path() — the Chrome profile root must stay under MAX_PATH.
+
+Why this exists: Chrome's deepest per-profile paths are its Service Worker
+CacheStorage entries, roughly 127 characters below the profile root. Add a
+32-character session name and an install that lives a few directories down,
+and the total crosses Windows' 260-character MAX_PATH. Chrome then cannot
+create those entries, WhatsApp Web never gets its persistent storage bucket,
+and it logs ITSELF out — the page navigates to `?post_logout=1&logout_reason=0`,
+taking wa-js with it, and loops until WPPConnect force-kills the session. No
+log anywhere says "path too long"; the navigation is the only symptom.
+
+Two installs that differed in nothing else produced 262 vs 219 characters,
+and only the 219 one could ever show a QR.
+"""
+
+import os
+
+import pytest
+
+from main import shorten_windows_path
+
+
+# The real shape, measured on the install where this was found: two hashed
+# 32-character directories plus Chrome's own index naming.
+_CHROME_SW_SUFFIX = (
+    os.sep.join(["", "Default", "Service Worker", "CacheStorage",
+                 "b" * 32, "c" * 32, "index-dir", "the-real-index"])
+)
+MAX_PATH = 260
+
+
+class TestItNeverMakesThingsWorse:
+    """Best-effort by design: 8.3 generation can be disabled per volume, and
+    the caller must be no worse off than before when it is."""
+
+    def test_it_never_returns_a_longer_path(self, tmp_path):
+        result = shorten_windows_path(str(tmp_path))
+        assert len(result) <= len(str(tmp_path))
+
+    def test_it_never_returns_empty_for_a_real_directory(self, tmp_path):
+        assert shorten_windows_path(str(tmp_path))
+
+    def test_an_empty_path_is_returned_unchanged(self):
+        assert shorten_windows_path("") == ""
+
+    def test_a_missing_directory_is_returned_unchanged(self, tmp_path):
+        """The Win32 call resolves a real directory entry, so a path that is
+        not there yet cannot be shortened — the caller creates the directory
+        first precisely because of this."""
+        missing = str(tmp_path / "not-created-yet")
+        assert shorten_windows_path(missing) == missing
+
+    def test_it_still_points_at_the_same_directory(self, tmp_path):
+        """8.3 is an alias, not a copy. Everything else in main.py checks
+        these directories through the long form, so the two must resolve to
+        one directory or those checks would silently stop finding anything."""
+        marker = tmp_path / "marker.txt"
+        marker.write_text("x", encoding="utf-8")
+        short = shorten_windows_path(str(tmp_path))
+        assert os.path.isfile(os.path.join(short, "marker.txt"))
+        assert os.path.samefile(short, str(tmp_path))
+
+
+@pytest.mark.skipif(os.name != "nt", reason="8.3 short names are Windows-only")
+class TestItActuallyShortensAPathWithSpaces:
+    """The install this was found on lives under a directory name containing
+    a space, which is exactly when Windows keeps an 8.3 alias around."""
+
+    def test_a_spaced_directory_name_gets_shortened(self, tmp_path):
+        spaced = tmp_path / "code troopers with spaces"
+        spaced.mkdir()
+        short = shorten_windows_path(str(spaced))
+        if short == str(spaced):
+            pytest.skip("8.3 generation appears disabled on this volume")
+        assert len(short) < len(str(spaced))
+        assert os.path.samefile(short, str(spaced))
+
+
+class TestTheBudgetThisProtects:
+    """Documents the arithmetic, so a future change that lengthens the
+    profile root fails here rather than in the field as a pairing that never
+    produces a QR."""
+
+    def test_chromes_deepest_known_suffix_is_what_blows_the_budget(self):
+        # Anything at or under this leaves no room for a 32-char session name.
+        assert len(_CHROME_SW_SUFFIX) > 120
+
+    def test_a_deep_profile_root_crosses_max_path(self):
+        root = (r"c:\inatel\code troopers\gabrielhhaber-winzapp_python"
+                r"\winzapp_python\client\data\global\api\userDataDir")
+        full = os.path.join(root, "a" * 32) + _CHROME_SW_SUFFIX
+        assert len(full) > MAX_PATH
+
+    def test_the_shortened_equivalent_fits(self):
+        root = r"c:\inatel\CODETR~1\GABRIE~1\WINZAP~1\client\api\userDataDir"
+        full = os.path.join(root, "a" * 32) + _CHROME_SW_SUFFIX
+        assert len(full) < MAX_PATH
+
+
+class TestTheLiteralUserDataDirSurvivesShortening:
+    """The regression guard for the one thing that must NOT be shortened.
+
+    `GetShortPathNameW` rewrites every component longer than 8 characters,
+    and `userDataDir` is 11 — so shortening the WHOLE path turns it into
+    `USERDA~1`. Two separate places identify a session's Chrome by matching
+    that literal in a command line, and both fail by matching NOTHING: a
+    stale Chrome holding the profile lock is then never killed and the
+    session hangs in INITIALIZING. Shortening only the ancestor costs 3 of
+    the 43 characters saved.
+
+    This ties the two modules together deliberately: the env var is built in
+    main.py, and the matcher lives in connection_state.py, so neither file's
+    own tests would notice the other changing.
+    """
+
+    SESSION = "a" * 32
+
+    def _env_value(self, ancestor):
+        """Mirrors what _start_wpp_background() puts in WINZAPP_USER_DATA_DIR."""
+        return os.path.join(shorten_windows_path(str(ancestor)), "userDataDir") + os.sep
+
+    def test_the_matcher_still_recognises_the_shortened_path(self, tmp_path):
+        from connection_state import chrome_cmdline_owns_session
+        ancestor = tmp_path / "code troopers with spaces" / "api"
+        ancestor.mkdir(parents=True)
+        cmdline = (r"chrome.exe --user-data-dir="
+                   + self._env_value(ancestor) + self.SESSION)
+        assert chrome_cmdline_owns_session(cmdline, self.SESSION) is True
+
+    def test_shortening_the_whole_path_would_break_that_matcher(self, tmp_path):
+        """States the bug that was nearly shipped, so the guard above cannot
+        be 'simplified' back into it without a red test."""
+        from connection_state import chrome_cmdline_owns_session
+        udd = tmp_path / "code troopers with spaces" / "api" / "userDataDir"
+        udd.mkdir(parents=True)
+        whole = shorten_windows_path(str(udd))
+        if "userdatadir" in whole.lower():
+            pytest.skip("8.3 generation appears disabled on this volume")
+        cmdline = rf"chrome.exe --user-data-dir={whole}\{self.SESSION}"
+        assert chrome_cmdline_owns_session(cmdline, self.SESSION) is False

--- a/tests/test_wpp_dependency_not_pinned.py
+++ b/tests/test_wpp_dependency_not_pinned.py
@@ -104,4 +104,5 @@ def test_the_patched_set_stays_narrow():
         "prom-client",              # src/middleware/instrumentation.ts
         "zod",                      # src/dto/sync.ts response contracts
         "@ffmpeg-installer/ffmpeg", # main.py's _find_api_ffmpeg/_convert_wav_to_ogg
+        "qrcode",                   # the getQrCode patch renders the QR PNG
     }


### PR DESCRIPTION
Nenhuma das duas vias de pareamento produzia nada na tela — nem QR, nem código de 8 caracteres. Eram quatro defeitos independentes empilhados, e três deles estavam escondidos pelo mesmo padrão: um `.catch(() => <valor inocente>)` que transforma "quebrou" em "está tudo bem".

## Causa raiz: o Chrome estourava o MAX_PATH dentro do perfil

Os caminhos mais profundos que o Chrome cria por perfil são os do Service Worker CacheStorage — dois diretórios de 32 hex mais `index-dir\the-real-index`, ~127 caracteres abaixo da raiz do perfil. Somando o nome de sessão de 32 caracteres, a instalação medida dava **262**; MAX_PATH é **260**.

Acima disso o Chrome não cria essas entradas, o WhatsApp Web nunca obtém o bucket de storage persistente, e responde **se deslogando**: navega para `/?post_logout=1&logout_reason=0`, leva o wa-js junto, e repete a cada ~10 s até o WPPConnect matar a sessão em `notLogged`. **Nenhum log diz "caminho longo demais"** — a navegação é o único sintoma.

Isso apareceu comparando duas instalações que não diferiam em mais nada. A que funcionava passava um `./userDataDir/` **relativo**, que o Chrome resolvia contra um cwd que o Windows já devolvia em forma 8.3 (a instalação fica sob um diretório com espaço no nome) — 31 caracteres mais curto por acidente.

Vale registrar a armadilha: **medir o perfil depois diz o oposto**. O Windows reporta a forma longa, então o perfil que funcionava aparece com 262 caracteres. Isso custou um "MAX_PATH está descartado" errado no meio do diagnóstico, e está documentado na docstring de `shorten_windows_path()`.

## Os outros três defeitos (patches em node_modules)

| | |
|---|---|
| `getQrCode` | O scraper do upstream lê `document.querySelector('canvas').closest('[data-ref]')`. O WhatsApp Web atual não renderiza mais o QR num `<canvas>` cujo ancestral com `data-ref` seja o código — ele acha o banner de download. Medido: o scraper devolve `https://wa.me/settings/...`, enquanto `WPP.conn.getAuthCode()` devolve 237 caracteres começando em `2@`. O que o upstream emitia **nunca foi um QR de login**. |
| `checkQrCode` v5→v7 | A via do código lançava `Invariant Violation #56367`. As versões v1–v5 subiram o ramo do `phoneNumber` para antes do `await this.getQrCode()`, e derrubaram junto a única coisa que tornava a chamada segura: o upstream só chega no `loginByCode()` depois de existir um `urlCode`, o que também garante que o storage de user-prefs foi inicializado. |
| `waitForQrCodeScan` | `this.isLogged = !needScan` com `needScan` vindo de `.catch(() => null)` lia "não consegui descobrir" como "o usuário logou" — o único valor sem informação virando a afirmação mais forte possível. |

## Duas coisas que a revisão pegou e que valem atenção de quem revisar

Ambas foram introduzidas pela própria correção da causa raiz e já estão corrigidas, mas são o tipo de coisa que passa batido:

1. **Os `os.makedirs()` não podem rodar antes da migração de sessão.** `migrate_legacy_api_state()` pula qualquer pasta já existente no destino e grava o marcador de uma vez só mesmo sem mover nada — criar as pastas antes tornava o pulo **permanente**. Todo usuário já pareado subiria num perfil virgem e o perfil real ficaria preso no local antigo, sem nenhuma tentativa futura.
2. **Encurtar só o ancestral, nunca o caminho inteiro.** O 8.3 reescreve todo componente com mais de 8 caracteres, e `userDataDir` tem 11. Perder esse literal cega `chrome_cmdline_owns_session()` e `forceKillByUserDataDir()`, que identificam o Chrome de uma sessão casando a string na linha de comando — e ambos falham casando **nada**. Manter o componente custa 3 dos 43 caracteres economizados: 262 → 231.

O `start.js` ganha apenas breadcrumbs e um comentário que **trava o padrão da interceptação como igualdade exata**. Alargá-lo para casar toda navegação de documento parece a correção óbvia (o `?post_logout=1` escapa) e **piora**: serve o documento fixado também na navegação que a página usa para se reiniciar, e ela nunca se reassenta. Dois testes travam isso.

## Testes

`5170 passed, 66 skipped`. Novos guardas para os dois defeitos acima, incluindo um comportamental que declara o primeiro como teste (destino pré-criado ⇒ nada move **e** o marcador é gravado) e um que amarra `main.py` a `connection_state.py`, porque nenhum dos dois arquivos notaria o outro mudando.

Verificado no app real: pareamento funcionando pelas duas vias, QR renderizado ~12 s após `start-session`.

Fora do escopo: 3 erros em `tests/test_headless_shell.py` (`spawn EFTYPE`) vêm de um `chrome-headless-shell.exe` extraído pela metade no ambiente, e são anteriores a estas mudanças.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
