### PR TITLE
Mensagens somem da lista aberta: janela ancorada, e o rebuild deixa de ser o caminho normal

### DIFF
--- a/client/core/utils.py
+++ b/client/core/utils.py
@@ -1182,7 +1182,8 @@ def db_fetch_limit(configured_limit: int, unread_count: int, cap: int = 2000, bu
     return visible_page
 
 
-def paginated_window(total_len: int, limit: int, unread_sep_idx: int) -> tuple:
+def paginated_window(total_len: int, limit: int, unread_sep_idx: int,
+                     min_visible: int = 0) -> tuple:
     """Where populate_messages()'s pagination window should start.
 
     Returns ``(offset, adjusted_sep_idx)``: ``offset`` is how many leading
@@ -1200,10 +1201,19 @@ def paginated_window(total_len: int, limit: int, unread_sep_idx: int) -> tuple:
     demonstrably still unread. So the window widens — but only while there is
     something unread to protect (``unread_sep_idx >= 0``); a fully-read
     conversation still respects the configured limit exactly as before.
+
+    ``min_visible`` widens the window for the same kind of reason, but for
+    history the user asked for by hand: Home/scroll-up loads older messages
+    and grows the rendered list past the page size, and a background rebuild
+    (the 60s resync, or the one every new message triggers) recomputing the
+    window from the end alone would throw all of it away and snap back to the
+    configured limit. It is a count of rows already materialized, not an
+    offset, so it stays anchored to the same old point as new messages arrive,
+    and it only grows when the user actually pulls more history in.
     """
-    effective_limit = limit
+    effective_limit = max(limit, min_visible)
     if unread_sep_idx >= 0:
-        effective_limit = max(limit, total_len - unread_sep_idx)
+        effective_limit = max(effective_limit, total_len - unread_sep_idx)
     if total_len <= effective_limit:
         return 0, unread_sep_idx
     offset = total_len - effective_limit
@@ -1211,6 +1221,68 @@ def paginated_window(total_len: int, limit: int, unread_sep_idx: int) -> tuple:
     if adjusted < 0:
         adjusted = -1
     return offset, adjusted
+
+
+def expanded_min_visible(displayable: list, anchor_id: str, fallback_count: int,
+                         cap: int = 0) -> int:
+    """How wide populate_messages() must keep the window it rebuilds.
+
+    ``fallback_count`` is how many rows the list had after the user last pulled
+    older history in. On its own it is not enough: every message that arrives
+    afterwards grows ``displayable``, so a window sized purely by that count
+    slides one row forward per arrival and eats back exactly the history that
+    was loaded. ``anchor_id`` — the oldest message displayed at that moment —
+    pins it instead, and the count stays as the floor for when that message is
+    no longer there (deleted remotely), so a missing anchor widens the window
+    less rather than collapsing it back to the page size.
+
+    ``cap`` is off by default (0, or any non-positive value) and exists only
+    for a caller that has a reason to bound the window. A standing cap must
+    NOT be reintroduced here: it reproduces the original bug with a higher
+    floor. Expanded to 4200 rows, the next arriving message recomputes the
+    window at the cap and 2200 rows vanish under the reader mid-read;
+    ``_expanded_visible_count`` is not rewritten, so every later rebuild
+    performs the same cut, and the Home that follows only reaches
+    ``_load_more_messages()`` and is undone again — above the cap the user can
+    never reach older history at all. Rendering cost was the argument for one,
+    but the multi-second stalls that argument cited were measured to be caused
+    by *frequency*, not window size (see main.py's _schedule_refresh_active_
+    messages(), where an oversized pagination window is recorded as a tested
+    and discarded theory) and are fixed by its 1s debounce. Whether a very
+    large window costs anything on its own has not been measured.
+    """
+    try:
+        floor = max(0, int(fallback_count))
+    except (TypeError, ValueError):
+        floor = 0
+    widened = floor
+    if anchor_id:
+        for idx, msg in enumerate(displayable):
+            if isinstance(msg, dict) and msg.get("key", {}).get("id") == anchor_id:
+                widened = max(floor, len(displayable) - idx)
+                break
+    try:
+        ceiling = int(cap)
+    except (TypeError, ValueError):
+        ceiling = 0
+    return min(widened, ceiling) if ceiling > 0 else widened
+
+
+def history_window(displayable: list, anchor_id: str, expanded_count: int,
+                   limit: int, unread_sep_idx: int, cap: int = 0) -> tuple:
+    """The pagination window populate_messages() should rebuild with.
+
+    Pulled out of populate_messages() whole because it is the entire fix for
+    "the conversation drops the history I loaded": the panel state, the
+    anchoring and the widening only matter together, and testing the two
+    halves separately left the wiring between them — the one line that carries
+    the expanded window into paginated_window() — covered by nothing.
+
+    Returns ``paginated_window()``'s own ``(offset, adjusted_sep_idx)``.
+    """
+    min_visible = expanded_min_visible(displayable, anchor_id, expanded_count, cap)
+    return paginated_window(len(displayable), limit, unread_sep_idx,
+                            min_visible=min_visible)
 
 
 def reaction_targets_status(msg: dict) -> bool:

--- a/client/main.py
+++ b/client/main.py
@@ -14976,7 +14976,7 @@ class MainWindow(wx.Frame):
     # resolution loops that trigger it run in batches for minutes on end.
     _ACTIVE_REFRESH_DEBOUNCE_MS = 1000
 
-    def _schedule_refresh_active_messages(self):
+    def _schedule_refresh_active_messages(self, jids=None):
         """Debounce refresh_active_conversation_messages().
 
         That method re-renders every row of the open conversation
@@ -14993,7 +14993,35 @@ class MainWindow(wx.Frame):
         self._render_message_line(msg))`. Two earlier theories about this
         freeze (a refresh storm on the history path, then an oversized
         pagination window) were wrong; this is what the stacks actually show.
+
+        *jids* are the JIDs the caller has just resolved, accumulated across
+        every batch that lands inside one debounce window. The resolution
+        loops know exactly whose name changed, and since the message window no
+        longer has a ceiling (it keeps whatever history the user loaded with
+        Home) the difference is repainting a handful of rows instead of
+        thousands. Omitting it — or passing an empty collection — still means
+        "I don't know what changed, repaint everything", which stays the safe
+        default for any caller that can't tell: a row that should have been
+        repainted and wasn't keeps announcing raw @lid/phone digits, which is
+        worse than the slowness this avoids.
+
+        **UI thread only.** The accumulator below is a plain set with no lock,
+        and every caller reaches it through wx.CallAfter — including
+        register_jid_mapping(), which is itself a multi-threaded writer (the
+        sync thread and the Socket.IO thread both call it, under
+        _lid_mapping_lock). Dropping that wx.CallAfter because it looks
+        redundant corrupts this set silently, with no exception to point at it.
         """
+        if jids:
+            pending = getattr(self, "_refresh_active_jids", set())
+            # None is the sticky "repaint everything" request — a later batch
+            # that does know its JIDs must not narrow it back down.
+            if pending is not None:
+                pending = set(pending)
+                pending.update(j for j in jids if isinstance(j, str) and j)
+                self._refresh_active_jids = pending
+        else:
+            self._refresh_active_jids = None
         if getattr(self, "_refresh_active_pending", False):
             return
         self._refresh_active_pending = True
@@ -15004,8 +15032,22 @@ class MainWindow(wx.Frame):
         """Run the coalesced name repaint. Flag is cleared first so a failure
         cannot wedge every later batch."""
         self._refresh_active_pending = False
+        # Drain before rendering, not after: a batch arriving while the
+        # repaint runs then finds an empty accumulator and a cleared pending
+        # flag, so it schedules its own round instead of being swallowed by
+        # this one (or repainted twice by it).
+        jids = getattr(self, "_refresh_active_jids", None)
+        self._refresh_active_jids = set()
+        # An empty set means every JID handed in was filtered out, i.e. we no
+        # longer know what changed — same contract as None.
+        if not jids:
+            jids = None
         cp = getattr(self, "conversations_panel", None)
         if cp is None:
+            # The drained JIDs are dropped here, unlike on the failure path
+            # below, and that is fine rather than overlooked: with no panel
+            # there is no open conversation to leave stale, and whenever one is
+            # opened it renders from scratch.
             return
         # Medido, não estimado: a janela de paginação deixou de ser limitada a
         # messages_page_size quando o usuário carrega histórico, e a suspeita de
@@ -15014,15 +15056,48 @@ class MainWindow(wx.Frame):
         # 80 ms ou 900 ms — e é o mesmo laço que os stacks do watchdog apontam.
         started = time.monotonic()
         try:
-            cp.refresh_active_conversation_messages()
+            painted = cp.refresh_active_conversation_messages(jids=jids)
         except Exception:
             logging.exception("[_do_scheduled_refresh_active_messages] repaint failed")
+            # The batch was drained before the call, so those JIDs are gone and
+            # the next one would be scoped to its own — the rows this round was
+            # meant to fix would never be repainted again. _render_message_line()
+            # has raised in production, which is why the try exists at all, so
+            # degrade to a full repaint and reschedule it.
+            #
+            # Exactly once, though. A malformed record makes the render raise
+            # every time, and rescheduling unconditionally turns that into a
+            # permanent 1 Hz Freeze/SetItemText/Thaw cycle on messages_list —
+            # the accessibility-event flood the Freeze() exists to prevent, now
+            # forever — plus log.log growing without bound on one traceback, in
+            # the file that is this project's primary diagnostic tool. One
+            # retry keeps the whole point (a lost scoped round comes back as a
+            # full one) and gives up when the failure is deterministic.
+            if getattr(self, "_refresh_active_failed_once", False):
+                logging.error(
+                    "[_do_scheduled_refresh_active_messages] repaint failed twice "
+                    "in a row — not rescheduling; the open conversation keeps "
+                    "whatever text it currently shows until something else "
+                    "rebuilds it.")
+            else:
+                self._refresh_active_failed_once = True
+                self._refresh_active_jids = None
+                wx.CallAfter(self._schedule_refresh_active_messages)
         else:
-            logging.info(
-                "[_do_scheduled_refresh_active_messages] repainted %d row(s) in %.0f ms.",
-                len(getattr(cp, "_sorted_messages", []) or []),
-                (time.monotonic() - started) * 1000.0,
-            )
+            self._refresh_active_failed_once = False
+            if logging.getLogger().isEnabledFor(logging.INFO):
+                # The panel widens a scoped request back to a full pass when it
+                # can't address every affected row, so "requested" is all this
+                # side can honestly claim.
+                scope = "full" if jids is None else f"{len(jids)} resolved JID(s) requested"
+                logging.info(
+                    "[_do_scheduled_refresh_active_messages] repainted %d of %d row(s) "
+                    "in %.0f ms (%s).",
+                    painted,
+                    len(getattr(cp, "_sorted_messages", []) or []),
+                    (time.monotonic() - started) * 1000.0,
+                    scope,
+                )
 
     def _schedule_refresh_messages(self):
         """Debounce the open conversation's message-list rebuild.
@@ -15369,7 +15444,10 @@ class MainWindow(wx.Frame):
                         logging.error(f"[Contact Resolution] Error saving contacts incrementally: {e}")
                         self.save_data(self.chats, self.contacts)
                     wx.CallAfter(self._schedule_set_chats)
-                    wx.CallAfter(self._schedule_refresh_active_messages)
+                    # Only the contacts this batch actually named can change a
+                    # rendered row — every other row already reads the same.
+                    wx.CallAfter(self._schedule_refresh_active_messages,
+                                 set(updated_contacts))
             threading.Thread(target=resolve_phones_in_bg, daemon=True).start()
 
     def _queue_lid_resolutions(self, jids) -> None:
@@ -15456,6 +15534,17 @@ class MainWindow(wx.Frame):
             # Mappings learned by this scan, so the single end-of-scan refresh
             # below fires even when no contact record happened to change.
             mapped = 0
+            # Both sides of each mapping learned above: the open conversation
+            # may render the participant under either form, so the selective
+            # repaint has to be told about both.
+            mapped_jids = set()
+            # _learn_sender_names_bulk() writes names for arbitrary participant
+            # JIDs and reports none of them, so a scan that learned any is a
+            # scan that cannot say which rows changed — it asks for the full
+            # repaint. This scan runs once, not at 1 Hz, so that costs nothing;
+            # scoping it to mapped_jids instead left a 4000-row group showing
+            # formatted numbers for 40 participants until it was reopened.
+            learned_names = False
             # Senders are collected separately and capped: a busy account can
             # hold thousands of distinct group participants, and every one of
             # them would otherwise become an API round-trip through the single
@@ -15472,7 +15561,8 @@ class MainWindow(wx.Frame):
                 # Learn every sender name the stored history already carries.
                 # This is local and cheap, and it is what keeps the API lookups
                 # below down to the handful that genuinely need them.
-                self._learn_sender_names_bulk(records)
+                if self._learn_sender_names_bulk(records):
+                    learned_names = True
                 for msg in list(records):
                     if not isinstance(msg, dict):
                         continue
@@ -15489,10 +15579,12 @@ class MainWindow(wx.Frame):
                         if remote.endswith("@lid") and self._lid_to_phone.get(remote) != alt:
                             self.register_jid_mapping(remote, alt, defer_ui=True)
                             mapped += 1
+                            mapped_jids.update((remote, alt))
                     elif alt and alt.endswith("@lid") and remote.endswith("@s.whatsapp.net"):
                         if self._lid_to_phone.get(alt) != remote:
                             self.register_jid_mapping(alt, remote, defer_ui=True)
                             mapped += 1
+                            mapped_jids.update((alt, remote))
 
                     # Sender of a group message. Only mentioned JIDs used to be
                     # collected here, so a participant whose @lid we cannot
@@ -15585,9 +15677,17 @@ class MainWindow(wx.Frame):
             # and finds no unnamed mention refreshed nothing at all — with the
             # per-mapping refreshes deferred, the list kept showing raw @lid
             # until something unrelated happened to rebuild it.
-            if updated_contacts or mapped:
+            if updated_contacts or mapped or learned_names:
                 wx.CallAfter(self._schedule_set_chats)
-                wx.CallAfter(self._schedule_refresh_active_messages)
+                # resolve_lid_jids_via_api() above schedules its own repaint
+                # for the LIDs it resolved; this one only owns what this scan
+                # itself learned — the named mentions, the @lid <-> phone pairs
+                # read off remoteJidAlt, and (unscopable) the bulk pushName
+                # pass, which forces the full repaint.
+                wx.CallAfter(
+                    self._schedule_refresh_active_messages,
+                    None if learned_names else (set(updated_contacts) | mapped_jids),
+                )
             
             logging.info("[Mentions Scan] Scan and resolution of cached messages completed.")
 
@@ -21786,6 +21886,17 @@ class MainWindow(wx.Frame):
                     self.save_data(self.chats, self.contacts)
             if not defer_ui:
                 wx.CallAfter(self._schedule_set_chats)
+                # The open conversation needs the same treatment as the chat
+                # list, and only since the message repaint became scoped: the
+                # non-batch mapping writers (_extract_lid_mapping() on the
+                # Socket.IO thread, _get_participant_name()'s inline learn)
+                # never scheduled one of their own and used to be fixed up by
+                # whatever unrelated full repaint happened next. Both JIDs go
+                # in, since the rows can carry either form. Terminating even
+                # though rendering itself can reach here: a mapping is only
+                # `changed` once, so the second pass schedules nothing.
+                wx.CallAfter(self._schedule_refresh_active_messages,
+                             {lid_jid, phone_jid})
 
     def resolve_lid_jids_via_api(self, jids):
         """Resolve a list of @lid JIDs to phone JIDs using WPPConnect contact endpoint."""
@@ -22038,7 +22149,12 @@ class MainWindow(wx.Frame):
                 logging.error(f"[LID Resolution] Error saving contacts incrementally: {e}")
                 self.save_data(self.chats, self.contacts)
         wx.CallAfter(self._schedule_set_chats)
-        wx.CallAfter(self._schedule_refresh_active_messages)
+        # Every LID this batch was asked about (its name and/or its phone
+        # bridge may have just been filled in) plus the phone JIDs the answers
+        # named. _jid_address_forms() expands each into its counterpart, so a
+        # row still carrying the @lid matches a phone JID listed here.
+        wx.CallAfter(self._schedule_refresh_active_messages,
+                     {j for j in jids if isinstance(j, str) and j} | set(updated_contacts))
 
     def get_contact_profile(self, jid: str) -> dict:
         """Fetch contact profile from WPPConnect (runs on background thread)."""

--- a/client/main.py
+++ b/client/main.py
@@ -15007,10 +15007,22 @@ class MainWindow(wx.Frame):
         cp = getattr(self, "conversations_panel", None)
         if cp is None:
             return
+        # Medido, não estimado: a janela de paginação deixou de ser limitada a
+        # messages_page_size quando o usuário carrega histórico, e a suspeita de
+        # que uma janela grande custa caro aqui já foi levantada duas vezes sem
+        # nenhum número. Uma linha por repaint responde se 4000 linhas custam
+        # 80 ms ou 900 ms — e é o mesmo laço que os stacks do watchdog apontam.
+        started = time.monotonic()
         try:
             cp.refresh_active_conversation_messages()
         except Exception:
             logging.exception("[_do_scheduled_refresh_active_messages] repaint failed")
+        else:
+            logging.info(
+                "[_do_scheduled_refresh_active_messages] repainted %d row(s) in %.0f ms.",
+                len(getattr(cp, "_sorted_messages", []) or []),
+                (time.monotonic() - started) * 1000.0,
+            )
 
     def _schedule_refresh_messages(self):
         """Debounce the open conversation's message-list rebuild.

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -5510,8 +5510,20 @@ class ConversationsPanel(wx.Panel):
         for msg in self._sorted_messages:
             if isinstance(msg, dict) and not self._is_separator(msg):
                 found_real_row = True
-                oldest_id = (msg.get("key") or {}).get("id", "") or ""
-                break
+                # A primeira linha COM id, não simplesmente a primeira linha:
+                # populate_messages() mantém registros sem key.id, e parar no
+                # primeiro deles deixava a âncora vazia para sempre naquela
+                # conversa. Só o piso por contagem sobraria — e ele escorrega
+                # uma linha para frente a cada mensagem que chega ao vivo
+                # (on_incoming_message() não registra a janela), reintroduzindo
+                # em silêncio o mesmo sintoma que esta janela existe para
+                # corrigir. Pegar uma linha mais nova como âncora só pode
+                # alargar a janela, nunca estreitá-la: expanded_min_visible()
+                # aplica max(piso, âncora).
+                mid = (msg.get("key") or {}).get("id", "") or ""
+                if mid:
+                    oldest_id = mid
+                    break
         if not found_real_row:
             return
         self._expanded_visible_count = len(self._sorted_messages)
@@ -9961,6 +9973,17 @@ class ConversationsPanel(wx.Panel):
             key.get("remoteJidAlt") or "",
             msg.get("participant") or "",
         ]
+        # O JID da CONVERSA, e não só os que estão na mensagem: em 1:1
+        # _sender_label() e os dois ramos 1:1 de _get_quoted_sender() resolvem
+        # o nome a partir de self.conversation quando a linha não tem
+        # participant, então uma linha cujo key.remoteJid está sob outra forma
+        # (@lid) e ainda sem bridge não cruzaria com o JID de telefone que o
+        # laço de resolução reportou — e ficaria anunciando o número cru.
+        # Excluído em grupo: lá o nome nunca vem da conversa, e nenhum laço de
+        # resolução reporta um @g.us, então incluí-lo não pegaria nada.
+        conv_jid = (self.conversation or {}).get("remoteJid", "") or ""
+        if conv_jid and not conv_jid.endswith("@g.us"):
+            raw.append(conv_jid)
         raw.extend(self._raw_mentioned_jids(msg) or [])
         msg_obj = msg.get("message") or {}
         ext = msg_obj.get("extendedTextMessage") or {} if isinstance(msg_obj, dict) else {}
@@ -10071,6 +10094,18 @@ class ConversationsPanel(wx.Panel):
         if not self.conversation or not hasattr(self, "messages_list"):
             return 0
         target_ids = self._message_ids_touching_jids(jids) if jids else None
+        # Mesma guarda de _repaint_message_rows(): _set_message_row_texts()
+        # escreve por índice, então uma lista fora de passo com o controle põe
+        # o texto certo na linha errada — e um descompasso só de prefixo não
+        # levanta exceção nenhuma, o leitor de tela simplesmente passa a ler a
+        # mensagem trocada. Degrada para o passe completo, que percorre as duas
+        # em paralelo e no máximo pinta linhas a mais.
+        if (target_ids is not None
+                and self.messages_list.GetItemCount() != len(self._sorted_messages)):
+            logging.info(
+                "[refresh_active_conversation_messages] list out of step with rows "
+                "— full path")
+            target_ids = None
         # Um SetItemText por linha é um evento de acessibilidade por linha, e
         # os lotes de resolução de nomes/LID chamam isto repetidamente sobre a
         # lista inteira — sem congelar, o leitor de tela recebe a enxurrada e a
@@ -13654,10 +13689,16 @@ class ConversationsPanel(wx.Panel):
             # _all_sorted_messages só acompanha enquanto as duas listas
             # terminarem no mesmo objeto. O append ao vivo de
             # on_incoming_message() já as deixa fora de passo no fim (situação
-            # anterior a isto, e inofensiva: _load_more_messages() fatia só a
-            # cabeça e _load_older_messages() no máximo re-consulta algumas
-            # mensagens que o dedup descarta), e não é este método que vai
-            # inventar um alinhamento que ele não tem como verificar.
+            # anterior a isto), e não é este método que vai inventar um
+            # alinhamento que ele não tem como verificar.
+            # A consequência do desalinhamento é maior do que parece e vale
+            # dizer por extenso: _load_older_messages() tira loaded_db_count
+            # de _all_sorted_messages, então com ela curta a consulta local
+            # devolve mensagens que já estão em memória, o dedup zera n_new e
+            # ele cai para o servidor ANTES de esgotar o histórico local. O
+            # usuário ainda recebe o histórico, só que pelo caminho caro. É
+            # pré-existente, não regressão deste método — mas é o que dá para
+            # perder aqui, não "algumas mensagens que o dedup descarta".
             # O `is not` não é paranoia: _sorted_messages tem de ser um SUFIXO
             # de _all_sorted_messages, nunca o mesmo objeto de lista. Hoje todo
             # produtor fatia ou concatena, então são sempre listas distintas;

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -50,7 +50,7 @@ from ui.accessible import (
 )
 from ui.dialogs.emoji_picker import choose_and_insert_emoji
 from core.save_location import resolve_save_dialog_folder
-from core.utils import reaction_targets_status, format_number, decrypt_bytes, is_phone_like, encrypt, effective_unread_count, first_unread_index, paginated_window, db_fetch_limit, looks_like_binary_blob, normalize_for_search, normalize_line_separators, parse_bool_flag as _parse_bool_flag, append_selected_marker, is_message_forwarded, is_voice_message, video_seconds, MEASURED_SECONDS_KEY, link_preview_text
+from core.utils import history_window, reaction_targets_status, format_number, decrypt_bytes, is_phone_like, encrypt, effective_unread_count, first_unread_index, db_fetch_limit, looks_like_binary_blob, normalize_for_search, normalize_line_separators, parse_bool_flag as _parse_bool_flag, append_selected_marker, is_message_forwarded, is_voice_message, video_seconds, MEASURED_SECONDS_KEY, link_preview_text
 from core.locale_format import get_date_format, get_time_format, get_datetime_format
 from core.message_copy_format import format_copied_message
 from core.video_player import VideoPlayer
@@ -522,6 +522,16 @@ class ConversationsPanel(wx.Panel):
         self._messages_offset: int = 0
         # Guard to prevent recursive load-more triggers during list rebuild
         self._is_loading_more: bool = False
+        # Quantas mensagens exibíveis a lista passou a mostrar depois que o
+        # usuário puxou histórico (Home/scroll ao topo). populate_messages()
+        # reconstrói a janela sempre a partir do fim, então sem isso um
+        # rebuild de fundo — e há um a cada mensagem nova — descartava tudo
+        # que o usuário tinha carregado e voltava ao messages_page_size.
+        self._expanded_visible_count: int = 0
+        # Id da mensagem mais antiga exibida naquele momento: é a âncora real
+        # da janela, já que a contagem sozinha escorrega uma linha para frente
+        # a cada mensagem nova. Vazio quando ela não existe mais.
+        self._expanded_oldest_msg_id: str = ""
 
         self.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy)
         self.init_UI()
@@ -1586,6 +1596,7 @@ class ConversationsPanel(wx.Panel):
         self._quoted_message = None
         self._reaction_map   = {}
         self._is_loading_more = False
+        self._reset_expanded_window()
         # Reset mention state for the new conversation
         self._pending_mentions.clear()
         self._pending_mention_display_names.clear()
@@ -3558,6 +3569,7 @@ class ConversationsPanel(wx.Panel):
         # _msg_bookmarks is intentionally NOT reset here — see __init__.
         # _msg_temp_bookmarks is, for the same reason spelled out there.
         self._msg_temp_bookmarks.clear()
+        self._reset_expanded_window()
         closed_jid = self._last_open_jid
         self.conversation = None
         self.conversation_panel.Hide()
@@ -5424,6 +5436,127 @@ class ConversationsPanel(wx.Panel):
             return mapped_lid
         return remote_jid
 
+    def _reset_expanded_window(self) -> None:
+        """Volta a lista ao messages_page_size normal.
+
+        A janela expandida pertence à conversa em que o usuário pediu o
+        histórico; abrir outra (ou fechar esta) tem de recomeçar do limite
+        configurado, senão o chat seguinte já nasce renderizando milhares de
+        linhas por causa de uma conversa anterior.
+        """
+        self._expanded_visible_count = 0
+        self._expanded_oldest_msg_id = ""
+
+    def _history_window_for_rebuild(self, displayable: list, limit: int) -> tuple:
+        """(offset, sep_idx) da janela que populate_messages() vai reconstruir.
+
+        Método próprio, e não duas linhas dentro do rebuild, porque é aqui que
+        o histórico que o usuário carregou à mão sobrevive: a âncora diz até
+        onde a janela tem de continuar aberta (ver _remember_expanded_window()).
+        populate_messages() não é testável sem um wx.ListCtrl de verdade, então
+        sem isto o passo que corrige o bug ficava sem teste nenhum — dava para
+        apagar o argumento da âncora com a suíte inteira verde.
+        """
+        return history_window(
+            displayable,
+            getattr(self, "_expanded_oldest_msg_id", ""),
+            getattr(self, "_expanded_visible_count", 0),
+            limit,
+            self._unread_sep_idx,
+        )
+
+    def _remember_expanded_window(self) -> None:
+        """Registra até onde a lista foi expandida por um carregamento de histórico.
+
+        A contagem é o piso e o id da mensagem mais antiga exibida é a âncora:
+        cada mensagem nova aumenta o total de exibíveis, e uma janela definida
+        só por contagem andaria uma linha para frente a cada chegada, comendo
+        de volta justamente o histórico que o usuário pediu. Quando esse id
+        some (mensagem apagada remotamente), a contagem ainda segura a janela.
+        """
+        self._expanded_visible_count = len(self._sorted_messages)
+        self._expanded_oldest_msg_id = ""
+        for msg in self._sorted_messages:
+            if isinstance(msg, dict) and not self._is_separator(msg):
+                self._expanded_oldest_msg_id = msg.get("key", {}).get("id", "") or ""
+                break
+
+    def _merge_history_into_records(self, older_messages: list) -> None:
+        """Guarda no chat aberto o histórico recém-carregado.
+
+        O prepend feito por _load_older_messages()/_on_older_messages_loaded()
+        só vive nas listas em memória do painel, mas populate_messages()
+        reconstrói a conversa inteira a partir de
+        conversation["messages"]["messages"]["records"] — então um rebuild de
+        fundo redesenhava a conversa sem essas mensagens. É o mesmo merge que
+        MainWindow.fetch_older_messages() faz do lado do servidor, repetido
+        aqui porque self.conversation nem sempre é o mesmo dict que
+        main_window.chats[jid] (o resync da conversa aberta troca o dict), e é
+        idempotente: dedup por key.id, sem reordenar o que já existe
+        (populate_messages() ordena por timestamp de qualquer forma).
+
+        Só entra o que pertence mesmo à conversa aberta: a consulta local usa
+        _history_storage_jid() (que pode ser um @lid) e o fallback do servidor
+        reconsulta sob o JID alternativo, então um mapeamento @lid errado ou
+        velho traz mensagens de outro contato. Antes elas sumiam no rebuild
+        seguinte; guardadas nos records elas viram história permanente daquele
+        contato — sync_chat_messages() recolhe os records locais sem filtrar.
+        """
+        if not self.conversation or not older_messages:
+            return
+        try:
+            jid = self.conversation.get("remoteJid", "")
+            own = [
+                m for m in older_messages
+                if isinstance(m, dict) and self.main_window._chat_jids_equivalent(
+                    (m.get("key") or {}).get("remoteJid", ""), jid
+                )
+            ]
+            if len(own) != len(older_messages):
+                logging.warning(
+                    "[_merge_history_into_records] %d de %d mensagens descartadas "
+                    "por não pertencerem a %s",
+                    len(older_messages) - len(own), len(older_messages), jid,
+                )
+            if not own:
+                return
+            container = self.conversation.setdefault("messages", {}).setdefault(
+                "messages", {}
+            )
+            records = container.get("records") or []
+            existing_ids = {
+                (r.get("key") or {}).get("id")
+                for r in records
+                if isinstance(r, dict) and (r.get("key") or {}).get("id")
+            }
+            # Mensagem sem key.id fica de fora: um "" nos records faz
+            # _signature_changed_ids() devolver None para sempre, e aí todo
+            # repaint local (estrela, fixar) vira rebuild completo — sai mais
+            # caro do que perder uma linha que nem dá para endereçar.
+            new_records = [
+                m for m in own
+                if (m.get("key") or {}).get("id")
+                and (m.get("key") or {}).get("id") not in existing_ids
+            ]
+            if not new_records:
+                return
+            container["records"] = new_records + records
+            # "total" pode ser a contagem real do chat (db.get_message_count()),
+            # maior do que o que está carregado, então aqui só sobe. Vale até o
+            # próximo sync_chat_messages(), que reescreve com len(all_messages).
+            container["total"] = max(
+                int(container.get("total") or 0), len(container["records"])
+            )
+            logging.info(
+                "[_merge_history_into_records] %d mensagem(ns) antigas guardadas "
+                "nos records (total agora %d)",
+                len(new_records), container["total"],
+            )
+        except Exception:
+            logging.exception(
+                "[_merge_history_into_records] falha ao mesclar o histórico carregado"
+            )
+
     def _load_older_messages(self):
         """Load older messages from the local database, or fall back to the server if none remain locally."""
         if not self.conversation or not self._all_sorted_messages:
@@ -5468,6 +5601,8 @@ class ConversationsPanel(wx.Panel):
                         logging.info(f"[_load_older_messages] Prepend finished. Added {n_new} new unique messages. Rebuilding UI list.")
                         
                         if n_new > 0:
+                            self._merge_history_into_records(displayable)
+                            self._remember_expanded_window()
                             self._recompute_unread_sep_idx()
                                 
                             self.messages_list.DeleteAllItems()
@@ -5634,6 +5769,9 @@ class ConversationsPanel(wx.Panel):
                 return
 
             self._server_history_anchor.pop(requested_jid, None)
+
+            self._merge_history_into_records(displayable)
+            self._remember_expanded_window()
             
             self._recompute_unread_sep_idx()
 
@@ -5666,6 +5804,7 @@ class ConversationsPanel(wx.Panel):
             # Extend the in-memory list and update the offset
             self._sorted_messages   = new_msgs + self._sorted_messages
             self._messages_offset   = new_start
+            self._remember_expanded_window()
             if self._unread_sep_idx >= 0:
                 self._unread_sep_idx += n_new
 
@@ -9747,9 +9886,25 @@ class ConversationsPanel(wx.Panel):
         """Re-render all messages in the active message list (useful after background name/LID resolution)."""
         if not self.conversation or not hasattr(self, "messages_list"):
             return
-        for i, msg in enumerate(self._sorted_messages):
-            if not self._is_separator(msg):
-                self.messages_list.SetItemText(i, self._render_message_line(msg))
+        # Um SetItemText por linha é um evento de acessibilidade por linha, e
+        # os lotes de resolução de nomes/LID chamam isto repetidamente sobre a
+        # lista inteira — sem congelar, o leitor de tela recebe a enxurrada e a
+        # janela trava por segundos (ver as notas do watchdog em main.py).
+        self.messages_list.Freeze()
+        try:
+            total = len(self._sorted_messages)
+            for i, msg in enumerate(self._sorted_messages):
+                if not self._is_separator(msg):
+                    # index/total explícitos como em _set_message_row_texts():
+                    # sem eles o modo listbox com contagem de itens cai no
+                    # fallback self._sorted_messages.index(msg), uma varredura
+                    # linear com comparação profunda de dicts por linha — e duas
+                    # mensagens de mesmo conteúdo anunciam a posição errada.
+                    self.messages_list.SetItemText(
+                        i, self._render_message_line(msg, index=i, total=total)
+                    )
+        finally:
+            self.messages_list.Thaw()
 
     def _on_menu_reply_private(self, msg: dict, participant_jid: str):
         """Open a private conversation with the group participant and cite their message."""
@@ -13328,8 +13483,8 @@ class ConversationsPanel(wx.Panel):
             limit = int(
                 self.main_window.settings.get("user_interface", {}).get("messages_page_size", 200)
             )
-            self._messages_offset, self._unread_sep_idx = paginated_window(
-                len(displayable), limit, self._unread_sep_idx
+            self._messages_offset, self._unread_sep_idx = (
+                self._history_window_for_rebuild(displayable, limit)
             )
             paginated = displayable[self._messages_offset:]
 

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -5466,20 +5466,56 @@ class ConversationsPanel(wx.Panel):
         )
 
     def _remember_expanded_window(self) -> None:
-        """Registra até onde a lista foi expandida por um carregamento de histórico.
+        """Registra até onde a lista está materializada agora.
 
         A contagem é o piso e o id da mensagem mais antiga exibida é a âncora:
         cada mensagem nova aumenta o total de exibíveis, e uma janela definida
         só por contagem andaria uma linha para frente a cada chegada, comendo
         de volta justamente o histórico que o usuário pediu. Quando esse id
         some (mensagem apagada remotamente), a contagem ainda segura a janela.
+
+        Chamado por quem carrega histórico (Home) E pelo fim de
+        populate_messages(): o piso não é "o que o Home trouxe", é "o que já
+        está na tela". Sem a segunda chamada, uma conversa aberta e nunca
+        expandida abre com messages_page_size linhas, cresce por append a cada
+        mensagem que chega ou que o usuário manda (on_incoming_message() e os
+        caminhos de envio otimista apendam sem cortar nada), e o primeiro
+        rebuild de fundo recalcula a janela do fim e devolve a lista a
+        exatamente o page size — apagando da lista, sob o leitor de tela, uma
+        linha antiga por mensagem nova. Foi assim que o bug reapareceu depois
+        da âncora: com 200 linhas na tela, 4 mensagens enviadas e o repaint
+        seguinte, as 4 mais antigas sumiram.
+
+        "O que está na tela" inclui o alargamento que paginated_window() faz
+        por causa do separador de não lidas, e não só o histórico que o usuário
+        puxou: um grupo com 4000 não lidas abre com 4001 linhas, e essas 4001
+        viram o piso da sessão inteira — o separador ser descartado depois não
+        as estreita. É de propósito. Apará-las é apagar da lista, sob o leitor
+        de tela, exatamente as mensagens que ele acabou de ler, que é o bug.
+        Quem for medir custo de rebuild em conversa nunca expandida precisa
+        saber que essa janela larga é esperada, não defeito.
+
+        Uma lista só com sentinela (o placeholder de "sem mensagens") não
+        registra nada: um piso de 1 linha não significa nada e a âncora vazia
+        não prenderia coisa alguma. Também não zera o que já estava gravado, e
+        isso é escolha, não esquecimento: "Limpar conversa" esvazia records e
+        cai aqui, mas um records momentaneamente vazio no meio de um resync
+        cairia igual, e zerar ali derrubaria um piso legítimo — de novo linhas
+        sumindo sob o leitor. O custo de manter é o oposto e é suportável: se o
+        chat limpo voltar a encher na mesma sessão, o rebuild seguinte pinta
+        uma janela mais larga que o page size até a conversa ser fechada.
         """
-        self._expanded_visible_count = len(self._sorted_messages)
-        self._expanded_oldest_msg_id = ""
+        oldest_id = ""
+        found_real_row = False
         for msg in self._sorted_messages:
             if isinstance(msg, dict) and not self._is_separator(msg):
-                self._expanded_oldest_msg_id = msg.get("key", {}).get("id", "") or ""
+                found_real_row = True
+                oldest_id = (msg.get("key") or {}).get("id", "") or ""
                 break
+        if not found_real_row:
+            return
+        self._expanded_visible_count = len(self._sorted_messages)
+        self._expanded_oldest_msg_id = oldest_id
 
     def _merge_history_into_records(self, older_messages: list) -> None:
         """Guarda no chat aberto o histórico recém-carregado.
@@ -13570,6 +13606,13 @@ class ConversationsPanel(wx.Panel):
         # suppresses native repaint/accessibility notifications until Thaw()
         # runs in the finally block below, by which point only the final,
         # correct Focus()/Select() call (or lack thereof) is ever observed.
+        #
+        # Medido, não estimado, pelo mesmo motivo do repaint de nomes em
+        # main.py: este rebuild é DeleteAllItems() + um Append() por linha, ele
+        # roda a cada mensagem nova, e a janela deixou de ser limitada ao
+        # messages_page_size. Uma linha por rebuild diz quanto custa a janela
+        # no tamanho a que ela chegou.
+        _rebuild_started = time.monotonic()
         self.messages_list.Freeze()
         try:
             self.messages_list.DeleteAllItems()
@@ -13740,6 +13783,15 @@ class ConversationsPanel(wx.Panel):
                         logging.info("[populate_messages] default-select tail: list is empty (last=-1)")
         finally:
             self.messages_list.Thaw()
+            # A janela que acabou de ser pintada é o piso da próxima. Aqui, no
+            # finally, pelo mesmo motivo da assinatura abaixo: o corpo retorna
+            # de vários pontos, e um rebuild que não registrasse a janela
+            # deixaria o seguinte livre para cortá-la. Ver
+            # _remember_expanded_window().
+            try:
+                self._remember_expanded_window()
+            except Exception:
+                logging.exception("[populate_messages] failed to record the rendered window")
             # Snapshot what is now on screen so the next background refresh can
             # tell "nothing changed" apart from "needs a rebuild" — see
             # refresh_messages_if_changed(). Taken here, in the finally, because
@@ -13748,6 +13800,24 @@ class ConversationsPanel(wx.Panel):
                 self._messages_signature_cache = self._messages_signature()
             except Exception:
                 self._messages_signature_cache = None
+            _rebuild_ms = (time.monotonic() - _rebuild_started) * 1000.0
+            # Acima do limiar sobe para WARNING. Em INFO o número só aparece
+            # para quem já foi procurar por ele, e este é o laço que a janela
+            # sem teto alarga: DeleteAllItems() + um Append() por linha, a cada
+            # mensagem nova. 250 ms é uma ordem de grandeza abaixo dos stalls
+            # que o watchdog mediu no laço vizinho (9,4 s / 19,8 s / 40,1 s —
+            # ver _schedule_refresh_active_messages() em main.py), então o
+            # aviso chega no log antes de o usuário sentir travamento.
+            if _rebuild_ms > 250.0:
+                logging.warning(
+                    "[populate_messages] rebuilt %d row(s) in %.0f ms (offset=%d).",
+                    len(self._sorted_messages), _rebuild_ms, self._messages_offset,
+                )
+            elif logging.getLogger().isEnabledFor(logging.INFO):
+                logging.info(
+                    "[populate_messages] rebuilt %d row(s) in %.0f ms (offset=%d).",
+                    len(self._sorted_messages), _rebuild_ms, self._messages_offset,
+                )
 
 
     # ── Mass action handlers ────────────────────────────────────────────────

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -9882,27 +9882,203 @@ class ConversationsPanel(wx.Panel):
         return participant_jid.rsplit("@", 1)[0]
 
 
-    def refresh_active_conversation_messages(self):
-        """Re-render all messages in the active message list (useful after background name/LID resolution)."""
+    def _row_jids(self, msg, participant_by_id=None) -> set:
+        """Every JID whose newly-resolved name can change this row's text.
+
+        _render_message_line() resolves a name from five different places, and
+        all five have to be collected here or the row silently stops being
+        repainted:
+
+        * the sender (_sender_label);
+        * the quoted message's sender (_get_quoted_sender), by contextInfo
+          participant or, failing that, by stanzaId;
+        * every mention in the body and in the quoted preview
+          (_resolve_mentions_in_text);
+        * a group notification's author and recipients, which
+          _get_message_content() runs through _get_participant_name() to build
+          the "X added Y" sentence.
+
+        Each is expanded through the @lid <-> phone bridge: the row can carry
+        the @lid while the resolution loop reported the phone JID, and
+        comparing the raw strings would leave it stale.
+
+        *participant_by_id* maps message id -> sender JID for the rows
+        currently loaded. _get_quoted_sender() falls back to the quoted
+        message's own recorded sender when contextInfo carries a stanzaId but
+        no participant, so without that map such a reply would be missed.
+        """
+        if not isinstance(msg, dict):
+            return set()
+
+        def _as_jid_str(j) -> str:
+            # Same tolerance _get_message_content()'s own _as_jid_str() has:
+            # records written to disk by an older build can still carry a raw
+            # WPPConnect Wid dict here.
+            if isinstance(j, dict):
+                return j.get("_serialized") or j.get("id") or ""
+            return j if isinstance(j, str) else ""
+
+        key = msg.get("key") or {}
+        raw = [
+            key.get("participant") or "",
+            key.get("remoteJid") or "",
+            key.get("remoteJidAlt") or "",
+            msg.get("participant") or "",
+        ]
+        raw.extend(self._raw_mentioned_jids(msg) or [])
+        msg_obj = msg.get("message") or {}
+        ext = msg_obj.get("extendedTextMessage") or {} if isinstance(msg_obj, dict) else {}
+        # _raw_mentioned_jids() only reads mentionedJid; _get_message_content()
+        # also accepts the mentionedJidList spelling, so both are collected.
+        for ctx_candidate in (
+            msg.get("contextInfo"),
+            msg_obj.get("contextInfo") if isinstance(msg_obj, dict) else None,
+            ext.get("contextInfo") if isinstance(ext, dict) else None,
+        ):
+            if isinstance(ctx_candidate, dict):
+                raw.extend(ctx_candidate.get("mentionedJidList") or [])
+        # A group notification names its author and everyone it acted on, and
+        # the recipients live nowhere else in the message: only key.participant
+        # happens to mirror the author (WebSocketClient copies it there). A row
+        # left out here is the worst case this whole path has — the "X entrou
+        # no grupo" line falls back to raw @lid digits, _get_participant_name()
+        # itself kicks off the resolution meant to fix that very line, and the
+        # scoped repaint it schedules would then skip it.
+        notif = msg_obj.get("groupNotification") or {} if isinstance(msg_obj, dict) else {}
+        if isinstance(notif, dict) and notif:
+            raw.append(_as_jid_str(notif.get("author")))
+            raw.extend(_as_jid_str(r) for r in (notif.get("recipients") or []))
+        ctx = self._get_context_info(msg)
+        if ctx:
+            quoted_participant = ctx.get("participant") or ""
+            raw.append(quoted_participant)
+            if not quoted_participant and participant_by_id:
+                raw.append(participant_by_id.get(ctx.get("stanzaId") or "", ""))
+            quoted = ctx.get("quotedMessage") or {}
+            if isinstance(quoted, dict):
+                q_ext = quoted.get("extendedTextMessage") or {}
+                for holder in (
+                    quoted,
+                    quoted.get("contextInfo"),
+                    q_ext.get("contextInfo") if isinstance(q_ext, dict) else None,
+                ):
+                    if isinstance(holder, dict):
+                        raw.extend(holder.get("mentionedJid") or [])
+                        raw.extend(holder.get("mentionedJidList") or [])
+        mw = self.main_window
+        forms = set()
+        for jid in raw:
+            if not isinstance(jid, str) or not jid:
+                continue
+            normalized = mw._normalize_jid(jid)
+            if normalized:
+                forms.update(mw._jid_address_forms(normalized) or (normalized,))
+        return forms
+
+    def _message_ids_touching_jids(self, jids):
+        """Ids of the loaded messages whose rendered text depends on *jids*,
+        or None when the selective repaint cannot be trusted.
+
+        None means "repaint everything": a row that matches but carries no
+        key.id cannot be addressed by _set_message_row_texts(), and leaving it
+        behind is exactly the failure this path must never cause — the row
+        keeps announcing raw @lid/phone digits to the screen reader, which is
+        worse than the slowness the selective repaint buys back.
+        """
+        mw = self.main_window
+        targets = set()
+        for jid in jids or ():
+            if not isinstance(jid, str) or not jid:
+                continue
+            normalized = mw._normalize_jid(jid)
+            if normalized:
+                targets.update(mw._jid_address_forms(normalized) or (normalized,))
+        if not targets:
+            return None
+        # Built in its own pass so the quoted-sender fallback is a dict lookup
+        # rather than a scan of _sorted_messages per reply row.
+        participant_by_id = {}
+        for m in self._sorted_messages:
+            if not isinstance(m, dict) or self._is_separator(m):
+                continue
+            m_key = m.get("key") or {}
+            m_id = m_key.get("id") or ""
+            if m_id:
+                participant_by_id[m_id] = (
+                    m_key.get("participant") or m.get("participant")
+                    or m_key.get("remoteJid") or ""
+                )
+        ids = set()
+        for m in self._sorted_messages:
+            if not isinstance(m, dict) or self._is_separator(m):
+                continue
+            if not (self._row_jids(m, participant_by_id) & targets):
+                continue
+            m_id = (m.get("key") or {}).get("id") or ""
+            if not m_id:
+                return None
+            ids.add(m_id)
+        return ids
+
+    def refresh_active_conversation_messages(self, jids=None) -> int:
+        """Re-render messages in the active message list (useful after
+        background name/LID resolution). Returns how many rows it repainted.
+
+        *jids* narrows the work to the rows whose text can depend on those
+        JIDs. The message window has had no ceiling since it started
+        preserving the history the user loads with Home, so a full pass is
+        thousands of _render_message_line() calls once per resolved batch —
+        while a batch typically renames one person. None (the default) keeps
+        the original behaviour of re-rendering everything, and every path that
+        cannot say with certainty which rows changed falls back to it.
+        """
         if not self.conversation or not hasattr(self, "messages_list"):
-            return
+            return 0
+        target_ids = self._message_ids_touching_jids(jids) if jids else None
         # Um SetItemText por linha é um evento de acessibilidade por linha, e
         # os lotes de resolução de nomes/LID chamam isto repetidamente sobre a
         # lista inteira — sem congelar, o leitor de tela recebe a enxurrada e a
         # janela trava por segundos (ver as notas do watchdog em main.py).
         self.messages_list.Freeze()
         try:
+            if target_ids is not None:
+                # Reuses the same SetItemText loop the selection-marker
+                # refresh goes through; it already renders with an explicit
+                # index/total.
+                return len(self._set_message_row_texts(target_ids))
+            painted = 0
+            failed = 0
             total = len(self._sorted_messages)
             for i, msg in enumerate(self._sorted_messages):
                 if not self._is_separator(msg):
-                    # index/total explícitos como em _set_message_row_texts():
-                    # sem eles o modo listbox com contagem de itens cai no
-                    # fallback self._sorted_messages.index(msg), uma varredura
-                    # linear com comparação profunda de dicts por linha — e duas
-                    # mensagens de mesmo conteúdo anunciam a posição errada.
-                    self.messages_list.SetItemText(
-                        i, self._render_message_line(msg, index=i, total=total)
-                    )
+                    # Per row, not around the loop: a single malformed record
+                    # used to abort the whole pass, so every row after it kept
+                    # its old text — one bad message turning into a whole
+                    # conversation that stops being repainted. Only the first
+                    # traceback is logged, since this runs on a timer and a
+                    # permanently bad record would otherwise fill log.log.
+                    try:
+                        # index/total explícitos como em _set_message_row_texts():
+                        # sem eles o modo listbox com contagem de itens cai no
+                        # fallback self._sorted_messages.index(msg), uma varredura
+                        # linear com comparação profunda de dicts por linha — e duas
+                        # mensagens de mesmo conteúdo anunciam a posição errada.
+                        self.messages_list.SetItemText(
+                            i, self._render_message_line(msg, index=i, total=total)
+                        )
+                    except Exception:
+                        if not failed:
+                            logging.exception(
+                                "[refresh_active_conversation_messages] row %d "
+                                "failed to render; skipping it and continuing.", i)
+                        failed += 1
+                    else:
+                        painted += 1
+            if failed > 1:
+                logging.warning(
+                    "[refresh_active_conversation_messages] %d of %d rows failed "
+                    "to render.", failed, total)
+            return painted
         finally:
             self.messages_list.Thaw()
 

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -13504,6 +13504,188 @@ class ConversationsPanel(wx.Panel):
         if not self._repaint_message_rows(msg_ids):
             self.populate_messages(preserve_focus=True)
 
+    def _row_position_suffix_active(self) -> bool:
+        """Se cada linha carrega o sufixo ", N de M" (modo listbox com a
+        contagem de itens ligada).
+
+        Importa para quem acrescenta linha em vez de reconstruir: acrescentar
+        muda o M de TODAS as linhas já renderizadas, e só o rebuild re-renderiza
+        todas. Com o sufixo ligado, o caminho incremental deixaria a lista
+        inteira anunciando um total velho ao leitor de tela — pior que a
+        lentidão que ele evita.
+        """
+        if getattr(self, "_message_list_mode", "classic") != "listbox":
+            return False
+        mw = getattr(self, "main_window", None)
+        settings = getattr(mw, "settings", None)
+        if not isinstance(settings, dict):
+            return False
+        return bool(settings.get("user_interface", {}).get("show_listbox_item_count", False))
+
+    def _append_new_tail_rows(self, old_sig, new_sig) -> bool:
+        """Renderiza mensagens que só chegaram no FIM da conversa acrescentando
+        as linhas delas, em vez de reconstruir a lista. Devolve se a diferença
+        inteira entre as duas assinaturas foi coberta assim; quem chama
+        reconstrói quando não foi.
+
+        É o caso mais comum que sobrou passando pelo rebuild: mensagem nova. O
+        painel já a acrescenta ao vivo em on_incoming_message(), mas o refresh
+        de fundo que vem segundos depois (sync_chat_messages() ->
+        _refresh_open_conversation_after_sync(), o backfill de histórico, a
+        rodada de 60s) só sabia comparar a assinatura e chamar
+        populate_messages(): DeleteAllItems() mais um Append() por linha, para
+        pintar de novo o que já estava na tela — numa janela que agora pode ter
+        milhares de linhas. Mesma ideia de _repaint_message_rows(), que já faz
+        isso para estrela/fixar/apagar, e de refresh_chat_row_text() na lista de
+        conversas.
+
+        Na prática o caminho normal acrescenta ZERO linha: a mensagem já foi
+        pintada ao vivo, e o que este método faz é reconhecer isso e adotar a
+        assinatura, transformando o rebuild seguinte em nada. Acrescentar de
+        fato é o caminho de quem chegou pelo sync sem passar pelo live.
+
+        Recusa tudo que não seja "linhas novas no fim, nada mais mudou", porque
+        aí o rebuild é a única coisa que sabe onde a linha vai:
+
+        - qualquer linha existente que mudou de texto ou sumiu (a comparação
+          por id de _signature_changed_ids(), que já devolve None sozinha para
+          conversa trocada, separador movido ou id vazio/repetido);
+        - registro novo que não vira linha — a reação é o caso comum: ela muda
+          o texto de OUTRA linha, e a assinatura não diz de qual;
+        - registro novo mais antigo que a última linha, que entraria no meio da
+          lista ordenada por timestamp, não no fim;
+        - qualquer reordenação dos registros antigos, que a comparação por id
+          não veria e o sort estável do rebuild veria;
+        - lista fora de passo com o controle, lista vazia (acrescentar na lista
+          vazia com foco reproduz o pulo de foco para a linha 0 que o Freeze()
+          de populate_messages() documenta) e a lista de placeholder;
+        - o sufixo ", N de M" ligado (ver _row_position_suffix_active()).
+
+        Uma exceção à recusa por registro não exibível: reação a um status
+        NOSSO é linha de verdade (_is_displayable_message() ->
+        reaction_targets_status()), então ela é acrescentada como qualquer
+        mensagem. O rebuild também a poria em _reaction_map, e o atalho não —
+        sem divergência visível, porque essa entrada é chaveada por um id de
+        status@broadcast, que não tem linha nesta conversa para decorar.
+
+        Consequência deliberada, não efeito colateral: o separador de não
+        lidas que on_incoming_message() insere ao vivo passa a sobreviver a
+        este refresh. Ele nunca escreve _first_unread_msg_id, então o rebuild
+        não o renderizava de volta e ele sumia poucos segundos depois de
+        aparecer — o marcador de "onde começa o que eu não li" e o alvo do
+        Alt+3 evaporavam sozinhos. Mantê-lo é o que a inserção ao vivo
+        pretendia, e é seguro porque só se acrescenta na cauda: _unread_sep_idx
+        continua apontando para a mesma linha e _dismiss_unread_separator()
+        continua funcionando. A assimetria que sobra vale saber: o separador
+        ainda é removido pelo primeiro rebuild que qualquer OUTRA mudança
+        provocar.
+        """
+        if self.conversation is None or not self._sorted_messages:
+            return False
+        changed = self._signature_changed_ids(old_sig, new_sig)
+        if changed is None:
+            return False
+        old_rows, new_rows = old_sig[3], new_sig[3]
+        # Crescimento no fim, e nada mais: os registros antigos têm de continuar
+        # lá, iguais e na mesma ordem. Comparar só os conjuntos de id deixaria
+        # passar uma reordenação pura, e ela não é inócua — populate_messages()
+        # ordena por timestamp com sort estável, então duas mensagens de mesmo
+        # timestamp trocam de lugar no rebuild e a lista na tela deixaria de ser
+        # a que o rebuild produziria.
+        if len(new_rows) < len(old_rows) or new_rows[:len(old_rows)] != old_rows:
+            return False
+        added = {row[0] for row in new_rows[len(old_rows):]}
+        # Implicado pelo prefixo acima; custa uma comparação de conjuntos e
+        # prende a conclusão em vez de depender do raciocínio.
+        if changed != added:
+            return False
+        if self._row_position_suffix_active():
+            return False
+        # Lista de fora de passo com o controle: um Append() aqui desalinharia
+        # texto e registro para sempre. Mesma guarda de _repaint_message_rows().
+        if self.messages_list.GetItemCount() != len(self._sorted_messages):
+            logging.info("[_append_new_tail_rows] list out of step with rows — full path")
+            return False
+        first_row = self._sorted_messages[0]
+        if isinstance(first_row, dict) and first_row.get("_type") == "empty_placeholder":
+            return False
+
+        records = []
+        container = self.conversation.get("messages")
+        if isinstance(container, dict):
+            inner = container.get("messages")
+            if isinstance(inner, dict) and isinstance(inner.get("records"), list):
+                records = inner["records"]
+        newly = {}
+        for m in records:
+            if not isinstance(m, dict):
+                continue
+            mid = (m.get("key") or {}).get("id", "")
+            # `mid not in newly` é inalcançável — _signature_changed_ids() já
+            # devolveu None para id repetido — e fica pelo mesmo motivo que a
+            # comparação `changed != added` acima: o mapa por id só é seguro se
+            # o id for único, e isso passa a estar dito aqui também.
+            if mid in added and mid not in newly:
+                newly[mid] = m
+        if len(newly) != len(added):
+            return False
+        if any(not self._is_displayable_message(m) for m in newly.values()):
+            return False
+
+        rendered = {
+            (m.get("key") or {}).get("id", "")
+            for m in self._sorted_messages if not self._is_separator(m)
+        }
+        newcomers = [m for mid, m in newly.items() if mid not in rendered]
+        newcomers.sort(key=lambda m: self._extract_timestamp(m) or 0)
+        tail_ts = None
+        for m in reversed(self._sorted_messages):
+            if not self._is_separator(m):
+                tail_ts = self._extract_timestamp(m) or 0
+                break
+        if tail_ts is None:
+            # Só sentinela na tela e nenhuma mensagem: não há cauda contra a
+            # qual comparar, e um piso 0 aqui aprovaria qualquer timestamp.
+            return False
+        if any((self._extract_timestamp(m) or 0) < tail_ts for m in newcomers):
+            return False
+
+        if newcomers:
+            # _all_sorted_messages só acompanha enquanto as duas listas
+            # terminarem no mesmo objeto. O append ao vivo de
+            # on_incoming_message() já as deixa fora de passo no fim (situação
+            # anterior a isto, e inofensiva: _load_more_messages() fatia só a
+            # cabeça e _load_older_messages() no máximo re-consulta algumas
+            # mensagens que o dedup descarta), e não é este método que vai
+            # inventar um alinhamento que ele não tem como verificar.
+            # O `is not` não é paranoia: _sorted_messages tem de ser um SUFIXO
+            # de _all_sorted_messages, nunca o mesmo objeto de lista. Hoje todo
+            # produtor fatia ou concatena, então são sempre listas distintas;
+            # se alguma passar a aliasar, os dois append() abaixo virariam dois
+            # na mesma lista e ela desalinharia do controle.
+            in_step = (
+                self._all_sorted_messages
+                and self._all_sorted_messages is not self._sorted_messages
+                and self._all_sorted_messages[-1] is self._sorted_messages[-1]
+            )
+            self.messages_list.Freeze()
+            try:
+                for m in newcomers:
+                    if in_step:
+                        self._all_sorted_messages.append(m)
+                    self._sorted_messages.append(m)
+                    self.messages_list.Append((self._render_message_line(m),))
+            finally:
+                self.messages_list.Thaw()
+            self._remember_expanded_window()
+        self._messages_signature_cache = new_sig
+        logging.info(
+            "[_append_new_tail_rows] %d new record(s), %d row(s) appended, %d row(s) total "
+            "— no rebuild.",
+            len(added), len(newcomers), len(self._sorted_messages),
+        )
+        return True
+
     def refresh_messages_if_changed(self):
         """Repopulate the messages list only when its content actually changed.
 
@@ -13518,8 +13700,12 @@ class ConversationsPanel(wx.Panel):
         of the conversation roughly once a minute, mid-read.
 
         Nothing periodic needs a rebuild when nothing changed, so compare first
-        and skip. When something genuinely did change, the rebuild still runs
-        (and still preserves focus as best it can).
+        and skip. When the only difference is messages at the END of the
+        conversation — a new message, which is the overwhelmingly common case —
+        _append_new_tail_rows() covers it by appending those rows (usually
+        none: the live path already painted them) and the rebuild is skipped
+        too. Anything else still rebuilds in full, preserving focus as best it
+        can.
         """
         if self.conversation is None:
             return
@@ -13532,6 +13718,16 @@ class ConversationsPanel(wx.Panel):
             return
         if sig == getattr(self, "_messages_signature_cache", None):
             return
+        try:
+            if self._append_new_tail_rows(
+                getattr(self, "_messages_signature_cache", None), sig
+            ):
+                return
+        except Exception:
+            # O rebuild abaixo repinta a conversa inteira de qualquer forma, e
+            # é ele que estava aqui antes: uma falha no atalho não pode custar
+            # a atualização.
+            logging.exception("[refresh_messages_if_changed] tail append failed — full path")
         self._messages_signature_cache = sig
         self.populate_messages(preserve_focus=True)
 

--- a/tests/test_close_conversation_for_panel_switch.py
+++ b/tests/test_close_conversation_for_panel_switch.py
@@ -54,6 +54,10 @@ class _Stub:
     close_conversation = ConversationsPanel.close_conversation
     close_conversation_for_panel_switch = ConversationsPanel.close_conversation_for_panel_switch
     _stop_typing_for_current_conversation = ConversationsPanel._stop_typing_for_current_conversation
+    # Closing the conversation also drops the expanded history window, so the
+    # next chat opens at the configured page size instead of inheriting this
+    # one's thousands of rows.
+    _reset_expanded_window = ConversationsPanel._reset_expanded_window
 
     def __init__(self, conversation):
         self.main_window = _FakeMainWindow()
@@ -67,6 +71,8 @@ class _Stub:
         self._search_result_idx = -1
         self._msg_bookmarks = {}
         self._msg_temp_bookmarks = {}
+        self._expanded_visible_count = 0
+        self._expanded_oldest_msg_id = ""
         self.conversation_panel = _FakeWidget(shown=True)
         self.message_field = _FakeWidget()
         self.restore_calls = []
@@ -160,6 +166,23 @@ class TestBookmarkLifetimeOnClose:
         stub.close_conversation_for_panel_switch()
 
         assert stub._msg_bookmarks == {1: ("5511999999999@s.whatsapp.net", "MSG-A")}
+
+
+class TestExpandedHistoryWindowOnClose:
+    """History the user loaded with Home widens the message list past
+    messages_page_size for as long as that conversation is open. Closing it has
+    to drop that, or the next conversation opens rendering the previous one's
+    thousands of rows."""
+
+    def test_closing_resets_the_expanded_window(self):
+        stub = _Stub(_conv())
+        stub._expanded_visible_count = 4200
+        stub._expanded_oldest_msg_id = "MSG-OLD"
+
+        stub.close_conversation_for_panel_switch()
+
+        assert stub._expanded_visible_count == 0
+        assert stub._expanded_oldest_msg_id == ""
 
 
 class TestCloseConversationStillRestoresFocus:

--- a/tests/test_history_window_preservation.py
+++ b/tests/test_history_window_preservation.py
@@ -1,0 +1,509 @@
+"""Tests for keeping user-loaded history alive across a message-list rebuild.
+
+Reported as "a conversa some com as mensagens antigas": with
+``user_interface.messages_page_size`` = 200 the user pressed Home to pull older
+messages in, and a few seconds after the next message arrived the list snapped
+back to exactly 200 rows. Two independent defects added up to that:
+
+1. ``_load_older_messages()`` prepended what it read from the local DB only to
+   the panel's in-memory lists, never into
+   ``conversation["messages"]["messages"]["records"]`` — which is the only
+   thing ``populate_messages()`` rebuilds from. The server path already merged
+   (``MainWindow.fetch_older_messages()``), the local one did not, so that
+   history existed nowhere a rebuild could find it.
+
+2. ``populate_messages()`` recomputed the pagination window from the end of the
+   list on every rebuild, so even history that *was* in ``records`` got cut back
+   to the configured limit. ``_remember_expanded_window()`` now records how far
+   the list was expanded (count + the oldest displayed message as the anchor)
+   and ``history_window()`` turns that into the window the rebuild uses.
+
+The rebuild became frequent (every new message, plus the 60s resync) when
+``_refresh_open_conversation_after_sync()`` landed, which is why this only
+started showing up recently — the destructive rebuild is the bug, not its
+trigger.
+
+Two things the fix must NOT do are pinned here as well: the window is capped,
+because nothing shrinks it back while the conversation stays open and every row
+in it is re-rendered one by one by refresh_active_conversation_messages(); and
+only messages belonging to the open conversation reach ``records``, since the
+history query runs against ``_history_storage_jid()`` (possibly a stale @lid)
+and anything stored under the wrong contact now survives the whole session.
+
+ConversationsPanel is a wx.Panel and cannot be instantiated without a running
+wx.App, so the methods under test are exercised as plain functions against a
+small stub carrying just the attributes they touch — same approach as
+tests/test_message_bookmarks.py.
+"""
+
+import inspect
+
+import pytest
+
+from core.utils import expanded_min_visible, history_window, paginated_window
+from ui.conversations import ConversationsPanel
+
+JID = "1234567890@s.whatsapp.net"
+OTHER_JID = "1098765432@s.whatsapp.net"
+
+
+def _msg(mid, ts=0, jid=JID):
+    return {
+        "key": {"id": mid, "fromMe": False, "remoteJid": jid},
+        "timestamp": ts,
+        "messageTimestamp": ts,
+        "messageType": "conversation",
+    }
+
+
+def _chat(jid=JID, records=None):
+    return {
+        "remoteJid": jid,
+        "messages": {"messages": {"records": list(records or []),
+                                  "total": len(records or [])}},
+    }
+
+
+class _FakeList:
+    """Just enough wx.ListCtrl for the prepend paths (Freeze/Thaw + rebuild)."""
+
+    def __init__(self):
+        self.rows = []
+
+    def Freeze(self):
+        pass
+
+    def Thaw(self):
+        pass
+
+    def DeleteAllItems(self):
+        self.rows = []
+
+    def Append(self, row):
+        self.rows.append(row)
+
+    def Focus(self, idx):
+        pass
+
+    def Select(self, idx, on=True):
+        pass
+
+    def EnsureVisible(self, idx):
+        pass
+
+
+class _FakeDB:
+    def __init__(self, pages):
+        # pages: list of message lists, newest-first as the real DB returns them
+        self.pages = list(pages)
+        self.calls = []
+
+    def get_messages(self, jid, limit=200, offset=0):
+        self.calls.append((jid, limit, offset))
+        return self.pages.pop(0) if self.pages else []
+
+
+class _FakeMainWindow:
+    """Stands in for MainWindow: settings, the DB and the JID equivalence rule.
+
+    _chat_jids_equivalent() is reimplemented rather than bound, because the real
+    one pulls in _normalize_jid()/_jid_address_forms() and the whole @lid cache;
+    all the merge needs from it is "same conversation or not".
+    """
+
+    def __init__(self, db=None, page_size=200, lid_map=None):
+        self.db = db
+        self.settings = {"user_interface": {"messages_page_size": page_size}}
+        self._phone_to_lid = dict(lid_map or {})
+
+    def _chat_jids_equivalent(self, left, right):
+        def _forms(jid):
+            jid = (jid or "").replace("@c.us", "@s.whatsapp.net")
+            forms = {jid} if jid else set()
+            mapped = self._phone_to_lid.get(jid)
+            if mapped:
+                forms.add(mapped)
+            for phone, lid in self._phone_to_lid.items():
+                if lid == jid:
+                    forms.add(phone)
+            return forms
+        left_forms, right_forms = _forms(left), _forms(right)
+        return bool(left_forms and right_forms and (left_forms & right_forms))
+
+
+class _Stub:
+    """Minimal stand-in for ConversationsPanel for the history-load paths."""
+
+    def __init__(self, conversation=None, main_window=None, sorted_messages=None,
+                 messages_offset=0, all_sorted_messages=None):
+        self.conversation = conversation
+        self.main_window = main_window if main_window is not None else _FakeMainWindow()
+        self.messages_list = _FakeList()
+        self._all_sorted_messages = list(
+            all_sorted_messages if all_sorted_messages is not None
+            else (sorted_messages or [])
+        )
+        self._sorted_messages = list(sorted_messages or [])
+        self._messages_offset = messages_offset
+        self._unread_sep_idx = -1
+        self._is_loading_more = False
+        self._expanded_visible_count = 0
+        self._expanded_oldest_msg_id = ""
+        self._server_history_anchor = {}
+        self.server_fetch_calls = 0
+
+    # Real implementations under test.
+    _merge_history_into_records = ConversationsPanel._merge_history_into_records
+    _remember_expanded_window = ConversationsPanel._remember_expanded_window
+    _reset_expanded_window = ConversationsPanel._reset_expanded_window
+    _history_window_for_rebuild = ConversationsPanel._history_window_for_rebuild
+    _load_older_messages = ConversationsPanel._load_older_messages
+    _on_older_messages_loaded = ConversationsPanel._on_older_messages_loaded
+    _extract_timestamp = ConversationsPanel._extract_timestamp
+    _load_more_messages = ConversationsPanel._load_more_messages
+    _deduplicate_messages = ConversationsPanel._deduplicate_messages
+    _history_storage_jid = ConversationsPanel._history_storage_jid
+    _is_separator = ConversationsPanel._is_separator
+
+    # Collaborators the methods call through self, stubbed to the bare minimum.
+    def _is_displayable_message(self, msg):
+        return not self._is_separator(msg)
+
+    def _recompute_unread_sep_idx(self):
+        pass
+
+    def _render_message_line(self, msg):
+        return ""
+
+    def _load_older_messages_from_server(self):
+        self.server_fetch_calls += 1
+        self._is_loading_more = False
+
+
+class TestMergeHistoryIntoRecords:
+    def test_older_messages_are_prepended_and_total_updated(self):
+        chat = _chat(records=[_msg("new-1", 20)])
+        stub = _Stub(conversation=chat)
+        stub._merge_history_into_records([_msg("old-1", 5), _msg("old-2", 10)])
+        container = chat["messages"]["messages"]
+        assert [r["key"]["id"] for r in container["records"]] == ["old-1", "old-2", "new-1"]
+        assert container["total"] == 3
+
+    def test_merge_is_idempotent(self):
+        """self.conversation is usually the same dict as main_window.chats[jid],
+        and both paths (local DB and server) can merge the same page."""
+        chat = _chat(records=[_msg("new-1", 20)])
+        stub = _Stub(conversation=chat)
+        older = [_msg("old-1", 5)]
+        stub._merge_history_into_records(older)
+        stub._merge_history_into_records(older)
+        container = chat["messages"]["messages"]
+        assert [r["key"]["id"] for r in container["records"]] == ["old-1", "new-1"]
+        assert container["total"] == 2
+
+    def test_existing_records_are_not_reordered(self):
+        chat = _chat(records=[_msg("b", 30), _msg("a", 10)])
+        stub = _Stub(conversation=chat)
+        stub._merge_history_into_records([_msg("z", 1)])
+        assert [r["key"]["id"] for r in chat["messages"]["messages"]["records"]] == [
+            "z", "b", "a",
+        ]
+
+    def test_missing_containers_are_created(self):
+        chat = {"remoteJid": JID}
+        stub = _Stub(conversation=chat)
+        stub._merge_history_into_records([_msg("old-1", 5)])
+        assert chat["messages"]["messages"]["total"] == 1
+
+    def test_a_larger_stored_total_is_not_overwritten(self):
+        """`total` is the chat's real message count (db.get_message_count()),
+        which is legitimately larger than what is loaded — it only goes up."""
+        chat = _chat(records=[_msg("new-1", 20)])
+        chat["messages"]["messages"]["total"] = 4000
+        stub = _Stub(conversation=chat)
+        stub._merge_history_into_records([_msg("old-1", 5)])
+        assert chat["messages"]["messages"]["total"] == 4000
+
+    def test_no_conversation_or_no_messages_is_a_noop(self):
+        stub = _Stub(conversation=None)
+        stub._merge_history_into_records([_msg("old-1", 5)])  # must not raise
+        chat = _chat(records=[_msg("new-1", 20)])
+        stub2 = _Stub(conversation=chat)
+        stub2._merge_history_into_records([])
+        assert chat["messages"]["messages"]["total"] == 1
+
+
+class TestMergeRejectsForeignHistory:
+    """A stale/wrong @lid mapping makes the history query answer with someone
+    else's messages. They used to vanish on the next rebuild; stored in
+    `records` they become that contact's permanent history, because
+    sync_chat_messages() picks the local records back up without filtering."""
+
+    def test_messages_from_another_conversation_are_dropped(self):
+        chat = _chat(records=[_msg("new-1", 20)])
+        stub = _Stub(conversation=chat)
+        stub._merge_history_into_records(
+            [_msg("old-1", 5), _msg("stranger", 6, jid=OTHER_JID)]
+        )
+        ids = [r["key"]["id"] for r in chat["messages"]["messages"]["records"]]
+        assert ids == ["old-1", "new-1"]
+
+    def test_a_page_entirely_from_another_conversation_changes_nothing(self):
+        chat = _chat(records=[_msg("new-1", 20)])
+        stub = _Stub(conversation=chat)
+        stub._merge_history_into_records([_msg("stranger", 6, jid=OTHER_JID)])
+        assert [r["key"]["id"] for r in chat["messages"]["messages"]["records"]] == ["new-1"]
+
+    def test_the_matching_lid_form_is_still_accepted(self):
+        """The local history genuinely lives under the @lid for many one-to-one
+        chats — that is the mapping working, not a wrong one."""
+        lid = "111122223333@lid"
+        chat = _chat(records=[_msg("new-1", 20)])
+        stub = _Stub(conversation=chat,
+                     main_window=_FakeMainWindow(lid_map={JID: lid}))
+        stub._merge_history_into_records([_msg("old-1", 5, jid=lid)])
+        assert [r["key"]["id"] for r in chat["messages"]["messages"]["records"]] == [
+            "old-1", "new-1",
+        ]
+
+
+class TestLoadOlderMessagesPersistsHistory:
+    def _stub_with_local_history(self, page_size=2):
+        resident = [_msg("new-1", 100), _msg("new-2", 110)]
+        chat = _chat(records=list(resident))
+        # The DB returns newest-first; _load_older_messages() reverses it.
+        db = _FakeDB([[_msg("old-2", 20), _msg("old-1", 10)]])
+        stub = _Stub(
+            conversation=chat,
+            main_window=_FakeMainWindow(db=db, page_size=page_size),
+            sorted_messages=resident,
+        )
+        return stub, chat, db
+
+    def test_locally_loaded_history_reaches_the_conversation_records(self):
+        """Without this the prepend lived only in _sorted_messages, so the next
+        populate_messages() rebuilt the conversation without it."""
+        stub, chat, _db = self._stub_with_local_history()
+        stub._load_older_messages()
+        assert stub.server_fetch_calls == 0
+        assert [r["key"]["id"] for r in chat["messages"]["messages"]["records"]] == [
+            "old-1", "old-2", "new-1", "new-2",
+        ]
+        assert chat["messages"]["messages"]["total"] == 4
+
+    def test_the_expanded_window_is_recorded(self):
+        stub, _chat_dict, _db = self._stub_with_local_history()
+        stub._load_older_messages()
+        assert stub._expanded_visible_count == len(stub._sorted_messages) == 4
+        assert stub._expanded_oldest_msg_id == "old-1"
+
+    def test_a_duplicate_only_page_falls_through_to_the_server(self):
+        """No new unique messages means nothing to protect — the expanded count
+        must stay put rather than pinning a window that was never widened."""
+        resident = [_msg("new-1", 100)]
+        chat = _chat(records=list(resident))
+        db = _FakeDB([[_msg("new-1", 100)]])
+        stub = _Stub(
+            conversation=chat,
+            main_window=_FakeMainWindow(db=db),
+            sorted_messages=resident,
+        )
+        stub._load_older_messages()
+        assert stub.server_fetch_calls == 1
+        assert stub._expanded_visible_count == 0
+        assert stub._expanded_oldest_msg_id == ""
+
+
+class TestLoadMoreMessages:
+    """Paging back through history already in memory expands the window too —
+    without recording it, the next rebuild undid the page the user just asked
+    for, exactly the same way."""
+
+    def _stub(self):
+        history = [_msg(f"m-{i}", i) for i in range(10)]
+        return _Stub(
+            conversation=_chat(records=history),
+            main_window=_FakeMainWindow(page_size=4),
+            sorted_messages=history[6:],
+            all_sorted_messages=history,
+            messages_offset=6,
+        )
+
+    def test_paging_back_records_the_new_window(self):
+        stub = self._stub()
+        stub._load_more_messages()
+        assert stub._messages_offset == 2
+        assert stub._expanded_visible_count == len(stub._sorted_messages) == 8
+        assert stub._expanded_oldest_msg_id == "m-2"
+
+    def test_nothing_left_to_page_leaves_the_window_alone(self):
+        stub = self._stub()
+        stub._messages_offset = 0
+        stub._sorted_messages = list(stub._all_sorted_messages)
+        stub._load_more_messages()
+        assert stub._expanded_visible_count == 0
+
+
+class TestOlderMessagesFromTheServer:
+    """The deep-scrollback path, and the worse of the two: it runs where the
+    history is genuinely new and has never been in `records`, so losing it on
+    the next rebuild means fetching it from the phone all over again."""
+
+    def _stub(self):
+        resident = [_msg("new-1", 100), _msg("new-2", 110)]
+        return _Stub(
+            conversation=_chat(records=list(resident)),
+            sorted_messages=resident,
+        )
+
+    def test_fetched_history_reaches_the_conversation_records(self):
+        stub = self._stub()
+        # fetch_older_messages() answers newest-first, like the REST endpoint.
+        stub._on_older_messages_loaded([_msg("old-2", 20), _msg("old-1", 10)], JID)
+        records = stub.conversation["messages"]["messages"]["records"]
+        assert [r["key"]["id"] for r in records] == ["old-1", "old-2", "new-1", "new-2"]
+
+    def test_the_expanded_window_is_recorded(self):
+        stub = self._stub()
+        stub._on_older_messages_loaded([_msg("old-2", 20), _msg("old-1", 10)], JID)
+        assert stub._expanded_visible_count == len(stub._sorted_messages) == 4
+        assert stub._expanded_oldest_msg_id == "old-1"
+
+    def test_a_page_from_another_conversation_never_reaches_the_records(self):
+        """fetch_older_messages() has a fallback that re-queries under the
+        alternate JID and does not filter what comes back."""
+        stub = self._stub()
+        stub._on_older_messages_loaded([_msg("stranger", 10, jid=OTHER_JID)], JID)
+        records = stub.conversation["messages"]["messages"]["records"]
+        assert [r["key"]["id"] for r in records] == ["new-1", "new-2"]
+
+    def test_a_duplicate_only_page_leaves_the_window_alone(self):
+        stub = self._stub()
+        stub._on_older_messages_loaded([_msg("new-1", 100)], JID)
+        assert stub._expanded_visible_count == 0
+
+
+class TestHistoryWindowForRebuild:
+    """What populate_messages() actually calls. Driven as the real method
+    against the stub, so replacing the anchor arguments with empty values —
+    the silent revert that reintroduces the whole bug — fails here."""
+
+    def test_the_expanded_history_survives_the_rebuild(self):
+        displayable = [_msg(f"m-{i}", i) for i in range(400)]
+        stub = _Stub(conversation=_chat(records=displayable))
+        stub._expanded_visible_count = 400
+        stub._expanded_oldest_msg_id = "m-0"
+        assert stub._history_window_for_rebuild(displayable, 200) == (0, -1)
+
+    def test_messages_arriving_after_the_expansion_do_not_push_it_out(self):
+        displayable = [_msg(f"m-{i}", i) for i in range(410)]
+        stub = _Stub(conversation=_chat(records=displayable))
+        stub._expanded_visible_count = 400
+        stub._expanded_oldest_msg_id = "m-0"
+        assert stub._history_window_for_rebuild(displayable, 200)[0] == 0
+
+    def test_a_conversation_that_was_never_expanded_uses_the_page_size(self):
+        displayable = [_msg(f"m-{i}", i) for i in range(500)]
+        stub = _Stub(conversation=_chat(records=displayable))
+        assert stub._history_window_for_rebuild(displayable, 200)[0] == 300
+
+    def test_the_unread_separator_is_rebased_onto_the_window(self):
+        displayable = [_msg(f"m-{i}", i) for i in range(500)]
+        stub = _Stub(conversation=_chat(records=displayable))
+        stub._unread_sep_idx = 450
+        offset, sep = stub._history_window_for_rebuild(displayable, 200)
+        assert (offset, sep) == (300, 150)
+
+
+class TestExpandedWindowIsScopedToOneConversation:
+    def test_reset_clears_both_halves_of_the_anchor(self):
+        stub = _Stub(conversation=_chat())
+        stub._expanded_visible_count = 900
+        stub._expanded_oldest_msg_id = "m-0"
+        stub._reset_expanded_window()
+        assert stub._expanded_visible_count == 0
+        assert stub._expanded_oldest_msg_id == ""
+
+    def test_navigating_to_another_conversation_resets_it(self):
+        """navigate_to_conversation() cannot be driven from a stub (it rebuilds
+        the whole conversation panel), so this is the one place left where the
+        call itself is what gets checked — without it the next conversation
+        opens already rendering the previous one's thousands of rows.
+        _close_conversation_core() is covered for real in
+        tests/test_close_conversation_for_panel_switch.py."""
+        src = inspect.getsource(ConversationsPanel.navigate_to_conversation)
+        assert "self._reset_expanded_window()" in src
+
+
+class TestHistoryWindow:
+    """The whole decision populate_messages() delegates, in one call.
+
+    Kept as one function on purpose: with the panel state and paginated_window()
+    covered only separately, deleting the single line that carried the expanded
+    window between them reintroduced the entire bug with the suite still green.
+    """
+
+    def test_a_background_rebuild_keeps_the_loaded_history(self):
+        # 200 older messages loaded on top of the 200 already shown.
+        displayable = [_msg(f"m-{i}", i) for i in range(400)]
+        offset, sep = history_window(displayable, "m-0", 400, 200, -1)
+        assert (offset, sep) == (0, -1), "the rebuild must not cut back to 200"
+
+    def test_new_messages_do_not_slide_the_window_forward(self):
+        """Three messages arrived after the expansion: the list must grow at the
+        bottom, not lose its three oldest rows at the top."""
+        displayable = [_msg(f"m-{i}", i) for i in range(403)]
+        assert history_window(displayable, "m-0", 400, 200, -1)[0] == 0
+
+    def test_a_deleted_anchor_falls_back_to_the_count(self):
+        """The oldest displayed message was deleted remotely — the window may
+        end up one row narrower, but must not collapse back to the page size."""
+        displayable = [_msg(f"m-{i}", i) for i in range(1, 400)]
+        assert history_window(displayable, "m-0", 400, 200, -1)[0] == 0
+
+    def test_no_expansion_leaves_the_page_size_alone(self):
+        displayable = [_msg(f"m-{i}", i) for i in range(500)]
+        assert history_window(displayable, "", 0, 200, -1)[0] == 300
+
+    def test_a_huge_expansion_is_not_capped(self):
+        """Twenty Page Ups in a 6000-message group stay on screen. A standing
+        cap looked prudent and is the original bug with a higher floor: the
+        first message to arrive would cut the window back to it, wiping 2200
+        rows out from under the reader, every later rebuild would repeat the
+        cut, and the Home that follows would be undone again — history past the
+        cap becomes permanently unreachable."""
+        displayable = [_msg(f"m-{i}", i) for i in range(6000)]
+        # 4200 rows expanded, so the oldest one on screen is m-1800.
+        assert history_window(displayable, "m-1800", 4200, 200, -1)[0] == 1800
+
+    def test_the_cap_is_off_by_default_but_still_available(self):
+        displayable = [_msg(f"m-{i}", i) for i in range(1000)]
+        assert history_window(displayable, "m-0", 1000, 200, -1)[0] == 0
+        assert history_window(displayable, "m-0", 1000, 200, -1, cap=500)[0] == 500
+        # 0 and anything non-positive mean "no ceiling", not "no widening".
+        assert history_window(displayable, "m-0", 1000, 200, -1, cap=0)[0] == 0
+        assert history_window(displayable, "m-0", 1000, 200, -1, cap=-5)[0] == 0
+
+    def test_a_cap_never_cuts_into_the_unread_separator(self):
+        """A caller passing one bounds the history the user asked for, not the
+        separator — cutting above it would drop every genuinely unread message,
+        which is what paginated_window()'s own widening exists to prevent."""
+        displayable = [_msg(f"m-{i}", i) for i in range(6000)]
+        sep_idx = 6000 - 2500
+        offset, sep = history_window(displayable, "m-0", 4200, 200, sep_idx, cap=2000)
+        assert offset == sep_idx
+        assert sep == 0
+
+    def test_a_non_numeric_expanded_count_falls_back_to_the_page_size(self):
+        """settings.json is hand-editable and this state is read defensively
+        with getattr() — a junk value must not take the whole rebuild down."""
+        displayable = [_msg(f"m-{i}", i) for i in range(500)]
+        assert history_window(displayable, "", None, 200, -1)[0] == 300
+        assert history_window(displayable, "", "abc", 200, -1)[0] == 300
+
+    def test_it_agrees_with_the_pieces_it_composes(self):
+        displayable = [_msg(f"m-{i}", i) for i in range(900)]
+        min_visible = expanded_min_visible(displayable, "m-100", 300)
+        assert history_window(displayable, "m-100", 300, 200, -1) == paginated_window(
+            900, 200, -1, min_visible=min_visible
+        )

--- a/tests/test_history_window_preservation.py
+++ b/tests/test_history_window_preservation.py
@@ -23,12 +23,21 @@ The rebuild became frequent (every new message, plus the 60s resync) when
 started showing up recently — the destructive rebuild is the bug, not its
 trigger.
 
-Two things the fix must NOT do are pinned here as well: the window is capped,
-because nothing shrinks it back while the conversation stays open and every row
-in it is re-rendered one by one by refresh_active_conversation_messages(); and
-only messages belonging to the open conversation reach ``records``, since the
-history query runs against ``_history_storage_jid()`` (possibly a stale @lid)
-and anything stored under the wrong contact now survives the whole session.
+3. The anchor was recorded only where history was pulled in by hand, so a
+   conversation the user never expanded kept the old behaviour with the floor
+   at the page size: it opens with 200 rows, the live-append paths grow it past
+   that (nothing trims on append), and the first background rebuild snapped it
+   back to 200 — one old row deleted under the reader per new message. That is
+   how the report came back after (1) and (2) shipped. ``populate_messages()``
+   now records the window it just painted, so the floor is what is on screen,
+   not what Home loaded.
+
+Two things the fix must NOT do are pinned here as well: the window must not be
+capped, because a standing cap is this same bug with a higher floor (see
+``test_a_huge_expansion_is_not_capped``); and only messages belonging to the
+open conversation may reach ``records``, since the history query runs against
+``_history_storage_jid()`` (possibly a stale @lid) and anything stored under
+the wrong contact now survives the whole session.
 
 ConversationsPanel is a wx.Panel and cannot be instantiated without a running
 wx.App, so the methods under test are exercised as plain functions against a
@@ -507,3 +516,86 @@ class TestHistoryWindow:
         assert history_window(displayable, "m-100", 300, 200, -1) == paginated_window(
             900, 200, -1, min_visible=min_visible
         )
+
+
+class TestTheRenderedWindowIsTheFloor:
+    """A segunda metade do mesmo bug, relatada depois da âncora: sem nunca
+    pressionar Home, a lista abre com 200 linhas, cresce por append a cada
+    mensagem, e o rebuild seguinte a devolve a 200 — sumindo com uma linha
+    antiga por mensagem nova, exatamente o sintoma original com o piso no page
+    size. O log da sessão que reproduziu isto mostra a sequência inteira:
+    200 -> 201 -> 202 -> 204 linhas e, 17 segundos depois, 200 de novo.
+
+    A correção é o piso deixar de ser "o que o Home trouxe" e passar a ser "o
+    que já está na tela": populate_messages() registra a janela que acabou de
+    pintar."""
+
+    def _rendered(self, n, offset=0):
+        stub = _Stub(sorted_messages=[_msg(f"m-{i}", i) for i in range(offset, offset + n)])
+        stub._remember_expanded_window()
+        return stub
+
+    def test_four_sent_messages_do_not_drop_four_rows(self):
+        """O relato, ponta a ponta: 200 linhas na tela, 4 mensagens enviadas,
+        repaint. As 4 linhas mais antigas têm de continuar lá."""
+        stub = self._rendered(200, offset=300)
+        # Os appends ao vivo (on_incoming_message() e o envio otimista) não
+        # passam por populate_messages(); o rebuild é que vem depois.
+        displayable = [_msg(f"m-{i}", i) for i in range(300, 504)]
+        offset, sep = stub._history_window_for_rebuild(displayable, 200)
+        assert (offset, sep) == (0, -1), "o rebuild cortou de volta ao page size"
+        assert len(displayable[offset:]) == 204
+
+    def test_the_window_only_grows_while_the_conversation_stays_open(self):
+        """Cada rebuild registra a janela que pintou, então o piso acompanha as
+        chegadas em vez de ficar preso na contagem da abertura."""
+        stub = self._rendered(200, offset=300)
+        displayable = [_msg(f"m-{i}", i) for i in range(300, 504)]
+        stub._sorted_messages = displayable[stub._history_window_for_rebuild(displayable, 200)[0]:]
+        stub._remember_expanded_window()
+        assert stub._expanded_visible_count == 204
+        assert stub._expanded_oldest_msg_id == "m-300"
+        displayable = [_msg(f"m-{i}", i) for i in range(300, 510)]
+        assert stub._history_window_for_rebuild(displayable, 200)[0] == 0
+
+    def test_opening_a_conversation_still_honours_the_page_size(self):
+        """O piso é o que foi pintado, não tudo que existe: uma conversa recém
+        aberta continua rendendo messages_page_size linhas, e só a partir daí
+        para de encolher."""
+        stub = _Stub()
+        displayable = [_msg(f"m-{i}", i) for i in range(500)]
+        assert stub._history_window_for_rebuild(displayable, 200)[0] == 300
+
+    def test_populate_messages_records_the_window_it_rendered(self):
+        """populate_messages() precisa de um wx.ListCtrl de verdade, então o
+        que dá para prender aqui é a chamada — sem ela o piso volta a ser só o
+        que o Home carregou e o corte a cada mensagem nova volta junto."""
+        src = inspect.getsource(ConversationsPanel.populate_messages)
+        assert "self._remember_expanded_window()" in src
+
+    def test_a_list_with_only_a_placeholder_records_nothing(self):
+        """Conversa sem histórico exibível: um piso de 1 linha não significa
+        nada e a âncora vazia não prenderia coisa alguma."""
+        stub = _Stub(sorted_messages=[{"_type": "empty_placeholder"}])
+        stub._remember_expanded_window()
+        assert stub._expanded_visible_count == 0
+        assert stub._expanded_oldest_msg_id == ""
+
+    def test_the_unread_separator_is_never_the_anchor(self):
+        """O separador não tem key.id; ancorar nele perderia a âncora inteira."""
+        sep = {"_type": "unread_separator", "count": 3}
+        stub = _Stub(sorted_messages=[sep] + [_msg(f"m-{i}", i) for i in range(10)])
+        stub._remember_expanded_window()
+        assert stub._expanded_oldest_msg_id == "m-0"
+        assert stub._expanded_visible_count == 11
+
+    def test_a_record_without_a_key_does_not_take_the_rebuild_down(self):
+        """key ausente ou None aparece em registro malformado, e isto agora roda
+        no finally de todo rebuild — levantar aqui derrubaria a lista inteira."""
+        stub = _Stub(sorted_messages=[{"timestamp": 1}, _msg("m-1", 1)])
+        stub._remember_expanded_window()
+        assert stub._expanded_oldest_msg_id == ""
+        assert stub._expanded_visible_count == 2
+        stub = _Stub(sorted_messages=[{"key": None, "timestamp": 1}])
+        stub._remember_expanded_window()
+        assert stub._expanded_oldest_msg_id == ""

--- a/tests/test_history_window_preservation.py
+++ b/tests/test_history_window_preservation.py
@@ -594,8 +594,35 @@ class TestTheRenderedWindowIsTheFloor:
         no finally de todo rebuild — levantar aqui derrubaria a lista inteira."""
         stub = _Stub(sorted_messages=[{"timestamp": 1}, _msg("m-1", 1)])
         stub._remember_expanded_window()
-        assert stub._expanded_oldest_msg_id == ""
         assert stub._expanded_visible_count == 2
         stub = _Stub(sorted_messages=[{"key": None, "timestamp": 1}])
         stub._remember_expanded_window()
         assert stub._expanded_oldest_msg_id == ""
+
+    def test_a_malformed_record_on_top_does_not_cost_the_anchor(self):
+        """Um registro sem key.id no topo não pode zerar a âncora.
+
+        Parar nele deixava só o piso por contagem, e o piso sozinho escorrega
+        uma linha para frente a cada mensagem que chega ao vivo — que é
+        exatamente o sintoma que esta janela existe para corrigir, reaparecendo
+        por outra porta. A âncora passa a ser a primeira linha que TEM id.
+        """
+        stub = _Stub(sorted_messages=[
+            {"timestamp": 1},
+            {"key": None, "timestamp": 2},
+            {"key": {"id": ""}, "timestamp": 3},
+            _msg("m-4", 4),
+            _msg("m-5", 5),
+        ])
+        stub._remember_expanded_window()
+        assert stub._expanded_oldest_msg_id == "m-4"
+        assert stub._expanded_visible_count == 5
+
+    def test_an_anchor_further_in_only_widens_the_window(self):
+        """A âncora mais nova nunca estreita: expanded_min_visible() aplica
+        max(piso, âncora), e o piso é a contagem inteira da lista."""
+        displayable = [_msg(f"m-{i}", i) for i in range(500)]
+        # Âncora em m-100 => 400 linhas; piso (contagem registrada) => 450.
+        assert expanded_min_visible(displayable, "m-100", 450) == 450
+        # E com a âncora mais antiga que o piso, é ela que manda.
+        assert expanded_min_visible(displayable, "m-100", 10) == 400

--- a/tests/test_lid_mapping_defer_ui.py
+++ b/tests/test_lid_mapping_defer_ui.py
@@ -47,12 +47,16 @@ class _Stub:
         # (see tests/test_lid_mapping_thread_safety.py for what it guards).
         self._lid_mapping_lock = threading.RLock()
         self.refreshes = 0
+        self.message_refresh_jids = []
 
     def _is_self_jid(self, jid):
         return False
 
     def _schedule_set_chats(self):
         self.refreshes += 1
+
+    def _schedule_refresh_active_messages(self, jids=None):
+        self.message_refresh_jids.append(None if jids is None else set(jids))
 
 
 LID = "111222333444555@lid"
@@ -109,3 +113,37 @@ class TestRegisterJidMapping:
         stub.db.set_lid_mapping = lambda l, p: written.append((l, p))
         stub.register_jid_mapping(LID, PHONE, defer_ui=True)
         assert written == [(LID, PHONE)]
+
+
+class TestTheOpenConversationIsRepaintedToo:
+    """Only relevant since the message repaint became scoped.
+
+    The non-batch mapping writers — _extract_lid_mapping() on the Socket.IO
+    thread and _get_participant_name()'s inline learn — never scheduled a
+    message repaint of their own; they were fixed up by whatever unrelated full
+    repaint happened next. Now that every repaint is scoped to the JIDs its own
+    caller resolved, that free ride is gone and a chat whose @lid was just
+    bridged would keep announcing raw digits until it was reopened.
+    """
+
+    def test_a_new_mapping_repaints_the_open_conversation(self, stub):
+        stub.register_jid_mapping(LID, PHONE)
+        assert stub.message_refresh_jids == [{LID, PHONE}]
+
+    def test_both_address_forms_are_handed_over(self, stub):
+        """The rows can carry either one, and which they carry depends on who
+        sent the message."""
+        stub.register_jid_mapping(LID, PHONE)
+        assert stub.message_refresh_jids[0] == {LID, PHONE}
+
+    def test_defer_ui_suppresses_it_like_the_chat_list(self, stub):
+        stub.register_jid_mapping(LID, PHONE, defer_ui=True)
+        assert stub.message_refresh_jids == []
+
+    def test_a_mapping_already_known_schedules_nothing(self, stub):
+        """What keeps this terminating: _get_participant_name() can reach here
+        from inside a render, so a repaint could schedule a repaint. A mapping
+        is only `changed` once, so the second pass is silent."""
+        stub.register_jid_mapping(LID, PHONE)
+        stub.register_jid_mapping(LID, PHONE)
+        assert len(stub.message_refresh_jids) == 1

--- a/tests/test_lid_mapping_thread_safety.py
+++ b/tests/test_lid_mapping_thread_safety.py
@@ -117,6 +117,9 @@ class _Stub:
     def _schedule_set_chats(self):
         pass
 
+    def _schedule_refresh_active_messages(self, jids=None):
+        pass
+
 
 def _msg(i):
     lid = f"{1000 + i}@lid"

--- a/tests/test_mentions_scan_refresh.py
+++ b/tests/test_mentions_scan_refresh.py
@@ -53,6 +53,9 @@ class _Stub:
         self._contact_resolution_lock = threading.Lock()
         self.refreshes = 0
         self.message_refreshes = 0
+        self.message_refresh_jids = []
+        self.bulk_name_batches = []
+        self.bulk_learns_names = False
         self.mapped_calls = []
         self.resolved_lid_batches = []
         self.profile_lookups = []
@@ -72,7 +75,8 @@ class _Stub:
         return {"response": {"name": "Alguém"}}
 
     def _learn_sender_names_bulk(self, records):
-        pass
+        self.bulk_name_batches.append(list(records))
+        return self.bulk_learns_names
 
     def _needs_sender_resolution(self, jid):
         return False
@@ -83,8 +87,9 @@ class _Stub:
     def _schedule_set_chats(self):
         self.refreshes += 1
 
-    def _schedule_refresh_active_messages(self):
+    def _schedule_refresh_active_messages(self, jids=None):
         self.message_refreshes += 1
+        self.message_refresh_jids.append(None if jids is None else set(jids))
 
 
 def _make(chats):
@@ -120,6 +125,15 @@ class TestAScanThatOnlyLearnsMappings:
         stub = _make({LID: _chat_with_alt()})
         stub.scan_all_cached_messages_for_mentions()
         assert stub.message_refreshes == 1
+
+    def test_the_repaint_is_scoped_to_both_sides_of_the_learned_mapping(self):
+        """The rows of a conversation with thousands of loaded messages are
+        repainted selectively now, and the open conversation may render this
+        participant under either address — so both have to be handed over or
+        the row keeps announcing raw @lid digits."""
+        stub = _make({LID: _chat_with_alt()})
+        stub.scan_all_cached_messages_for_mentions()
+        assert stub.message_refresh_jids == [{LID, PHONE}]
 
     def test_nothing_was_resolved_through_the_api(self):
         """Pins the premise: this scan never reaches
@@ -216,3 +230,45 @@ class TestTheEmptyAccount:
         stub = _make({})
         stub.scan_all_cached_messages_for_mentions()
         assert stub.refreshes == 0
+
+
+class TestTheBulkPushNamePassForcesAFullRepaint:
+    """_learn_sender_names_bulk() writes names for arbitrary participant JIDs
+    and reports none of them — not in `mapped_jids` (only remoteJidAlt pairs)
+    and not in `updated_contacts` (only mentions resolved through the API).
+
+    Routine on a new account: an open group of ~4000 rows, the scan learns
+    pushNames for 40 participants plus one unrelated 1:1 mapping. `mapped == 1`
+    opens the gate, the repaint goes out scoped to that one pair, no row of the
+    group matches, and all 40 participants keep showing a formatted number
+    until the conversation is reopened. The scan runs once, not at 1 Hz, so
+    asking for the whole list back is free here.
+    """
+
+    def test_learning_any_pushname_asks_for_the_full_repaint(self):
+        stub = _make({LID: _chat_with_alt()})
+        stub.bulk_learns_names = True
+        stub.scan_all_cached_messages_for_mentions()
+        assert stub.message_refresh_jids == [None]
+
+    def test_it_alone_is_enough_to_open_the_gate(self):
+        """A scan that learned only pushNames changes no contact record and no
+        mapping, so `updated_contacts or mapped` would have skipped the refresh
+        entirely and left every one of those names unpainted."""
+        chat = {PHONE: {"remoteJid": PHONE, "messages": {"messages": {"records": [
+            {"key": {"id": "m1", "remoteJid": PHONE}},
+        ]}}}}
+        stub = _make(chat)
+        stub.bulk_learns_names = True
+        stub.scan_all_cached_messages_for_mentions()
+        assert stub.message_refreshes == 1
+        assert stub.message_refresh_jids == [None]
+        assert stub.refreshes == 1
+
+    def test_learning_nothing_keeps_the_repaint_scoped(self):
+        """The widening must be conditional — otherwise the scan is back to a
+        full repaint of a 4000-row conversation on every run."""
+        stub = _make({LID: _chat_with_alt()})
+        stub.bulk_learns_names = False
+        stub.scan_all_cached_messages_for_mentions()
+        assert stub.message_refresh_jids == [{LID, PHONE}]

--- a/tests/test_message_list_refresh.py
+++ b/tests/test_message_list_refresh.py
@@ -11,7 +11,16 @@ unread separator, focus lands somewhere else entirely.
 
 refresh_messages_if_changed() compares a fingerprint of what would be rendered
 and skips the rebuild when nothing changed, so periodic polls stop touching the
-list at all. Anything that genuinely changed still rebuilds.
+list at all.
+
+The case that stayed expensive was the commonest one: a new message. The panel
+already appends it live in on_incoming_message(), and the background refresh
+seconds later rebuilt the whole list to paint what was already on screen — over
+a window that, since it stopped being capped at messages_page_size, can hold
+thousands of rows. _append_new_tail_rows() now covers "rows added at the end and
+nothing else" by appending them (usually none, the live path having painted
+them). Everything else still rebuilds; TestTailAppendInsteadOfRebuild pins where
+the line is.
 
 ConversationsPanel is a wx.Panel and cannot be instantiated without a running
 wx.App, so the methods under test are exercised as plain functions against a
@@ -23,8 +32,35 @@ import pytest
 from ui.conversations import ConversationsPanel
 
 
+class _FakeList:
+    """Só o que o caminho incremental toca de um wx.ListCtrl."""
+
+    def __init__(self):
+        self.rows = []
+
+    def GetItemCount(self):
+        return len(self.rows)
+
+    def Append(self, row):
+        self.rows.append(row[0] if isinstance(row, tuple) else row)
+
+    def Freeze(self):
+        pass
+
+    def Thaw(self):
+        pass
+
+
 class _Stub:
     _messages_signature = ConversationsPanel._messages_signature
+    # staticmethod no painel real; sem reembrulhar, o self entraria como
+    # primeiro argumento.
+    _signature_changed_ids = staticmethod(ConversationsPanel._signature_changed_ids)
+    _append_new_tail_rows = ConversationsPanel._append_new_tail_rows
+    _row_position_suffix_active = ConversationsPanel._row_position_suffix_active
+    _remember_expanded_window = ConversationsPanel._remember_expanded_window
+    _is_separator = ConversationsPanel._is_separator
+    _is_displayable_message = ConversationsPanel._is_displayable_message
     refresh_messages_if_changed = ConversationsPanel.refresh_messages_if_changed
 
     def __init__(self, records=None, jid="g@g.us"):
@@ -36,6 +72,12 @@ class _Stub:
         self._pending_open_unread = 0
         self._messages_signature_cache = None
         self.populate_calls = []
+        self.messages_list = _FakeList()
+        self._sorted_messages = []
+        self._all_sorted_messages = []
+        self._expanded_visible_count = 0
+        self._expanded_oldest_msg_id = ""
+        self._unread_sep_idx = -1
 
     # The panel's own helpers, kept trivial here: what is under test is how the
     # signature is composed and what it decides, not their formatting.
@@ -47,10 +89,23 @@ class _Stub:
     def _get_message_content(msg):
         return (msg.get("message") or {}).get("conversation", "")
 
+    def _render_message_line(self, msg, index=None, total=None):
+        return self._get_message_content(msg)
+
     def populate_messages(self, preserve_focus=False):
         self.populate_calls.append(preserve_focus)
-        # Mirrors the real method's finally block, including its tolerance of a
-        # signature that raises.
+        # O rebuild de verdade, no essencial que estes testes checam: ordena os
+        # exibíveis por timestamp, refaz a lista do zero e só então tira a
+        # fotografia da assinatura (o finally do método real, tolerância a uma
+        # assinatura que levanta incluída).
+        displayable = sorted(
+            (m for m in self._records
+             if isinstance(m, dict) and self._is_displayable_message(m)),
+            key=lambda m: self._extract_timestamp(m) or 0,
+        )
+        self._all_sorted_messages = list(displayable)
+        self._sorted_messages = list(displayable)
+        self.messages_list.rows = [self._render_message_line(m) for m in displayable]
         try:
             self._messages_signature_cache = self._messages_signature()
         except Exception:
@@ -87,12 +142,15 @@ class TestRefreshMessagesIfChanged:
             s.refresh_messages_if_changed()
         assert s.populate_calls == [True], "only the initial render should have run"
 
-    def test_a_new_message_rebuilds(self):
+    def test_a_new_message_appends_instead_of_rebuilding(self):
+        """Era um rebuild inteiro por mensagem nova. Ver
+        TestTailAppendInsteadOfRebuild para o resto do contrato."""
         s = _Stub([_msg("a")])
         s.refresh_messages_if_changed()
-        s._records.append(_msg("b"))
+        s._records.append(_msg("b", text="nova", ts=2000))
         s.refresh_messages_if_changed()
-        assert s.populate_calls == [True, True]
+        assert s.populate_calls == [True]
+        assert s.messages_list.rows == ["oi", "nova"]
 
     def test_a_deleted_message_rebuilds(self):
         s = _Stub([_msg("a"), _msg("b")])
@@ -191,3 +249,212 @@ class TestMessagesSignature:
         s = _Stub()
         s.conversation = {"remoteJid": "g@g.us"}
         assert s._messages_signature()
+
+
+class TestTailAppendInsteadOfRebuild:
+    """Mensagem nova deixa de reconstruir a lista inteira.
+
+    Era o caso mais comum que ainda passava pelo rebuild: o painel já
+    acrescenta a mensagem ao vivo em on_incoming_message(), e o refresh de
+    fundo que vem segundos depois (sync_chat_messages() ->
+    _refresh_open_conversation_after_sync(), o backfill de histórico, a rodada
+    de 60s) fazia DeleteAllItems() mais um Append() por linha só para pintar de
+    novo o que já estava na tela — numa janela que, desde que ela deixou de ser
+    limitada ao messages_page_size, pode ter milhares de linhas.
+
+    O critério que governa o atalho é que a lista tem de terminar exatamente
+    como o rebuild a deixaria; tudo que não for "linha nova no fim, nada mais
+    mudou" continua reconstruindo."""
+
+    def _rendered(self, records):
+        s = _Stub(list(records))
+        s.refresh_messages_if_changed()   # rebuild inicial
+        return s
+
+    def _paint_live(self, s, msg):
+        """O que on_incoming_message() faz, e SÓ o que ele faz.
+
+        Ele não toca _all_sorted_messages (conversations.py, o append no fim
+        de on_incoming_message): é justamente esse desalinhamento que a guarda
+        in_step do atalho tem de enxergar, e um fixture que o "consertasse"
+        deixaria a guarda sem teste nenhum."""
+        s._records.append(msg)
+        s._sorted_messages.append(msg)
+        s.messages_list.rows.append(s._render_message_line(msg))
+
+    def test_the_common_case_appends_nothing_because_the_live_path_painted_it(self):
+        s = self._rendered([_msg("a")])
+        self._paint_live(s, _msg("b", text="nova", ts=2000))
+        s.refresh_messages_if_changed()
+        assert s.populate_calls == [True], "o rebuild por mensagem nova sumiu"
+        assert s.messages_list.rows == ["oi", "nova"], "não pode duplicar a linha"
+
+    def test_the_poll_after_that_does_nothing_at_all(self):
+        """A assinatura tem de ser adotada, senão o rebuild só foi adiado."""
+        s = self._rendered([_msg("a")])
+        self._paint_live(s, _msg("b", text="nova", ts=2000))
+        s.refresh_messages_if_changed()
+        for _ in range(10):
+            s.refresh_messages_if_changed()
+        assert s.populate_calls == [True]
+        assert s.messages_list.rows == ["oi", "nova"]
+
+    def test_a_message_that_only_reached_records_is_appended(self):
+        """Chegou pelo sync, sem passar pelo caminho ao vivo: a linha não está
+        na tela e é este método que tem de pintá-la."""
+        s = self._rendered([_msg("a")])
+        s._records.append(_msg("b", text="nova", ts=2000))
+        s.refresh_messages_if_changed()
+        assert s.populate_calls == [True]
+        assert s.messages_list.rows == ["oi", "nova"]
+        assert [m["key"]["id"] for m in s._sorted_messages] == ["a", "b"]
+        assert [m["key"]["id"] for m in s._all_sorted_messages] == ["a", "b"]
+
+    def test_several_at_once_are_appended_in_timestamp_order(self):
+        s = self._rendered([_msg("a", ts=1000)])
+        s._records.append(_msg("c", text="terceira", ts=3000))
+        s._records.append(_msg("b", text="segunda", ts=2000))
+        s.refresh_messages_if_changed()
+        assert s.populate_calls == [True]
+        assert s.messages_list.rows == ["oi", "segunda", "terceira"]
+
+    def test_a_message_older_than_the_last_row_rebuilds(self):
+        """Ela entra no meio da lista ordenada por timestamp, não no fim — só o
+        rebuild sabe onde."""
+        s = self._rendered([_msg("a", ts=5000)])
+        s._records.append(_msg("b", text="antiga", ts=1000))
+        s.refresh_messages_if_changed()
+        assert len(s.populate_calls) == 2
+
+    def test_a_new_record_that_is_not_a_row_rebuilds(self):
+        """A reação é o caso comum: ela muda o texto de OUTRA linha, e a
+        assinatura não diz de qual."""
+        s = self._rendered([_msg("a")])
+        s._records.append(_msg("r", ts=2000, messageType="reactionMessage"))
+        s.refresh_messages_if_changed()
+        assert len(s.populate_calls) == 2
+
+    def test_a_row_changing_alongside_a_new_one_rebuilds(self):
+        s = self._rendered([_msg("a")])
+        s._records[0]["status"] = "READ"
+        s._records.append(_msg("b", ts=2000))
+        s.refresh_messages_if_changed()
+        assert len(s.populate_calls) == 2
+
+    def test_records_reordered_under_a_new_message_rebuilds(self):
+        """Reordenação passa pela comparação por id, mas o sort estável do
+        rebuild trocaria de lugar duas mensagens de mesmo timestamp."""
+        s = self._rendered([_msg("a", ts=1000), _msg("b", ts=1000)])
+        s._records[0], s._records[1] = s._records[1], s._records[0]
+        s._records.append(_msg("c", ts=2000))
+        s.refresh_messages_if_changed()
+        assert len(s.populate_calls) == 2
+
+    def test_a_list_out_of_step_with_the_control_rebuilds(self):
+        """Um Append() com a lista desalinhada gruda texto e registro errados."""
+        s = self._rendered([_msg("a")])
+        s.messages_list.rows.append("linha fantasma")
+        s._records.append(_msg("b", ts=2000))
+        s.refresh_messages_if_changed()
+        assert len(s.populate_calls) == 2
+
+    def test_the_placeholder_list_rebuilds(self):
+        s = self._rendered([_msg("a")])
+        s._sorted_messages = [{"_type": "empty_placeholder"}]
+        s.messages_list.rows = ["sem mensagens"]
+        s._records.append(_msg("b", ts=2000))
+        s.refresh_messages_if_changed()
+        assert len(s.populate_calls) == 2
+
+    def test_an_empty_list_rebuilds(self):
+        """Append() na lista vazia com foco reproduz o pulo de foco para a
+        linha 0 que o Freeze() de populate_messages() documenta."""
+        s = self._rendered([])
+        s._records.append(_msg("b", ts=2000))
+        s.refresh_messages_if_changed()
+        assert len(s.populate_calls) == 2
+
+    def test_the_item_count_suffix_forces_the_rebuild(self):
+        """Com ", N de M" ligado, acrescentar muda o M de todas as linhas já
+        renderizadas — o leitor de tela passaria a anunciar total velho."""
+        s = self._rendered([_msg("a")])
+        s._message_list_mode = "listbox"
+        s.main_window = type("_MW", (), {})()
+        s.main_window.settings = {"user_interface": {"show_listbox_item_count": True}}
+        s._records.append(_msg("b", ts=2000))
+        s.refresh_messages_if_changed()
+        assert len(s.populate_calls) == 2
+
+    def test_the_same_setting_off_still_takes_the_shortcut(self):
+        s = self._rendered([_msg("a")])
+        s._message_list_mode = "listbox"
+        s.main_window = type("_MW", (), {})()
+        s.main_window.settings = {"user_interface": {"show_listbox_item_count": False}}
+        s._records.append(_msg("b", text="nova", ts=2000))
+        s.refresh_messages_if_changed()
+        assert s.populate_calls == [True]
+        assert s.messages_list.rows == ["oi", "nova"]
+
+    def test_the_history_window_floor_follows_the_appended_rows(self):
+        """O piso da janela é o que está na tela; acrescentar sem atualizá-lo
+        deixaria o rebuild seguinte livre para cortar as linhas novas."""
+        s = self._rendered([_msg("a")])
+        s._records.append(_msg("b", ts=2000))
+        s.refresh_messages_if_changed()
+        assert s._expanded_visible_count == 2
+        assert s._expanded_oldest_msg_id == "a"
+
+    def test_a_failure_in_the_shortcut_falls_back_to_the_rebuild(self):
+        """O atalho é otimização: uma falha nele não pode custar a
+        atualização."""
+        s = self._rendered([_msg("a")])
+
+        def _boom(self, old_sig, new_sig):
+            raise RuntimeError("nope")
+
+        s._append_new_tail_rows = _boom.__get__(s)
+        s._records.append(_msg("b", ts=2000))
+        s.refresh_messages_if_changed()
+        assert len(s.populate_calls) == 2
+
+    def test_all_sorted_messages_is_left_alone_when_it_is_out_of_step(self):
+        """on_incoming_message() acrescenta só em _sorted_messages, então as
+        duas listas terminam diferentes. O atalho não pode inventar um
+        alinhamento que não tem como verificar — a metade contrária está em
+        test_a_message_that_only_reached_records_is_appended."""
+        s = self._rendered([_msg("a")])
+        self._paint_live(s, _msg("b", text="nova", ts=2000))
+        s._records.append(_msg("c", text="terceira", ts=3000))
+        s.refresh_messages_if_changed()
+        assert s.populate_calls == [True]
+        assert [m["key"]["id"] for m in s._sorted_messages] == ["a", "b", "c"]
+        assert [m["key"]["id"] for m in s._all_sorted_messages] == ["a"]
+        assert s.messages_list.rows == ["oi", "nova", "terceira"]
+
+    def test_the_live_unread_separator_survives_the_shortcut(self):
+        """Consequência declarada da mudança, não efeito colateral.
+
+        on_incoming_message() insere o separador ao vivo mas nunca escreve
+        _first_unread_msg_id, então o rebuild não o renderizava de volta e ele
+        sumia segundos depois de aparecer — junto com o alvo do Alt+3. O atalho
+        o mantém, e mantém _unread_sep_idx apontando para ele."""
+        s = self._rendered([_msg("a")])
+        sep = {"_type": "unread_separator", "count": 1}
+        s._sorted_messages.append(sep)
+        s.messages_list.rows.append("--- não lidas ---")
+        s._unread_sep_idx = len(s._sorted_messages) - 1
+        self._paint_live(s, _msg("b", text="nova", ts=2000))
+        s.refresh_messages_if_changed()
+        assert s.populate_calls == [True]
+        assert s.messages_list.rows == ["oi", "--- não lidas ---", "nova"]
+        assert s._sorted_messages[s._unread_sep_idx] is sep
+
+    def test_a_list_of_separators_alone_rebuilds(self):
+        """Sem nenhuma mensagem na tela não há cauda contra a qual comparar o
+        timestamp do recém-chegado."""
+        s = self._rendered([_msg("a")])
+        s._sorted_messages = [{"_type": "unread_separator", "count": 1}]
+        s.messages_list.rows = ["--- não lidas ---"]
+        s._records.append(_msg("b", ts=2000))
+        s.refresh_messages_if_changed()
+        assert len(s.populate_calls) == 2

--- a/tests/test_refresh_messages_debounce.py
+++ b/tests/test_refresh_messages_debounce.py
@@ -36,12 +36,15 @@ class _Panel:
         self.conversation = conversation
         self.refreshes = 0
         self.repaints = 0
+        self.repaint_jids = []   # what each repaint was scoped to (None = all)
 
     def refresh_messages_if_changed(self):
         self.refreshes += 1
 
-    def refresh_active_conversation_messages(self):
+    def refresh_active_conversation_messages(self, jids=None):
         self.repaints += 1
+        self.repaint_jids.append(jids)
+        return 0
 
 
 class _Stub:
@@ -194,14 +197,32 @@ class TestScheduleRefreshActiveMessages:
         _fire(later)
         assert s._refresh_active_pending is False
 
-    def test_a_raising_repaint_does_not_wedge_the_flag(self, later):
+    def test_a_raising_repaint_reschedules_itself(self, monkeypatch, later):
+        """The flag is cleared before the call, so a failure can never wedge
+        the scheduler — and since the repaint became scoped (see
+        tests/test_selective_message_repaint.py) the failed round also has to
+        come back as a full one, or the rows it never painted are lost."""
+        monkeypatch.setattr("main.wx.CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
         panel = _Panel(conversation={"remoteJid": "g@g.us"})
 
-        def _boom():
+        def _boom(jids=None):
             raise RuntimeError("render failed")
 
         panel.refresh_active_conversation_messages = _boom
         s = _Stub(panel)
         s._schedule_refresh_active_messages()
         _fire(later)
+        # Still the original point of this test: the flag is cleared before the
+        # call, so a raising repaint can never leave the scheduler wedged.
+        # (It reads True here only because the retry has already re-armed it.)
+        assert s._refresh_active_pending is True
+        assert len(later) == 1
+        assert s._refresh_active_jids is None
+        # …and the scheduler is genuinely still usable afterwards, which is
+        # what "does not wedge" actually means.
+        panel.refresh_active_conversation_messages = _Panel.refresh_active_conversation_messages.__get__(panel)
+        _fire(later)
+        s._schedule_refresh_active_messages()
+        _fire(later)
+        assert panel.repaints == 2
         assert s._refresh_active_pending is False

--- a/tests/test_selective_message_repaint.py
+++ b/tests/test_selective_message_repaint.py
@@ -275,10 +275,18 @@ class TestScheduledJidAccumulation:
 class _FakeList:
     """Just enough wx.ListCtrl to record what was re-rendered."""
 
-    def __init__(self):
+    def __init__(self, item_count=0):
         self.painted = []
         self.frozen = 0
         self.thawed = 0
+        # O caminho seletivo escreve por indice, entao ele confere se a lista
+        # esta em passo com o controle antes de enderecar linha nenhuma - como
+        # _repaint_message_rows() ja fazia. Um fake sem contagem deixaria essa
+        # guarda sem cobertura.
+        self.item_count = item_count
+
+    def GetItemCount(self):
+        return self.item_count
 
     def Freeze(self):
         self.frozen += 1
@@ -321,8 +329,8 @@ class _PanelStub:
     def __init__(self, messages, main_window=None):
         self.conversation = {"remoteJid": "group-1@g.us"}
         self.main_window = main_window if main_window is not None else _FakeMainWindow()
-        self.messages_list = _FakeList()
         self._sorted_messages = list(messages)
+        self.messages_list = _FakeList(len(self._sorted_messages))
 
     def _render_message_line(self, msg, index=None, total=None):
         return f"row {index}"
@@ -884,3 +892,75 @@ class TestTheSameCriterionInAOneToOneChat:
         panel = self._panel()
         selected = panel._message_ids_touching_jids({PHONE})
         assert selected is None or "o1" in selected
+
+
+class TestAOneToOneChatWhoseRowsCarryTheLid:
+    """O caso que a classe acima não alcança: as linhas sob a forma @lid e a
+    conversa sob o telefone, sem bridge entre as duas ainda.
+
+    _sender_label() e os dois ramos 1:1 de _get_quoted_sender() resolvem o nome
+    a partir de self.conversation, e não de nenhum JID que esteja na mensagem.
+    Coletando só os JIDs da mensagem, o conjunto seletivo não cruza com o JID
+    de telefone que o laço de resolução reporta, e a linha muda sem ser
+    repintada — o leitor de tela continua lendo o número cru. Por isso
+    _row_jids() coleta também o JID da conversa.
+
+    Sem bridge de propósito: é justamente o estado em que as duas formas não se
+    encontram por normalização nenhuma.
+    """
+
+    def _panel(self):
+        rows = []
+        incoming = _msg("i1", participant=None)
+        incoming["key"]["remoteJid"] = LID
+        rows.append(incoming)
+        reply = _msg("r1", participant=None)
+        reply["key"]["remoteJid"] = LID
+        reply["contextInfo"] = {"_quotedFromMe": False,
+                                "quotedMessage": {"conversation": "oi"}}
+        rows.append(reply)
+        mw = _RenderMainWindow()  # sem _lid_to_phone
+        panel = _RenderPanel(rows, main_window=mw)
+        panel.conversation = {"remoteJid": PHONE}
+        return panel
+
+    def test_every_changed_row_is_in_the_selective_set(self):
+        panel = self._panel()
+        changed = _rows_the_full_pass_would_change(
+            panel, lambda m: m.contacts.__setitem__(PHONE, {"name": "Fulano"}))
+        assert changed, "o cenário precisa mudar alguma linha de verdade"
+        selected = panel._message_ids_touching_jids({PHONE})
+        assert selected is None or not (changed - selected)
+
+    def test_a_group_conversation_jid_is_not_collected(self):
+        """Em grupo o nome nunca vem da conversa, e nenhum laço de resolução
+        reporta um @g.us — incluí-lo só alargaria o conjunto à toa."""
+        panel = self._panel()
+        panel.conversation = {"remoteJid": "12036304@g.us"}
+        assert "12036304@g.us" not in panel._row_jids(panel._sorted_messages[0])
+
+
+class TestTheListOutOfStepWithTheControl:
+    """Escrever por índice numa lista fora de passo põe o texto certo na linha
+    errada, e um descompasso só de prefixo não levanta exceção nenhuma: o
+    leitor de tela simplesmente passa a ler a mensagem trocada. É a mesma
+    guarda que _repaint_message_rows() já tinha, e o caminho seletivo herda os
+    mesmos índices."""
+
+    def _panel(self):
+        rows = [_msg("m1", participant=PHONE), _msg("m2", participant=OTHER)]
+        return _PanelStub(rows)
+
+    def test_a_mismatch_degrades_to_the_full_pass(self):
+        panel = self._panel()
+        panel.messages_list.item_count = 5  # controle com mais linhas que a lista
+        painted = panel.refresh_active_conversation_messages(jids={PHONE})
+        # Passe completo: as duas linhas, não só a que casa com PHONE.
+        assert painted == 2
+        assert sorted(panel.messages_list.painted) == [0, 1]
+
+    def test_in_step_still_takes_the_selective_path(self):
+        panel = self._panel()
+        painted = panel.refresh_active_conversation_messages(jids={PHONE})
+        assert painted == 1
+        assert panel.messages_list.painted == [0]

--- a/tests/test_selective_message_repaint.py
+++ b/tests/test_selective_message_repaint.py
@@ -1,0 +1,886 @@
+"""Tests for repainting only the rows a resolved batch can have changed.
+
+The message window stopped having a ceiling when it started preserving the
+history the user pulls in with Home (see
+tests/test_history_window_preservation.py), so a conversation can legitimately
+sit at thousands of rows. Every one of them used to be re-rendered by
+``refresh_active_conversation_messages()`` once per resolved batch — and the
+three background loops that trigger it ([Contact Resolution], [Mentions Scan]
+and [LID Resolution]) deliver batches continuously for minutes on a fresh
+account, while each batch typically renames a single person. The scheduler was
+a signal with no payload even though those loops know exactly which JIDs they
+just resolved.
+
+Two halves are pinned here, and the second one is where the accessibility risk
+sits:
+
+* ``MainWindow._schedule_refresh_active_messages(jids)`` accumulates the JIDs
+  across every batch inside one debounce window, drains them when it fires, and
+  keeps ``None``/empty meaning "I don't know what changed, repaint everything".
+
+* ``ConversationsPanel.refresh_active_conversation_messages(jids=...)`` repaints
+  a row when *any* JID the row renders a name for — sender, quoted sender,
+  mentions in the body, mentions in the quoted preview — matches, compared
+  across the @lid <-> phone bridge rather than as raw strings. A row wrongly
+  left out does not merely look stale: ``_get_participant_name()`` falls back to
+  ``participant_jid.rsplit("@", 1)[0]``, i.e. the screen reader reads raw @lid
+  or phone digits, forever. So anything the selective path cannot address
+  (a matching row carrying no ``key.id``) must fall back to the full repaint.
+
+MainWindow is a wx.Frame and ConversationsPanel a wx.Panel, so both are driven
+as unbound methods against small stubs — same approach as
+tests/test_refresh_messages_debounce.py and
+tests/test_history_window_preservation.py.
+"""
+
+import json
+import os
+
+import pytest
+
+from main import MainWindow
+from ui.conversations import ConversationsPanel
+
+PHONE = "5511900000001@s.whatsapp.net"
+LID = "111122223333@lid"
+OTHER = "5511900000002@s.whatsapp.net"
+
+
+# ── Half 1: the scheduler's JID accumulator ─────────────────────────────────
+
+
+class _Panel:
+    def __init__(self, conversation=None, on_repaint=None):
+        self.conversation = conversation
+        self.repaint_jids = []
+        self._sorted_messages = []
+        self._on_repaint = on_repaint
+
+    def refresh_active_conversation_messages(self, jids=None):
+        self.repaint_jids.append(None if jids is None else set(jids))
+        if self._on_repaint is not None:
+            self._on_repaint()
+        return 0
+
+
+class _MainStub:
+    _schedule_refresh_active_messages = MainWindow._schedule_refresh_active_messages
+    _do_scheduled_refresh_active_messages = MainWindow._do_scheduled_refresh_active_messages
+    _ACTIVE_REFRESH_DEBOUNCE_MS = MainWindow._ACTIVE_REFRESH_DEBOUNCE_MS
+
+    def __init__(self, panel=None):
+        self.conversations_panel = panel
+
+
+@pytest.fixture
+def later(monkeypatch):
+    """Capture wx.CallLater instead of needing a running event loop."""
+    calls = []
+    monkeypatch.setattr("main.wx.CallLater",
+                        lambda delay, fn, *a, **kw: calls.append((delay, fn, a, kw)))
+    # Inline, unlike CallLater: the failure path reschedules through CallAfter
+    # and the retry it queues is exactly what has to be observable here.
+    monkeypatch.setattr("main.wx.CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+    return calls
+
+
+def _fire(later_calls):
+    """Run everything wx.CallLater has queued, as the event loop would."""
+    pending, later_calls[:] = list(later_calls), []
+    for _delay, fn, a, kw in pending:
+        fn(*a, **kw)
+
+
+class TestScheduledJidAccumulation:
+    def test_batches_inside_one_window_are_unioned(self, later):
+        panel = _Panel(conversation={"remoteJid": "g@g.us"})
+        s = _MainStub(panel)
+        s._schedule_refresh_active_messages({PHONE})
+        s._schedule_refresh_active_messages({OTHER})
+        s._schedule_refresh_active_messages([LID])
+        assert len(later) == 1          # still one timer, as before
+        _fire(later)
+        assert panel.repaint_jids == [{PHONE, OTHER, LID}]
+
+    def test_no_jids_still_repaints_everything(self, later):
+        """The safe default every caller that cannot tell keeps using."""
+        panel = _Panel(conversation={"remoteJid": "g@g.us"})
+        s = _MainStub(panel)
+        s._schedule_refresh_active_messages()
+        _fire(later)
+        assert panel.repaint_jids == [None]
+
+    def test_an_empty_collection_means_the_same_as_none(self, later):
+        panel = _Panel(conversation={"remoteJid": "g@g.us"})
+        s = _MainStub(panel)
+        s._schedule_refresh_active_messages(set())
+        _fire(later)
+        assert panel.repaint_jids == [None]
+
+    def test_one_unknown_batch_widens_the_whole_window(self, later):
+        """A caller that cannot name what it changed must not have its request
+        narrowed by a later batch that can — the union of "everything" and a
+        JID set is still everything."""
+        panel = _Panel(conversation={"remoteJid": "g@g.us"})
+        s = _MainStub(panel)
+        s._schedule_refresh_active_messages({PHONE})
+        s._schedule_refresh_active_messages()
+        s._schedule_refresh_active_messages({OTHER})
+        _fire(later)
+        assert panel.repaint_jids == [None]
+
+    def test_blank_entries_are_dropped_and_the_batch_degrades_to_full(self, later):
+        """Filtering every JID out leaves us knowing nothing again."""
+        panel = _Panel(conversation={"remoteJid": "g@g.us"})
+        s = _MainStub(panel)
+        s._schedule_refresh_active_messages(["", None, 7])
+        _fire(later)
+        assert panel.repaint_jids == [None]
+
+    def test_the_accumulator_is_drained_between_windows(self, later):
+        panel = _Panel(conversation={"remoteJid": "g@g.us"})
+        s = _MainStub(panel)
+        s._schedule_refresh_active_messages({PHONE})
+        _fire(later)
+        s._schedule_refresh_active_messages({OTHER})
+        _fire(later)
+        assert panel.repaint_jids == [{PHONE}, {OTHER}]
+
+    def test_a_batch_arriving_during_the_repaint_is_not_lost(self, later):
+        """The accumulator and the pending flag are both cleared before the
+        render runs, so a batch landing mid-repaint schedules its own round
+        instead of being silently swallowed by the one already in flight."""
+        s = _MainStub()
+        panel = _Panel(
+            conversation={"remoteJid": "g@g.us"},
+            on_repaint=lambda: s._schedule_refresh_active_messages({OTHER}),
+        )
+        s.conversations_panel = panel
+        s._schedule_refresh_active_messages({PHONE})
+        _fire(later)
+        assert panel.repaint_jids == [{PHONE}]
+        assert len(later) == 1          # the mid-repaint batch queued its own
+        _fire(later)
+        assert panel.repaint_jids == [{PHONE}, {OTHER}]
+
+    def test_a_batch_arriving_during_the_repaint_is_not_repainted_twice(self, later):
+        """Its JID must land in the *next* round only — folding it back into
+        the running one would repaint it here and again a second later."""
+        s = _MainStub()
+        panel = _Panel(
+            conversation={"remoteJid": "g@g.us"},
+            on_repaint=lambda: s._schedule_refresh_active_messages({OTHER}),
+        )
+        s.conversations_panel = panel
+        s._schedule_refresh_active_messages({PHONE})
+        _fire(later)
+        _fire(later)
+        assert panel.repaint_jids[1] == {OTHER}
+
+    def test_a_raising_repaint_degrades_to_a_full_one_and_retries(self, later):
+        """The batch was drained before the call, so a failure would otherwise
+        lose those JIDs for good: the next batch is scoped to its own, and the
+        rows this round was meant to fix stay on raw digits forever. Before the
+        repaint became scoped this was harmless — the next one was always full.
+        _render_message_line() has raised in production, which is why the
+        try/except is there at all."""
+        calls = []
+
+        def _boom(jids=None):
+            calls.append(None if jids is None else set(jids))
+            if len(calls) == 1:
+                raise RuntimeError("render failed")
+            return 0
+
+        panel = _Panel(conversation={"remoteJid": "g@g.us"})
+        panel.refresh_active_conversation_messages = _boom
+        s = _MainStub(panel)
+        s._schedule_refresh_active_messages({PHONE})
+        _fire(later)                       # raises, degrades, reschedules
+        assert calls == [{PHONE}]
+        assert len(later) == 1
+        _fire(later)
+        assert calls == [{PHONE}, None], "the retry must repaint everything"
+
+    def test_a_deterministic_failure_stops_after_one_retry(self, later):
+        """The retry is bounded on purpose. A malformed record makes the render
+        raise every single time, and rescheduling unconditionally turns that
+        into a permanent 1 Hz Freeze/SetItemText/Thaw cycle on messages_list —
+        the very accessibility-event flood the Freeze() exists to prevent, now
+        for the rest of the session — plus log.log growing without bound on one
+        repeated traceback, in the file this project diagnoses everything from.
+        """
+        calls = []
+
+        def _always_boom(jids=None):
+            calls.append(None if jids is None else set(jids))
+            raise RuntimeError("malformed record")
+
+        panel = _Panel(conversation={"remoteJid": "g@g.us"})
+        panel.refresh_active_conversation_messages = _always_boom
+        s = _MainStub(panel)
+        s._schedule_refresh_active_messages({PHONE})
+        for _ in range(50):
+            _fire(later)
+        assert calls == [{PHONE}, None], "one scoped attempt, then one full retry"
+        assert later == [], "nothing left queued — the loop must not be endless"
+
+    def test_the_retry_budget_is_restored_by_a_successful_repaint(self):
+        """Otherwise a single transient failure early in the session would
+        leave every later one un-retried for good."""
+        panel = _Panel(conversation={"remoteJid": "g@g.us"})
+        s = _MainStub(panel)
+        s._refresh_active_failed_once = True
+        s._do_scheduled_refresh_active_messages()
+        assert s._refresh_active_failed_once is False
+
+    def test_a_failure_after_a_success_still_gets_its_retry(self, later):
+        outcomes = iter([None, RuntimeError("render failed"), None])
+
+        def _flaky(jids=None):
+            outcome = next(outcomes, None)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return 0
+
+        panel = _Panel(conversation={"remoteJid": "g@g.us"})
+        panel.refresh_active_conversation_messages = _flaky
+        s = _MainStub(panel)
+        s._schedule_refresh_active_messages({PHONE})
+        _fire(later)                       # succeeds, clears the budget
+        s._schedule_refresh_active_messages({OTHER})
+        _fire(later)                       # raises, must still reschedule
+        assert len(later) == 1
+
+    def test_a_batch_after_a_failure_is_still_widened_to_full(self, later):
+        """The degraded request is sticky, so a batch landing before the retry
+        runs cannot narrow it back down and re-lose the failed rows."""
+        def _boom(jids=None):
+            raise RuntimeError("render failed")
+
+        panel = _Panel(conversation={"remoteJid": "g@g.us"})
+        panel.refresh_active_conversation_messages = _boom
+        s = _MainStub(panel)
+        s._schedule_refresh_active_messages({PHONE})
+        _fire(later)
+        panel.refresh_active_conversation_messages = _Panel.refresh_active_conversation_messages.__get__(panel)
+        s._schedule_refresh_active_messages({OTHER})
+        _fire(later)
+        assert panel.repaint_jids == [None]
+
+
+# ── Half 2: which rows the panel actually repaints ──────────────────────────
+
+
+class _FakeList:
+    """Just enough wx.ListCtrl to record what was re-rendered."""
+
+    def __init__(self):
+        self.painted = []
+        self.frozen = 0
+        self.thawed = 0
+
+    def Freeze(self):
+        self.frozen += 1
+
+    def Thaw(self):
+        self.thawed += 1
+
+    def SetItemText(self, idx, text):
+        self.painted.append(idx)
+
+
+class _FakeMainWindow:
+    """MainWindow's real JID normalization/bridging, nothing else.
+
+    Bound rather than reimplemented on purpose: comparing raw JID strings is
+    the classic bug in this repository, and a hand-rolled equivalence in the
+    test would happily pass while the product code kept missing @lid rows.
+    """
+
+    _normalize_jid = staticmethod(MainWindow._normalize_jid)
+    _jid_address_forms = MainWindow._jid_address_forms
+
+    def __init__(self, lid_to_phone=None):
+        self._lid_to_phone = dict(lid_to_phone or {})
+        self._phone_to_lid = {p: l for l, p in self._lid_to_phone.items()}
+
+
+class _PanelStub:
+    """Minimal stand-in for ConversationsPanel for the selective repaint."""
+
+    # Real implementations under test.
+    refresh_active_conversation_messages = ConversationsPanel.refresh_active_conversation_messages
+    _message_ids_touching_jids = ConversationsPanel._message_ids_touching_jids
+    _row_jids = ConversationsPanel._row_jids
+    _set_message_row_texts = ConversationsPanel._set_message_row_texts
+    _is_separator = ConversationsPanel._is_separator
+    _get_context_info = ConversationsPanel._get_context_info
+    _raw_mentioned_jids = staticmethod(ConversationsPanel._raw_mentioned_jids)
+
+    def __init__(self, messages, main_window=None):
+        self.conversation = {"remoteJid": "group-1@g.us"}
+        self.main_window = main_window if main_window is not None else _FakeMainWindow()
+        self.messages_list = _FakeList()
+        self._sorted_messages = list(messages)
+
+    def _render_message_line(self, msg, index=None, total=None):
+        return f"row {index}"
+
+
+def _msg(mid, participant=None, **extra):
+    msg = {
+        "key": {"id": mid, "fromMe": False, "remoteJid": "group-1@g.us"},
+        "messageType": "conversation",
+        "message": {"conversation": "oi"},
+    }
+    if participant is not None:
+        msg["key"]["participant"] = participant
+    msg.update(extra)
+    return msg
+
+
+def _mention_msg(mid, participant, mentioned):
+    return {
+        "key": {"id": mid, "fromMe": False, "remoteJid": "group-1@g.us",
+                "participant": participant},
+        "messageType": "extendedTextMessage",
+        "message": {"extendedTextMessage": {
+            "text": "oi @5511900000001",
+            "contextInfo": {"mentionedJid": list(mentioned)},
+        }},
+    }
+
+
+class TestSelectiveRepaint:
+    def test_only_the_resolved_senders_row_is_repainted(self):
+        panel = _PanelStub([
+            _msg("a", participant=PHONE),
+            _msg("b", participant=OTHER),
+            _msg("c", participant=OTHER),
+        ])
+        painted = panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0]
+        assert painted == 1
+
+    def test_no_jids_repaints_every_row(self):
+        panel = _PanelStub([
+            _msg("a", participant=PHONE),
+            _msg("b", participant=OTHER),
+        ])
+        assert panel.refresh_active_conversation_messages() == 2
+        assert panel.messages_list.painted == [0, 1]
+
+    def test_the_batch_freeze_is_kept_on_both_paths(self):
+        """One accessibility event instead of one per row — the flood is what
+        made the reader unusable during a resolution storm."""
+        panel = _PanelStub([_msg("a", participant=PHONE)])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        panel.refresh_active_conversation_messages()
+        assert panel.messages_list.frozen == panel.messages_list.thawed == 2
+
+    def test_separators_are_never_addressed(self):
+        panel = _PanelStub([
+            {"_type": "unread_separator", "count": 2},
+            _msg("a", participant=PHONE),
+        ])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [1]
+
+
+class TestOneBadRowDoesNotStopTheRest:
+    """Predates the scoped repaint and is what turns one malformed record into
+    a whole conversation that stops being repainted: the full pass used to die
+    on the first row that raised, so every row after it kept its old text —
+    and on a name-resolution repaint "old text" means the screen reader goes on
+    reading raw @lid or phone digits."""
+
+    def _panel_with_a_bad_row(self):
+        panel = _PanelStub([_msg("a", participant=PHONE),
+                            _msg("bad", participant=OTHER),
+                            _msg("c", participant=OTHER)])
+        real = panel._render_message_line
+
+        def _render(msg, index=None, total=None):
+            if (msg.get("key") or {}).get("id") == "bad":
+                raise ValueError("malformed record")
+            return real(msg, index=index, total=total)
+
+        panel._render_message_line = _render
+        return panel
+
+    def test_the_rows_after_it_are_still_painted(self):
+        panel = self._panel_with_a_bad_row()
+        assert panel.refresh_active_conversation_messages() == 2
+        assert panel.messages_list.painted == [0, 2]
+
+    def test_the_list_is_still_thawed(self):
+        """A Freeze() left standing is a dead UI, so the finally has to survive
+        the row that raised as much as the pass does."""
+        panel = self._panel_with_a_bad_row()
+        panel.refresh_active_conversation_messages()
+        assert panel.messages_list.frozen == panel.messages_list.thawed == 1
+
+
+class TestJidEquivalence:
+    """A row carrying the @lid while the loop reported the phone JID (or the
+    other way round) is the whole reason this cannot be a string comparison:
+    missing it leaves the reader announcing raw digits for the session."""
+
+    def test_a_lid_row_matches_a_resolved_phone_jid(self):
+        mw = _FakeMainWindow(lid_to_phone={LID: PHONE})
+        panel = _PanelStub([_msg("a", participant=LID),
+                            _msg("b", participant=OTHER)], main_window=mw)
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0]
+
+    def test_a_phone_row_matches_a_resolved_lid(self):
+        mw = _FakeMainWindow(lid_to_phone={LID: PHONE})
+        panel = _PanelStub([_msg("a", participant=PHONE),
+                            _msg("b", participant=OTHER)], main_window=mw)
+        panel.refresh_active_conversation_messages(jids={LID})
+        assert panel.messages_list.painted == [0]
+
+    def test_the_legacy_c_us_form_matches_too(self):
+        panel = _PanelStub([_msg("a", participant="5511900000001@c.us"),
+                            _msg("b", participant=OTHER)])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0]
+
+    def test_a_baileys_device_suffix_still_matches(self):
+        panel = _PanelStub([_msg("a", participant="5511900000001:60@s.whatsapp.net"),
+                            _msg("b", participant=OTHER)])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0]
+
+    def test_an_unbridged_lid_does_not_drag_in_unrelated_rows(self):
+        panel = _PanelStub([_msg("a", participant=LID),
+                            _msg("b", participant=OTHER)])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == []
+
+
+class TestRowsThatNameSomeoneElse:
+    """_render_message_line() resolves three more names besides the sender, and
+    each is a way a row changes without its own sender changing."""
+
+    def test_a_mention_of_the_resolved_jid_is_repainted(self):
+        panel = _PanelStub([
+            _mention_msg("a", OTHER, [PHONE]),
+            _msg("b", participant=OTHER),
+        ])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0]
+
+    def test_a_mention_carried_as_a_lid_matches_the_phone_jid(self):
+        mw = _FakeMainWindow(lid_to_phone={LID: PHONE})
+        panel = _PanelStub([_mention_msg("a", OTHER, [LID])], main_window=mw)
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0]
+
+    def test_the_mentionedjidlist_spelling_is_covered(self):
+        """_get_message_content() accepts both spellings; _raw_mentioned_jids()
+        only reads mentionedJid, so the list form needs its own collection."""
+        msg = _mention_msg("a", OTHER, [])
+        msg["message"]["extendedTextMessage"]["contextInfo"] = {
+            "mentionedJidList": [PHONE]
+        }
+        panel = _PanelStub([msg])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0]
+
+    def test_the_quoted_senders_row_is_repainted(self):
+        reply = _msg("a", participant=OTHER)
+        reply["contextInfo"] = {"participant": PHONE,
+                                "quotedMessage": {"conversation": "oi"}}
+        panel = _PanelStub([reply, _msg("b", participant=OTHER)])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0]
+
+    def test_a_quote_without_a_participant_follows_its_stanza_id(self):
+        """_get_quoted_sender() resolves the quoted message's own recorded
+        sender in that case, so the reply's text depends on a *different*
+        row's participant."""
+        quoted = _msg("q1", participant=PHONE)
+        reply = _msg("a", participant=OTHER)
+        reply["contextInfo"] = {"stanzaId": "q1",
+                                "quotedMessage": {"conversation": "oi"}}
+        panel = _PanelStub([quoted, reply, _msg("b", participant=OTHER)])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0, 1]
+
+    def test_a_mention_inside_the_quoted_preview_is_repainted(self):
+        reply = _msg("a", participant=OTHER)
+        reply["contextInfo"] = {
+            "participant": OTHER,
+            "quotedMessage": {"conversation": "oi @5511900000001",
+                              "mentionedJid": [PHONE]},
+        }
+        panel = _PanelStub([reply, _msg("b", participant=OTHER)])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0]
+
+
+class TestFallbackToTheFullRepaint:
+    """Never leave a row stale: anything the selective path cannot address
+    goes back through the full pass."""
+
+    def test_a_matching_row_without_a_message_id_forces_a_full_repaint(self):
+        """_set_message_row_texts() addresses rows by key.id, so a matching row
+        that carries none simply cannot be reached — repaint everything rather
+        than skip it. (Virtual pending sends are *not* the case in point: they
+        do get a key.id, the _local_id uuid. This guards the malformed/legacy
+        record, where the shape is whatever an older build wrote to disk.)"""
+        idless = _mention_msg("", OTHER, [PHONE])
+        panel = _PanelStub([_msg("a", participant=OTHER), idless,
+                            _msg("b", participant=OTHER)])
+        assert panel._message_ids_touching_jids({PHONE}) is None
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0, 1, 2]
+
+    def test_a_non_matching_row_without_an_id_does_not_force_it(self):
+        panel = _PanelStub([_msg("", participant=OTHER),
+                            _msg("b", participant=PHONE)])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [1]
+
+    def test_jids_that_normalize_to_nothing_repaint_everything(self):
+        panel = _PanelStub([_msg("a", participant=PHONE),
+                            _msg("b", participant=OTHER)])
+        assert panel._message_ids_touching_jids(["", None]) is None
+
+    def test_no_conversation_open_is_a_noop(self):
+        panel = _PanelStub([_msg("a", participant=PHONE)])
+        panel.conversation = None
+        assert panel.refresh_active_conversation_messages(jids={PHONE}) == 0
+        assert panel.messages_list.painted == []
+
+
+class TestGroupNotifications:
+    """A group notification renders its author AND its recipients through
+    _get_participant_name(), and the recipients appear nowhere else in the
+    message — key.participant only mirrors the author, by way of
+    WebSocketClient copying it there.
+
+    Missing them closed the worst possible loop: the "X entrou no grupo" row
+    with an unbridged @lid recipient falls back to raw digits,
+    _get_participant_name() itself fires resolve_lid_jids_via_api() to fix that
+    very row, the resolution schedules a scoped repaint — and the row that
+    started it was the only one not in it.
+    """
+
+    def _notif(self, mid, author, recipients):
+        return {
+            "key": {"id": mid, "fromMe": False, "remoteJid": "group-1@g.us",
+                    "participant": author},
+            "messageType": "groupNotification",
+            "message": {"groupNotification": {"subtype": "add", "author": author,
+                                              "recipients": list(recipients)}},
+        }
+
+    def test_a_recipient_is_repainted(self):
+        panel = _PanelStub([self._notif("n1", OTHER, [LID]),
+                            _msg("b", participant=OTHER)])
+        panel.refresh_active_conversation_messages(jids={LID})
+        assert panel.messages_list.painted == [0]
+
+    def test_a_recipient_matches_across_the_lid_bridge(self):
+        mw = _FakeMainWindow(lid_to_phone={LID: PHONE})
+        panel = _PanelStub([self._notif("n1", OTHER, [LID])], main_window=mw)
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0]
+
+    def test_the_author_is_repainted(self):
+        panel = _PanelStub([self._notif("n1", PHONE, [OTHER])])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == [0]
+
+    def test_a_legacy_wid_dict_on_disk_is_tolerated(self):
+        """Records written before WebSocketClient normalised these to strings
+        still hold a raw WPPConnect Wid dict — _get_message_content() guards
+        for it, and so must this."""
+        notif = self._notif("n1", OTHER, [])
+        notif["message"]["groupNotification"]["recipients"] = [{"_serialized": LID}]
+        notif["message"]["groupNotification"]["author"] = {"_serialized": OTHER}
+        panel = _PanelStub([notif])
+        panel.refresh_active_conversation_messages(jids={LID})
+        assert panel.messages_list.painted == [0]
+
+    def test_an_unrelated_notification_is_left_alone(self):
+        panel = _PanelStub([self._notif("n1", OTHER, [OTHER])])
+        panel.refresh_active_conversation_messages(jids={PHONE})
+        assert panel.messages_list.painted == []
+
+
+# ── The acceptance criterion, differentially ────────────────────────────────
+
+
+def _translations():
+    """The real pt-BR strings: an i18n stub returning the bare key would drop
+    every {name}/{author} placeholder, and with the names gone from the
+    rendered line the differential below would see no change and pass on
+    everything."""
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        "client", "languages", "pt-BR.json")
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+class _I18n:
+    def __init__(self):
+        self._t = _translations()
+
+    def t(self, key):
+        return self._t.get(key, key)
+
+
+class _RenderMainWindow(_FakeMainWindow):
+    """Everything the *real* renderer reaches for while resolving a name."""
+
+    _is_bad_contact_name = staticmethod(MainWindow._is_bad_contact_name)
+
+    def __init__(self, lid_to_phone=None):
+        super().__init__(lid_to_phone=lid_to_phone)
+        self.i18n = _I18n()
+        self.app_name = "WinZapp"
+        self.contacts = {}
+        self.chats = {}
+        self._presence_pushname_map = {}
+        self.my_jid = "5511900000099@s.whatsapp.net"
+        self.settings = {"user_interface": {}, "speech_content": {}}
+
+    def get_chat(self, jid):
+        return self.chats.get(jid)
+
+    def _is_self_jid(self, jid):
+        return self._normalize_jid(jid or "") == self.my_jid
+
+    def self_reference_label(self):
+        return "Eu"
+
+    # The real one: the 1:1 branches of _get_quoted_sender() resolve the
+    # other party through it, so a stub returning chat["name"] would make
+    # those branches insensitive to exactly the caches the resolution loops
+    # write to, and the 1:1 scenario below would pass vacuously.
+    _resolve_contact_name = MainWindow._resolve_contact_name
+    _get_contact_tolerant = MainWindow._get_contact_tolerant
+    # Tried only after _resolve_contact_name(), and it memoises per chat — the
+    # real behaviour, and harmless here because the conversation carries no
+    # records for it to find a pushName in.
+    find_name_through_messages = MainWindow.find_name_through_messages
+
+    def register_jid_mapping(self, lid_jid, phone_jid, save=True, defer_ui=False):
+        self._lid_to_phone[lid_jid] = phone_jid
+        self._phone_to_lid[phone_jid] = lid_jid
+
+    def resolve_lid_jids_via_api(self, jids):
+        pass
+
+
+class _RenderPanel(_PanelStub):
+    """_PanelStub with the real _render_message_line() and every name-resolving
+    helper it calls left real. Only the parts orthogonal to name resolution —
+    the clock, the delivery status, reactions — are stubbed out, so any change
+    a rendered line shows is a name change by construction."""
+
+    _render_message_line = ConversationsPanel._render_message_line
+    _render_separator = ConversationsPanel._render_separator
+    _get_message_content = ConversationsPanel._get_message_content
+    _sender_label = ConversationsPanel._sender_label
+    _get_quoted_sender = ConversationsPanel._get_quoted_sender
+    _get_quoted_preview = ConversationsPanel._get_quoted_preview
+    _resolve_mentions_in_text = ConversationsPanel._resolve_mentions_in_text
+    _get_participant_name = ConversationsPanel._get_participant_name
+    _is_system_event = staticmethod(ConversationsPanel._is_system_event)
+    _is_message_forwarded = ConversationsPanel._is_message_forwarded
+    _extract_timestamp = ConversationsPanel._extract_timestamp
+
+    def __init__(self, messages, main_window=None):
+        super().__init__(messages, main_window=main_window or _RenderMainWindow())
+        self.selected_messages = set()
+        self._media_upload_progress = {}
+        self._download_progress = {}
+        self._message_list_mode = "classic"
+        self._group_participants_cache = []
+
+    def _format_date(self, ts):
+        return ""
+
+    def _map_status(self, msg):
+        return ""
+
+    def _reaction_counts(self, msg_id):
+        return {}
+
+    def _render_all(self):
+        total = len(self._sorted_messages)
+        return {
+            m["key"]["id"]: self._render_message_line(m, index=i, total=total)
+            for i, m in enumerate(self._sorted_messages)
+        }
+
+
+def _rows_the_full_pass_would_change(panel, mutate):
+    """Render everything, apply *mutate* to the name caches, render again, and
+    report the ids whose text actually moved."""
+    before = panel._render_all()
+    mutate(panel.main_window)
+    after = panel._render_all()
+    return {mid for mid, text in after.items() if before[mid] != text}
+
+
+class TestTheSelectiveSetCoversWhateverTheFullPassWouldChange:
+    """The acceptance criterion, stated as a property instead of a hand-written
+    row list.
+
+    An earlier version of this test asserted a literal [0, 1, 2, 3] — which is
+    how the groupNotification recipients hole shipped green: the row simply was
+    not in the list anyone thought to write down. Rendering for real, moving a
+    name, and re-rendering finds every JID source _render_message_line() has,
+    including ones added later that nobody remembers to mirror into
+    _row_jids().
+    """
+
+    def _rows(self):
+        quoted = _msg("q1", participant=LID)
+        reply_by_stanza = _msg("r1", participant=OTHER)
+        reply_by_stanza["contextInfo"] = {"stanzaId": "q1",
+                                          "quotedMessage": {"conversation": "oi"}}
+        reply_by_participant = _msg("r2", participant=OTHER)
+        reply_by_participant["contextInfo"] = {
+            "participant": PHONE,
+            "quotedMessage": {"conversation": "oi"},
+        }
+        quoted_mention = _msg("r3", participant=OTHER)
+        quoted_mention["contextInfo"] = {
+            "participant": OTHER,
+            "quotedMessage": {"conversation": "oi @5511900000001",
+                              "mentionedJid": [PHONE]},
+        }
+        notif = {
+            "key": {"id": "n1", "fromMe": False, "remoteJid": "group-1@g.us",
+                    "participant": OTHER},
+            "messageType": "groupNotification",
+            "message": {"groupNotification": {"subtype": "add", "author": OTHER,
+                                              "recipients": [LID]}},
+        }
+        return [
+            quoted,
+            reply_by_stanza,
+            reply_by_participant,
+            quoted_mention,
+            _mention_msg("m1", OTHER, [LID]),
+            notif,
+            _msg("u1", participant=OTHER),
+            _msg("u2", participant="5511900000009@s.whatsapp.net"),
+        ]
+
+    def _assert_covers(self, panel, jids, mutate):
+        changed = _rows_the_full_pass_would_change(panel, mutate)
+        assert changed, "the scenario must actually change something to be a test"
+        selected = panel._message_ids_touching_jids(jids)
+        if selected is None:
+            return                        # degraded to the full pass: covered
+        missing = changed - selected
+        assert not missing, (
+            f"rows {sorted(missing)} change when {sorted(jids)} resolves but "
+            f"would not be repainted — the screen reader keeps reading raw "
+            f"digits on them")
+
+    def test_a_name_learned_under_the_phone_jid_reaches_every_row(self):
+        mw = _RenderMainWindow(lid_to_phone={LID: PHONE})
+        panel = _RenderPanel(self._rows(), main_window=mw)
+        self._assert_covers(
+            panel, {PHONE},
+            lambda m: m.contacts.__setitem__(PHONE, {"name": "Fulano"}))
+
+    def test_a_name_learned_under_the_lid_reaches_every_row(self):
+        mw = _RenderMainWindow(lid_to_phone={LID: PHONE})
+        panel = _RenderPanel(self._rows(), main_window=mw)
+        self._assert_covers(
+            panel, {LID},
+            lambda m: m.contacts.__setitem__(LID, {"name": "Fulano"}))
+
+    def test_a_pushname_learned_from_presence_reaches_every_row(self):
+        """_learn_sender_name() writes here, and it is what the mentions scan's
+        bulk pass fills — the case that now forces the full repaint."""
+        mw = _RenderMainWindow(lid_to_phone={LID: PHONE})
+        panel = _RenderPanel(self._rows(), main_window=mw)
+        self._assert_covers(
+            panel, {PHONE},
+            lambda m: m._presence_pushname_map.__setitem__(PHONE, "Fulano"))
+
+    def test_a_bridge_learned_later_reaches_every_row(self):
+        """No name at all, just the @lid -> phone mapping: the rows switch from
+        raw @lid digits to a formatted phone number, which is a change of its
+        own and the most common one on a fresh account."""
+        mw = _RenderMainWindow()
+        panel = _RenderPanel(self._rows(), main_window=mw)
+
+        def _bridge(m):
+            m._lid_to_phone[LID] = PHONE
+            m._phone_to_lid[PHONE] = LID
+
+        self._assert_covers(panel, {LID}, _bridge)
+
+    def test_the_selective_set_is_not_simply_everything(self):
+        """Guards the other direction: a property test that repainted every row
+        would pass vacuously and buy nothing over the old full pass."""
+        mw = _RenderMainWindow(lid_to_phone={LID: PHONE})
+        panel = _RenderPanel(self._rows(), main_window=mw)
+        selected = panel._message_ids_touching_jids({PHONE})
+        assert selected is not None
+        assert "u1" not in selected and "u2" not in selected
+
+
+class TestTheSameCriterionInAOneToOneChat:
+    """The group scenarios never reach _get_quoted_sender()'s 1:1 branches
+    (a reply with no contextInfo participant, resolved from the conversation
+    itself rather than from a participant JID), nor a fromMe row.
+
+    In a 1:1 chat every row carries the same key.remoteJid, so the selective
+    set naturally widens to the whole list — this pins that it really does,
+    rather than leaving the branch untested on the assumption that it must.
+    """
+
+    def _rows(self):
+        incoming = _msg("i1", participant=None)
+        incoming["key"]["remoteJid"] = PHONE
+        outgoing = _msg("o1", participant=None)
+        outgoing["key"]["remoteJid"] = PHONE
+        outgoing["key"]["fromMe"] = True
+        reply_to_them = _msg("r1", participant=None)
+        reply_to_them["key"]["remoteJid"] = PHONE
+        reply_to_them["contextInfo"] = {"_quotedFromMe": False,
+                                        "quotedMessage": {"conversation": "oi"}}
+        reply_to_me = _msg("r2", participant=None)
+        reply_to_me["key"]["remoteJid"] = PHONE
+        reply_to_me["contextInfo"] = {"_quotedFromMe": True,
+                                      "quotedMessage": {"conversation": "oi"}}
+        reply_by_stanza = _msg("r3", participant=None)
+        reply_by_stanza["key"]["remoteJid"] = PHONE
+        reply_by_stanza["contextInfo"] = {"stanzaId": "i1",
+                                          "quotedMessage": {"conversation": "oi"}}
+        return [incoming, outgoing, reply_to_them, reply_to_me, reply_by_stanza]
+
+    def _panel(self):
+        mw = _RenderMainWindow()
+        panel = _RenderPanel(self._rows(), main_window=mw)
+        panel.conversation = {"remoteJid": PHONE}
+        return panel
+
+    def test_every_changed_row_is_in_the_selective_set(self):
+        panel = self._panel()
+        changed = _rows_the_full_pass_would_change(
+            panel, lambda m: m.contacts.__setitem__(PHONE, {"name": "Fulano"}))
+        assert changed, "the scenario must actually change something"
+        selected = panel._message_ids_touching_jids({PHONE})
+        assert selected is None or not (changed - selected)
+
+    def test_the_outgoing_row_is_covered_like_the_rest(self):
+        """A fromMe row renders "Eu" as its sender, but its quoted preview and
+        mentions still name the other party, so it must not be excluded on the
+        strength of its sender alone."""
+        panel = self._panel()
+        selected = panel._message_ids_touching_jids({PHONE})
+        assert selected is None or "o1" in selected

--- a/tests/test_unread_separator.py
+++ b/tests/test_unread_separator.py
@@ -193,6 +193,68 @@ class TestPaginatedWindow:
         assert sep == 0
 
 
+class TestPaginatedWindowMinVisible:
+    """History the user pulled in by hand (Home/scroll to top) must survive a
+    background rebuild — see ConversationsPanel._remember_expanded_window()."""
+
+    def test_min_visible_below_the_limit_changes_nothing(self):
+        offset, sep = paginated_window(
+            total_len=500, limit=200, unread_sep_idx=-1, min_visible=120
+        )
+        assert offset == 300
+        assert sep == -1
+
+    def test_min_visible_defaults_to_no_effect(self):
+        """The default keeps every existing caller behaving exactly as before."""
+        assert paginated_window(500, 200, -1) == paginated_window(
+            500, 200, -1, min_visible=0
+        )
+
+    def test_a_widened_window_is_not_cut_back_to_the_page_size(self):
+        """The reported case: 400 messages loaded against a 200 page size, and
+        a refresh a few seconds later snapped the list back to 200."""
+        offset, sep = paginated_window(
+            total_len=400, limit=200, unread_sep_idx=-1, min_visible=400
+        )
+        assert offset == 0
+        assert sep == -1
+
+    def test_the_window_grows_only_up_to_what_was_loaded(self):
+        """min_visible is a count of rows already materialized, so a new page
+        of older history arriving from a sync is not pulled in by itself."""
+        offset, _sep = paginated_window(
+            total_len=600, limit=200, unread_sep_idx=-1, min_visible=400
+        )
+        assert offset == 200
+
+    def test_the_unread_separator_still_wins_when_it_needs_more(self):
+        total = 500
+        sep_idx = total - 450
+        offset, sep = paginated_window(
+            total_len=total, limit=200, unread_sep_idx=sep_idx, min_visible=300
+        )
+        assert offset == sep_idx
+        assert sep == 0
+
+    def test_min_visible_wins_when_the_separator_needs_less(self):
+        total = 500
+        sep_idx = total - 250
+        offset, sep = paginated_window(
+            total_len=total, limit=200, unread_sep_idx=sep_idx, min_visible=400
+        )
+        assert offset == 100
+        assert sep == sep_idx - 100
+
+    def test_min_visible_larger_than_the_whole_history(self):
+        """A message deleted since the expansion leaves the count over-counting;
+        it must not produce a negative offset."""
+        offset, sep = paginated_window(
+            total_len=50, limit=200, unread_sep_idx=-1, min_visible=400
+        )
+        assert offset == 0
+        assert sep == -1
+
+
 # ── How much history navigate_to_conversation() pulls from the DB ──────────
 
 

--- a/tests/test_unresolvable_blacklist.py
+++ b/tests/test_unresolvable_blacklist.py
@@ -98,6 +98,9 @@ class _Stub:
     def _schedule_set_chats(self):
         pass
 
+    def _schedule_refresh_active_messages(self, jids=None):
+        pass
+
 
 @pytest.fixture
 def stub(monkeypatch):


### PR DESCRIPTION
Relatado como "some mensagem da lista": com `messages_page_size = 200`, mensagens antigas desapareciam do topo da conversa aberta poucos segundos depois de qualquer mensagem nova — sob o leitor de tela, no meio da leitura.

São quatro commits, dois de correção e dois de desempenho, todos no mesmo laço: o rebuild da lista de mensagens.

## O bug

A causa se revelou em três camadas, cada uma exposta depois que a anterior caiu.

**1. O histórico carregado não sobrevivia ao rebuild** (`7efd096f`). `_load_older_messages()` fazia prepend só nas listas em memória do painel, nunca em `conversation["messages"]["messages"]["records"]` — que é a única coisa de que `populate_messages()` reconstrói. E `populate_messages()` recalculava a paginação sempre a partir do fim, descartando a expansão que o usuário tinha pedido com Home. A janela passou a ser ancorada pelo id da mensagem mais antiga exibida, com a contagem como piso para quando essa âncora for apagada remotamente. Sem teto: um cap permanente foi tentado e reproduz o próprio sintoma acima do limite.

**2. O piso da janela só existia para quem apertava Home** (`5a99c784`). O sintoma voltou sem ninguém carregar histórico. O log da sessão que reproduziu mostra a sequência inteira: a conversa abre com `ItemCount=200` e `offset=0`, as linhas crescem `200 → 201 → 202 → 204` pelos appends ao vivo, e o rebuild seguinte devolve a lista a 200. Mais tarde na mesma sessão o `offset` vai a 5 e depois a 10. Os caminhos de append (`on_incoming_message()` e o envio otimista) não cortam nada, só o rebuild corta — append e rebuild discordavam sobre o tamanho da janela, e quem mandava era o rebuild. `populate_messages()` passa a registrar, no `finally`, a janela que acabou de pintar: o piso deixa de ser "o que o Home trouxe" e passa a ser "o que já está na tela".

## Desempenho

Os dois commits de perf existem porque a janela deixou de ter teto e pode legitimamente chegar a milhares de linhas.

**3. O repaint em lote pinta as linhas do lote** (`38bbd686`), não a conversa inteira. Os loops `[Contact Resolution]`, `[Mentions Scan]` e `[LID Resolution]` sabiam quais JIDs tinham acabado de resolver e jogavam a informação fora. Numa janela de 4200 linhas com um lote de 20 JIDs, sobram as poucas linhas daqueles remetentes em vez de 4200 `_render_message_line()` — que nem é O(1). O critério que governa tudo ali é que nenhuma linha pode ficar desatualizada: uma linha que devia ter sido repintada e não foi anuncia telefone ou `@lid` cru ao leitor de tela, que é pior que a lentidão sendo corrigida.

**4. Mensagem nova acrescenta a linha** (`4c4e403c`), em vez de reconstruir a lista. `on_incoming_message()` já acrescentava ao vivo; quem reconstruía era o refresh de fundo que vem segundos depois (`_refresh_open_conversation_after_sync()`, o backfill de histórico, a rodada de 60s), fazendo `DeleteAllItems()` mais um `Append()` por linha para pintar de novo o que já estava na tela. `refresh_messages_if_changed()` passa a tentar `_append_new_tail_rows()` antes do rebuild — no caminho comum ele acrescenta zero linha e o ganho é reconhecer que a linha já está pintada. Mesmo padrão de `_repaint_message_rows()`, que já fazia isso para estrela/fixar/apagar.

## O que um revisor precisa saber

**A janela cresce enquanto a conversa fica aberta** e nada a estreita fora de `_reset_expanded_window()` (fechar ou trocar de conversa). É deliberado: aparar essas linhas é apagar sob o leitor de tela exatamente o que ele acabou de ler, que é o bug. Duas fontes do piso estão declaradas no docstring de `_remember_expanded_window()` — o alargamento por não lidas (um grupo com 4000 não lidas fica com 4001 linhas de piso pela sessão) e o piso obsoleto que sobrevive a "Limpar conversa", cada um com o motivo de não ser zerado.

**Custo passou a ser medido, não estimado.** `populate_messages()` loga linhas, duração e offset por rebuild, em `WARNING` acima de 250 ms — uma ordem de grandeza abaixo dos stalls de 9,4 s / 19,8 s / 40,1 s que o watchdog mediu no laço vizinho. A próxima decisão sobre custo tem número em vez de palpite.

**O separador de não lidas ao vivo passa a sobreviver ao refresh**, e isso está declarado no docstring de `_append_new_tail_rows()`. `on_incoming_message()` nunca escreve `_first_unread_msg_id`, então o rebuild não renderizava o separador de volta e ele sumia poucos segundos depois de aparecer, junto com o alvo do Alt+3. Recusar o atalho na presença dele foi considerado e custa caro demais: o separador é inserido para toda mensagem recebida, então a guarda desligaria a otimização justamente no caso que a motivou. A assimetria que sobra: o separador ainda cai no primeiro rebuild que qualquer outra mudança provocar.

**O atalho recusa tudo que não seja "linhas novas no fim, nada mais mudou"** — linha existente alterada ou removida, registro que não vira linha (a reação muda o texto de outra linha e a assinatura não diz de qual), mensagem mais antiga que a última linha, reordenação dos registros (a comparação é por prefixo, não por conjunto de ids, porque o sort do rebuild é estável), lista fora de passo com o controle, lista vazia ou só de sentinela, e o sufixo ", N de M" ligado.

## Acessibilidade

`refresh_active_conversation_messages()` ganhou `Freeze()`/`Thaw()` — era um evento de acessibilidade por linha, uma vez por segundo. O atalho de append também acrescenta dentro de `Freeze()`/`Thaw()` e, ao contrário do rebuild, não mexe em foco nem em seleção.

## Testes

Suíte completa: **5352 passed, 69 skipped**.

- `tests/test_history_window_preservation.py` — a janela ancorada, o piso do que está na tela, o filtro por JID, os resets ao trocar de conversa, e o teste que prende a ausência de teto.
- `tests/test_selective_message_repaint.py` — 46 testes, incluindo um de aceitação diferencial que renderiza as linhas, muta o cache de nomes, renderiza de novo e afirma que todo id cujo texto mudou está no conjunto seletivo.
- `tests/test_message_list_refresh.py` — onde fica a linha entre acrescentar e reconstruir. A guarda `in_step` foi verificada por mutação.
