### PR TITLE
Hide delivery receipts and confirm message deletes in the Me chat

### DIFF
--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -966,6 +966,7 @@
     "success_delete": "Deleted successfully.",
     "success_archive": "Chats archived.",
     "delete_msg_confirm": "Are you sure you want to delete this message?",
+    "delete_msg_confirm_yes": "&Delete",
     "delete_msg_confirm_bulk": "Are you sure you want to delete the {count} selected messages?",
     "all_selected": "All selected",
     "all_unselected": "All deselected",

--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -965,6 +965,7 @@
     "success_clear": "Chats cleared.",
     "success_delete": "Deleted successfully.",
     "success_archive": "Chats archived.",
+    "delete_msg_confirm": "Are you sure you want to delete this message?",
     "delete_msg_confirm_bulk": "Are you sure you want to delete the {count} selected messages?",
     "all_selected": "All selected",
     "all_unselected": "All deselected",

--- a/client/languages/es-ES.json
+++ b/client/languages/es-ES.json
@@ -965,6 +965,7 @@
     "success_clear": "Conversaciones vaciadas.",
     "success_delete": "Eliminado correctamente.",
     "success_archive": "Conversaciones archivadas.",
+    "delete_msg_confirm": "¿Seguro que deseas eliminar este mensaje?",
     "delete_msg_confirm_bulk": "¿Seguro que deseas eliminar los {count} mensajes seleccionados?",
     "all_selected": "Todo seleccionado",
     "all_unselected": "Todo deseleccionado",

--- a/client/languages/es-ES.json
+++ b/client/languages/es-ES.json
@@ -966,6 +966,7 @@
     "success_delete": "Eliminado correctamente.",
     "success_archive": "Conversaciones archivadas.",
     "delete_msg_confirm": "¿Seguro que deseas eliminar este mensaje?",
+    "delete_msg_confirm_yes": "&Eliminar",
     "delete_msg_confirm_bulk": "¿Seguro que deseas eliminar los {count} mensajes seleccionados?",
     "all_selected": "Todo seleccionado",
     "all_unselected": "Todo deseleccionado",

--- a/client/languages/pl.json
+++ b/client/languages/pl.json
@@ -965,6 +965,7 @@
     "success_clear": "Rozmowy wyczyszczone.",
     "success_delete": "Usunięto pomyślnie.",
     "success_archive": "Rozmowy zarchiwizowane.",
+    "delete_msg_confirm": "Czy na pewno chcesz usunąć tę wiadomość?",
     "delete_msg_confirm_bulk": "Czy na pewno chcesz usunąć {count} zaznaczonych wiadomości?",
     "all_selected": "Wszystko zaznaczone",
     "all_unselected": "Wszystko odznaczone",

--- a/client/languages/pl.json
+++ b/client/languages/pl.json
@@ -966,6 +966,7 @@
     "success_delete": "Usunięto pomyślnie.",
     "success_archive": "Rozmowy zarchiwizowane.",
     "delete_msg_confirm": "Czy na pewno chcesz usunąć tę wiadomość?",
+    "delete_msg_confirm_yes": "&Usuń",
     "delete_msg_confirm_bulk": "Czy na pewno chcesz usunąć {count} zaznaczonych wiadomości?",
     "all_selected": "Wszystko zaznaczone",
     "all_unselected": "Wszystko odznaczone",

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -965,6 +965,7 @@
     "success_clear": "Conversas limpas.",
     "success_delete": "Apagado com sucesso.",
     "success_archive": "Conversas arquivadas.",
+    "delete_msg_confirm": "Tem certeza de que deseja apagar esta mensagem?",
     "delete_msg_confirm_bulk": "Tem certeza de que deseja apagar as {count} mensagens selecionadas?",
     "all_selected": "Tudo selecionado",
     "all_unselected": "Tudo desmarcado",

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -966,6 +966,7 @@
     "success_delete": "Apagado com sucesso.",
     "success_archive": "Conversas arquivadas.",
     "delete_msg_confirm": "Tem certeza de que deseja apagar esta mensagem?",
+    "delete_msg_confirm_yes": "&Apagar",
     "delete_msg_confirm_bulk": "Tem certeza de que deseja apagar as {count} mensagens selecionadas?",
     "all_selected": "Tudo selecionado",
     "all_unselected": "Tudo desmarcado",

--- a/client/languages/pt-PT.json
+++ b/client/languages/pt-PT.json
@@ -966,6 +966,7 @@
     "success_delete": "Eliminado com sucesso.",
     "success_archive": "Conversas arquivadas.",
     "delete_msg_confirm": "Tem a certeza de que pretende eliminar esta mensagem?",
+    "delete_msg_confirm_yes": "&Eliminar",
     "delete_msg_confirm_bulk": "Tem a certeza de que pretende eliminar as {count} mensagens selecionadas?",
     "all_selected": "Tudo selecionado",
     "all_unselected": "Tudo desmarcado",

--- a/client/languages/pt-PT.json
+++ b/client/languages/pt-PT.json
@@ -965,6 +965,7 @@
     "success_clear": "Conversas limpas.",
     "success_delete": "Eliminado com sucesso.",
     "success_archive": "Conversas arquivadas.",
+    "delete_msg_confirm": "Tem a certeza de que pretende eliminar esta mensagem?",
     "delete_msg_confirm_bulk": "Tem a certeza de que pretende eliminar as {count} mensagens selecionadas?",
     "all_selected": "Tudo selecionado",
     "all_unselected": "Tudo desmarcado",

--- a/client/main.py
+++ b/client/main.py
@@ -23652,7 +23652,12 @@ class MainWindow(wx.Frame):
             panel = getattr(self, "conversations_panel", None)
             if panel is not None:
                 try:
-                    status_text = panel._map_status(last)
+                    # The panel renders every row here, not just its own open
+                    # conversation, so the chat has to be named explicitly —
+                    # otherwise _map_status() falls back to whichever chat
+                    # happens to be open and applies its "Me"-chat receipt
+                    # rule to somebody else's preview line.
+                    status_text = panel._map_status(last, chat.get("remoteJid", ""))
                 except Exception:
                     status_text = ""
                 if status_text:

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -8357,9 +8357,22 @@ class ConversationsPanel(wx.Panel):
 
         from_me = msg.get("key", {}).get("fromMe", False)
 
-        for s in statuses:
-            if "PLAYED" in s or s == "5":
-                return i18n.t("status_played")
+        # The "Me" chat has only one participant — there is no one else to
+        # deliver to, read or play the message for, so "Enviada"/"Entregue"/
+        # "Lida"/"Reproduzida" are never a real receipt there, only a stale/
+        # misleading ack WPPConnect still happens to report (issue #95).
+        # Pending/failed below are left untouched: they are not receipts,
+        # they describe whether the send itself worked.
+        conv = getattr(self, "conversation", None)
+        remote_jid = msg.get("key", {}).get("remoteJid", "") or (
+            conv.get("remoteJid", "") if conv else ""
+        )
+        is_self_chat = bool(remote_jid) and self.main_window._is_self_jid(remote_jid)
+
+        if not is_self_chat:
+            for s in statuses:
+                if "PLAYED" in s or s == "5":
+                    return i18n.t("status_played")
 
         if not from_me:
             # Received messages only show status if they were played
@@ -8373,16 +8386,7 @@ class ConversationsPanel(wx.Panel):
         if latest.startswith("-") or str(msg.get("status", "")).startswith("-"):
             return i18n.t("status_failed")
 
-        # The "Me" chat has only one participant — there is no one else to
-        # deliver to or read the message, so "Enviada"/"Entregue"/"Lida" are
-        # never a real receipt there, only a stale/misleading ack WPPConnect
-        # still happens to report (issue #95). Failure/pending/played above
-        # are left untouched: they are not receipts and stay meaningful.
-        conv = getattr(self, "conversation", None)
-        remote_jid = msg.get("key", {}).get("remoteJid", "") or (
-            conv.get("remoteJid", "") if conv else ""
-        )
-        if remote_jid and self.main_window._is_self_jid(remote_jid):
+        if is_self_chat:
             return ""
 
         for s in statuses:
@@ -8430,18 +8434,20 @@ class ConversationsPanel(wx.Panel):
         updates = msg.get("MessageUpdate")
         if not isinstance(updates, list):
             return []
-        # Same "Me" chat exception as _map_status(): sent/delivered/read are
-        # never a real receipt when the only participant is yourself, so only
-        # "played" (and, below, a genuine failure) can appear there.
+        # Same "Me" chat exception as _map_status(): sent/delivered/read/
+        # played are never a real receipt when the only participant is
+        # yourself, so only a genuine failure (below) can appear there.
         conv = getattr(self, "conversation", None)
         remote_jid = msg.get("key", {}).get("remoteJid", "") or (
             conv.get("remoteJid", "") if conv else ""
         )
         is_self_chat = bool(remote_jid) and self.main_window._is_self_jid(remote_jid)
-        if from_me and not is_self_chat:
-            stage_order = ["sent", "delivered", "read", "played"]
-        else:
+        if not from_me:
             stage_order = ["played"]
+        elif is_self_chat:
+            stage_order = []
+        else:
+            stage_order = ["sent", "delivered", "read", "played"]
         label_keys = {
             "sent": "status_sent", "delivered": "status_delivered",
             "read": "status_read", "played": "status_played",

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -10767,6 +10767,31 @@ class ConversationsPanel(wx.Panel):
                 return i
         return -1
 
+    def _delete_target_jid(self, msg_key: dict) -> str:
+        """The chat a delete has to be addressed at.
+
+        Normally that is the message's own key.remoteJid, and the open
+        conversation is only a fallback for a record that somehow has none.
+        The "Me" chat is the exception, for the same reason
+        _receipts_are_meaningless() reads the chat rather than the key: it
+        holds records whose key still carries the raw self-chat artifact JID
+        ("<my digits>@g.us"), because _redirect_self_chat_artifact() files
+        such a message under my_jid and deduplicate_chats()'s Pass 0a merges
+        an already-stored phantom chat's records into it, and neither
+        rewrites the key. Handing that JID to delete_message_for_me() builds
+        phone="<my digits>@g.us", isGroup=True — a chat that does not exist
+        server-side — so the delete silently does nothing and the message
+        comes back on the next resync, which is issue #73's original symptom
+        in the one chat this whole path exists for.
+
+        Deliberately narrow: only the self-chat overrides the key, so a
+        group or 1:1 delete resolves exactly as it always did.
+        """
+        conv_jid = self.conversation.get("remoteJid", "") if self.conversation else ""
+        if conv_jid and self.main_window._is_self_jid(conv_jid):
+            return conv_jid
+        return msg_key.get("remoteJid", "") or conv_jid
+
     def _delete_message_for_me_only(self, msg: dict, msg_id: str, index: int):
         """Delete a message for this account only (delete_message_for_me),
         then remove it locally — the plain "delete for me" path, shared by
@@ -10775,9 +10800,7 @@ class ConversationsPanel(wx.Panel):
         "delete for everyone" is a no-op there, since the "Me" chat has no
         one else to delete it for)."""
         msg_key = msg.get("key", {})
-        jid = msg_key.get("remoteJid", "") or (
-            self.conversation.get("remoteJid", "") if self.conversation else ""
-        )
+        jid = self._delete_target_jid(msg_key)
 
         def _delete_for_me(k=dict(msg_key), j=jid):
             self.main_window.delete_message_for_me(j, k)
@@ -13934,7 +13957,7 @@ class ConversationsPanel(wx.Panel):
         def _delete_bg():
             for msg in msgs_to_delete:
                 msg_key = dict(msg.get("key", {}))
-                jid = msg_key.get("remoteJid", "") or (self.conversation.get("remoteJid", "") if self.conversation else "")
+                jid = self._delete_target_jid(msg_key)
                 if not jid:
                     continue
                 # Per message, never once for the batch: a mixed selection

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -8373,6 +8373,18 @@ class ConversationsPanel(wx.Panel):
         if latest.startswith("-") or str(msg.get("status", "")).startswith("-"):
             return i18n.t("status_failed")
 
+        # The "Me" chat has only one participant — there is no one else to
+        # deliver to or read the message, so "Enviada"/"Entregue"/"Lida" are
+        # never a real receipt there, only a stale/misleading ack WPPConnect
+        # still happens to report (issue #95). Failure/pending/played above
+        # are left untouched: they are not receipts and stay meaningful.
+        conv = getattr(self, "conversation", None)
+        remote_jid = msg.get("key", {}).get("remoteJid", "") or (
+            conv.get("remoteJid", "") if conv else ""
+        )
+        if remote_jid and self.main_window._is_self_jid(remote_jid):
+            return ""
+
         for s in statuses:
             if "READ" in s or s == "4":
                 return i18n.t("status_read")
@@ -8418,7 +8430,18 @@ class ConversationsPanel(wx.Panel):
         updates = msg.get("MessageUpdate")
         if not isinstance(updates, list):
             return []
-        stage_order = ["sent", "delivered", "read", "played"] if from_me else ["played"]
+        # Same "Me" chat exception as _map_status(): sent/delivered/read are
+        # never a real receipt when the only participant is yourself, so only
+        # "played" (and, below, a genuine failure) can appear there.
+        conv = getattr(self, "conversation", None)
+        remote_jid = msg.get("key", {}).get("remoteJid", "") or (
+            conv.get("remoteJid", "") if conv else ""
+        )
+        is_self_chat = bool(remote_jid) and self.main_window._is_self_jid(remote_jid)
+        if from_me and not is_self_chat:
+            stage_order = ["sent", "delivered", "read", "played"]
+        else:
+            stage_order = ["played"]
         label_keys = {
             "sent": "status_sent", "delivered": "status_delivered",
             "read": "status_read", "played": "status_played",
@@ -10398,6 +10421,25 @@ class ConversationsPanel(wx.Panel):
             wx.OK | wx.ICON_WARNING,
         )
 
+    def _confirm_local_only_delete(self, count: int) -> bool:
+        """Plain Delete/Cancel confirmation for a delete whose scope is
+        already fixed to "for me only" — the "Me" chat's only real option
+        (issue #73: "for everyone" is a no-op there). There is no scope left
+        to choose, only the delete itself to confirm (issue #95). Shared by
+        the single-message self-chat branch of _on_menu_delete_message() and
+        the bulk self-chat branch of _on_mass_delete_messages()."""
+        i18n = self.main_window.i18n
+        title = i18n.t("delete_message") if count == 1 else i18n.t("delete_messages_bulk_title")
+        prompt = (
+            i18n.t("delete_msg_confirm") if count == 1
+            else i18n.t("delete_msg_confirm_bulk").format(count=count)
+        )
+        dlg = wx.MessageDialog(self, prompt, title, wx.YES_NO | wx.ICON_QUESTION)
+        dlg.SetYesNoLabels(i18n.t("delete_message"), i18n.t("cancel"))
+        result = dlg.ShowModal()
+        dlg.Destroy()
+        return result == wx.ID_YES
+
     def _on_menu_delete_message(self, index: int):
         """Show delete-scope dialog and delete locally or for everyone.
 
@@ -10430,8 +10472,14 @@ class ConversationsPanel(wx.Panel):
         is_self_chat = bool(conv_jid) and self.main_window._is_self_jid(conv_jid)
         can_delete_for_all = from_me and not is_system and not is_self_chat
 
+        # There is only one scope possible here ("for me"), so there is
+        # nothing to choose — but a delete is still a delete, and used to fire
+        # with zero confirmation of any kind (issue #95). A plain Delete/
+        # Cancel prompt replaces the for-me/for-everyone dialog below, which
+        # would be misleading anyway (see the comment above).
         if is_self_chat and not is_system:
-            self._delete_message_for_me_only(msg, msg_id, index)
+            if self._confirm_local_only_delete(1):
+                self._delete_message_for_me_only(msg, msg_id, index)
             return
 
         if not can_delete_for_all and not is_system and self.conversation:
@@ -13764,6 +13812,30 @@ class ConversationsPanel(wx.Panel):
             if msg: msgs_to_delete.append(msg)
         if not msgs_to_delete:
             self.selected_messages.clear()
+            return
+
+        # The "Me" chat has only one participant, so "delete for everyone" is
+        # a no-op there for every message in the selection — same reasoning
+        # _on_menu_delete_message() applies to a single message (issue #73).
+        # Skip the for-me/for-everyone dialog below entirely and go straight
+        # to a plain Delete/Cancel confirmation (issue #95).
+        conv_jid = self.conversation.get("remoteJid", "") if self.conversation else ""
+        is_self_chat = bool(conv_jid) and self.main_window._is_self_jid(conv_jid)
+        if is_self_chat:
+            if not self._confirm_local_only_delete(len(msgs_to_delete)):
+                return
+
+            def _delete_bg_self():
+                for msg in msgs_to_delete:
+                    msg_key = dict(msg.get("key", {}))
+                    jid = msg_key.get("remoteJid", "") or conv_jid
+                    if jid:
+                        self.main_window.delete_message_for_me(jid, msg_key)
+            threading.Thread(target=_delete_bg_self, daemon=True).start()
+
+            self.remove_messages_by_id(set(self.selected_messages), focus_previous=True)
+            self.selected_messages.clear()
+            self.main_window.output(i18n.t("success_delete"), interrupt=True)
             return
 
         admin_override = self._group_admin_delete_override()

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -8318,7 +8318,34 @@ class ConversationsPanel(wx.Panel):
             return subtype not in ("initial_phash_mismatch", "phash_mismatch")
         return True
 
-    def _map_status(self, msg) -> str:
+    def _receipts_are_meaningless(self, chat_jid: "str | None" = None) -> bool:
+        """True when the chat being rendered is the "Me" chat, where Sent/
+        Delivered/Read/Played are never a real receipt (issue #95): there is
+        no second participant to deliver to, read or play anything, so the
+        ack WPPConnect still reports there is stale at best and misleading at
+        worst. Pending/failed are deliberately not covered — they describe
+        whether the send itself worked, not who received it.
+
+        Deliberately keyed on the *chat* the message is being rendered in,
+        never on msg["key"]["remoteJid"]: the "Me" chat legitimately holds
+        records whose key still carries the raw self-chat artifact JID —
+        _redirect_self_chat_artifact() (main.py) files such a message under
+        my_jid and deduplicate_chats()'s Pass 0a merges an already-stored
+        phantom chat's records into it, but neither rewrites the key. Those
+        keys end in "@g.us", for which _is_self_jid() returns False by
+        design, so reading the key would leave receipts showing on exactly
+        the self-chat messages that needed the artifact machinery.
+
+        *chat_jid* must be passed by any caller rendering a chat other than
+        the open conversation (the conversations list's preview line reuses
+        this panel for every row — see MainWindow._last_msg_preview()).
+        """
+        if chat_jid is None:
+            conv = getattr(self, "conversation", None)
+            chat_jid = conv.get("remoteJid", "") if isinstance(conv, dict) else ""
+        return bool(chat_jid) and self.main_window._is_self_jid(chat_jid)
+
+    def _map_status(self, msg, chat_jid: "str | None" = None) -> str:
         i18n = self.main_window.i18n
         # Locally-queued messages have their own pending status.
         if msg.get("_local_pending"):
@@ -8363,11 +8390,7 @@ class ConversationsPanel(wx.Panel):
         # misleading ack WPPConnect still happens to report (issue #95).
         # Pending/failed below are left untouched: they are not receipts,
         # they describe whether the send itself worked.
-        conv = getattr(self, "conversation", None)
-        remote_jid = msg.get("key", {}).get("remoteJid", "") or (
-            conv.get("remoteJid", "") if conv else ""
-        )
-        is_self_chat = bool(remote_jid) and self.main_window._is_self_jid(remote_jid)
+        is_self_chat = self._receipts_are_meaningless(chat_jid)
 
         if not is_self_chat:
             for s in statuses:
@@ -8419,7 +8442,7 @@ class ConversationsPanel(wx.Panel):
             return "sent"
         return ""
 
-    def _status_history_lines(self, msg) -> list:
+    def _status_history_lines(self, msg, chat_jid: "str | None" = None) -> list:
         """Per-stage delivery/read/played timeline for a sent message, one
         line per stage actually reached ("Enviada: 14:29", "Entregue: 14:30",
         "Lida: 14:32", …), mirroring the official WhatsApp message-info
@@ -8437,15 +8460,19 @@ class ConversationsPanel(wx.Panel):
         # Same "Me" chat exception as _map_status(): sent/delivered/read/
         # played are never a real receipt when the only participant is
         # yourself, so only a genuine failure (below) can appear there.
-        conv = getattr(self, "conversation", None)
-        remote_jid = msg.get("key", {}).get("remoteJid", "") or (
-            conv.get("remoteJid", "") if conv else ""
-        )
-        is_self_chat = bool(remote_jid) and self.main_window._is_self_jid(remote_jid)
-        if not from_me:
-            stage_order = ["played"]
-        elif is_self_chat:
+        # Checked *before* the not-from_me case, never after: a self-chat
+        # record can legitimately carry fromMe=False (the artifact shapes
+        # _redirect_self_chat_artifact() handles arrive that way, and
+        # on_new_message() only corrects its own local variable, never
+        # msg["key"]["fromMe"]), and mark_audio_message_played() records a
+        # timestamped "played" for exactly those messages — so ordering this
+        # the other way round left the message-data dialog printing
+        # "Reproduzida: 14:31" for a message whose row _map_status() had
+        # already, correctly, blanked.
+        if self._receipts_are_meaningless(chat_jid):
             stage_order = []
+        elif not from_me:
+            stage_order = ["played"]
         else:
             stage_order = ["sent", "delivered", "read", "played"]
         label_keys = {
@@ -10433,18 +10460,37 @@ class ConversationsPanel(wx.Panel):
         (issue #73: "for everyone" is a no-op there). There is no scope left
         to choose, only the delete itself to confirm (issue #95). Shared by
         the single-message self-chat branch of _on_menu_delete_message() and
-        the bulk self-chat branch of _on_mass_delete_messages()."""
+        the bulk self-chat branch of _on_mass_delete_messages().
+
+        OK/Cancel rather than Yes/No, for two reasons that both matter to a
+        keyboard-only user. wxMSW only sets the task dialog's
+        "allow cancellation" flag when wxCANCEL is present, so a wxYES_NO
+        prompt cannot be dismissed with Escape — this one is reached by a
+        keystroke on a focused message, and would have been the single
+        dialog in the app that swallows Escape. And wxCANCEL_DEFAULT keeps
+        the destructive button off the default: Enter must not carry
+        straight through from the message list into the delete, the same
+        reasoning tests/test_update_dialog_default_button.py pins for the
+        updater's own dialog.
+
+        Both labels carry a mnemonic (delete_msg_confirm_yes is the
+        Alt-accelerated form of delete_message): giving Cancelar an
+        accelerator the other button lacks would leave the two buttons
+        reachable in different ways."""
         i18n = self.main_window.i18n
         title = i18n.t("delete_message") if count == 1 else i18n.t("delete_messages_bulk_title")
         prompt = (
             i18n.t("delete_msg_confirm") if count == 1
             else i18n.t("delete_msg_confirm_bulk").format(count=count)
         )
-        dlg = wx.MessageDialog(self, prompt, title, wx.YES_NO | wx.ICON_QUESTION)
-        dlg.SetYesNoLabels(i18n.t("delete_message"), i18n.t("cancel"))
+        dlg = wx.MessageDialog(
+            self, prompt, title,
+            wx.OK | wx.CANCEL | wx.CANCEL_DEFAULT | wx.ICON_QUESTION,
+        )
+        dlg.SetOKCancelLabels(i18n.t("delete_msg_confirm_yes"), i18n.t("cancel"))
         result = dlg.ShowModal()
         dlg.Destroy()
-        return result == wx.ID_YES
+        return result == wx.ID_OK
 
     def _on_menu_delete_message(self, index: int):
         """Show delete-scope dialog and delete locally or for everyone.
@@ -13808,7 +13854,9 @@ class ConversationsPanel(wx.Panel):
         """Same delete-scope dialog _on_menu_delete_message() shows for a
         single message — radio buttons for "delete for me"/"delete for
         everyone" plus Apagar/Cancelar — applied to every selected message
-        instead of the old plain Yes/No "apagar N mensagens?" confirmation."""
+        instead of the old plain Yes/No "apagar N mensagens?" confirmation.
+        In the "Me" chat that scope dialog is replaced by a plain Delete/
+        Cancel confirmation, since "for everyone" is a no-op there."""
         i18n = self.main_window.i18n
         if not self.selected_messages: return
 
@@ -13820,29 +13868,8 @@ class ConversationsPanel(wx.Panel):
             self.selected_messages.clear()
             return
 
-        # The "Me" chat has only one participant, so "delete for everyone" is
-        # a no-op there for every message in the selection — same reasoning
-        # _on_menu_delete_message() applies to a single message (issue #73).
-        # Skip the for-me/for-everyone dialog below entirely and go straight
-        # to a plain Delete/Cancel confirmation (issue #95).
         conv_jid = self.conversation.get("remoteJid", "") if self.conversation else ""
         is_self_chat = bool(conv_jid) and self.main_window._is_self_jid(conv_jid)
-        if is_self_chat:
-            if not self._confirm_local_only_delete(len(msgs_to_delete)):
-                return
-
-            def _delete_bg_self():
-                for msg in msgs_to_delete:
-                    msg_key = dict(msg.get("key", {}))
-                    jid = msg_key.get("remoteJid", "") or conv_jid
-                    if jid:
-                        self.main_window.delete_message_for_me(jid, msg_key)
-            threading.Thread(target=_delete_bg_self, daemon=True).start()
-
-            self.remove_messages_by_id(set(self.selected_messages), focus_previous=True)
-            self.selected_messages.clear()
-            self.main_window.output(i18n.t("success_delete"), interrupt=True)
-            return
 
         admin_override = self._group_admin_delete_override()
 
@@ -13851,46 +13878,58 @@ class ConversationsPanel(wx.Panel):
                 return False
             return admin_override or msg.get("key", {}).get("fromMe", False)
 
-        any_eligible = any(_can_delete_for_all(m) for m in msgs_to_delete)
+        # The "Me" chat has only one participant, so "delete for everyone" is
+        # a no-op there for every message in the selection — same reasoning
+        # _on_menu_delete_message() applies to a single message (issue #73).
+        # Skip the for-me/for-everyone dialog entirely and go straight to a
+        # plain Delete/Cancel confirmation (issue #95). Only the scope choice
+        # is skipped: the delete itself goes through the same worker and the
+        # same local-removal tail as every other bulk delete.
+        if is_self_chat:
+            if not self._confirm_local_only_delete(len(msgs_to_delete)):
+                return
+            for_everyone = False
+        else:
+            any_eligible = any(_can_delete_for_all(m) for m in msgs_to_delete)
 
-        dlg = wx.Dialog(
-            self,
-            title=i18n.t("delete_messages_bulk_title"),
-            style=wx.DEFAULT_DIALOG_STYLE,
-        )
-        panel = wx.Panel(dlg)
-        sizer = wx.BoxSizer(wx.VERTICAL)
+            dlg = wx.Dialog(
+                self,
+                title=i18n.t("delete_messages_bulk_title"),
+                style=wx.DEFAULT_DIALOG_STYLE,
+            )
+            panel = wx.Panel(dlg)
+            sizer = wx.BoxSizer(wx.VERTICAL)
 
-        rb_me = wx.RadioButton(panel, label=i18n.t("delete_for_me"), style=wx.RB_GROUP)
-        rb_me.SetValue(True)
-        sizer.Add(rb_me, 0, wx.ALL, 8)
+            rb_me = wx.RadioButton(panel, label=i18n.t("delete_for_me"), style=wx.RB_GROUP)
+            rb_me.SetValue(True)
+            sizer.Add(rb_me, 0, wx.ALL, 8)
 
-        rb_all = None
-        if any_eligible:
-            rb_all = wx.RadioButton(panel, label=i18n.t("delete_for_everyone"))
-            sizer.Add(rb_all, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 8)
+            rb_all = None
+            if any_eligible:
+                rb_all = wx.RadioButton(panel, label=i18n.t("delete_for_everyone"))
+                sizer.Add(rb_all, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 8)
 
-        btn_sizer  = wx.StdDialogButtonSizer()
-        ok_btn     = wx.Button(panel, wx.ID_OK,     label=i18n.t("delete_messages_bulk_title"))
-        cancel_btn = wx.Button(panel, wx.ID_CANCEL, label=i18n.t("cancel"))
-        btn_sizer.AddButton(ok_btn)
-        btn_sizer.AddButton(cancel_btn)
-        btn_sizer.Realize()
-        sizer.Add(btn_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 8)
+            btn_sizer  = wx.StdDialogButtonSizer()
+            ok_btn     = wx.Button(panel, wx.ID_OK,     label=i18n.t("delete_messages_bulk_title"))
+            cancel_btn = wx.Button(panel, wx.ID_CANCEL, label=i18n.t("cancel"))
+            btn_sizer.AddButton(ok_btn)
+            btn_sizer.AddButton(cancel_btn)
+            btn_sizer.Realize()
+            sizer.Add(btn_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 8)
 
-        panel.SetSizer(sizer)
-        dlg_sizer = wx.BoxSizer(wx.VERTICAL)
-        dlg_sizer.Add(panel, 1, wx.EXPAND)
-        dlg.SetSizer(dlg_sizer)
-        dlg.Fit()
-        dlg.CentreOnParent()
+            panel.SetSizer(sizer)
+            dlg_sizer = wx.BoxSizer(wx.VERTICAL)
+            dlg_sizer.Add(panel, 1, wx.EXPAND)
+            dlg.SetSizer(dlg_sizer)
+            dlg.Fit()
+            dlg.CentreOnParent()
 
-        result       = dlg.ShowModal()
-        for_everyone = rb_all.GetValue() if rb_all else False
-        dlg.Destroy()
+            result       = dlg.ShowModal()
+            for_everyone = rb_all.GetValue() if rb_all else False
+            dlg.Destroy()
 
-        if result != wx.ID_OK:
-            return
+            if result != wx.ID_OK:
+                return
 
         def _delete_bg():
             for msg in msgs_to_delete:

--- a/tests/test_chat_list_delivery_status.py
+++ b/tests/test_chat_list_delivery_status.py
@@ -29,9 +29,14 @@ class _I18n:
 
 class _ConversationsPanelStub:
     _map_status = ConversationsPanel._map_status
+    _receipts_are_meaningless = ConversationsPanel._receipts_are_meaningless
 
     def __init__(self, main_window):
         self.main_window = main_window
+        # The panel the list borrows normally has an open conversation; these
+        # tests set it only where it matters (it must never leak into another
+        # chat's row).
+        self.conversation = None
 
 
 class _MainWindowStub:
@@ -39,12 +44,16 @@ class _MainWindowStub:
     _last_msg_preview = MainWindow._last_msg_preview
     _PREVIEW_MESSAGE_TYPES = MainWindow._PREVIEW_MESSAGE_TYPES
 
-    def __init__(self, show_status=True):
+    def __init__(self, show_status=True, self_jid=""):
         self.i18n = _I18n()
+        self._self_jid = self_jid
         self.settings = {
             "user_interface": {"show_delivery_status_in_chat_list": show_status}
         }
         self.conversations_panel = _ConversationsPanelStub(self)
+
+    def _is_self_jid(self, jid):
+        return bool(self._self_jid) and jid == self._self_jid
 
     def self_reference_label(self):
         return "You"
@@ -60,8 +69,8 @@ def _sent_message(status="READ", ts=1_700_000_000):
     }
 
 
-def _chat_with(message):
-    return {"remoteJid": "jid1", "messages": {"messages": {"records": [message]}}}
+def _chat_with(message, jid="jid1"):
+    return {"remoteJid": jid, "messages": {"messages": {"records": [message]}}}
 
 
 class TestChatListDeliveryStatus:
@@ -100,3 +109,33 @@ class TestChatListDeliveryStatus:
         preview = stub._last_msg_preview(_chat_with(message))
         assert "Read" not in preview
         assert "Delivered" not in preview
+
+
+class TestSelfChatRowInTheList:
+    """Issue #95: the "Me" chat's row must not carry a receipt either, and
+    the rule has to follow the row being rendered — _last_msg_preview()
+    borrows the open conversation's panel for every chat in the list, so
+    _map_status() is told which chat it is looking at rather than guessing
+    from self.conversation."""
+
+    def test_the_self_chats_own_row_shows_no_receipt(self):
+        stub = _MainWindowStub(show_status=True, self_jid="me@s.whatsapp.net")
+        preview = stub._last_msg_preview(
+            _chat_with(_sent_message("READ"), jid="me@s.whatsapp.net")
+        )
+        assert not preview.endswith(" Read")
+
+    def test_another_chats_row_still_shows_its_receipt(self):
+        """Even when the panel's own open conversation is the "Me" chat: the
+        row's JID decides, not whatever happens to be open."""
+        stub = _MainWindowStub(show_status=True, self_jid="me@s.whatsapp.net")
+        stub.conversations_panel.conversation = {"remoteJid": "me@s.whatsapp.net"}
+        preview = stub._last_msg_preview(_chat_with(_sent_message("READ")))
+        assert preview.endswith(" Read")
+
+    def test_a_failed_send_still_shows_in_the_self_chats_row(self):
+        stub = _MainWindowStub(show_status=True, self_jid="me@s.whatsapp.net")
+        preview = stub._last_msg_preview(
+            _chat_with(_sent_message("-1"), jid="me@s.whatsapp.net")
+        )
+        assert preview.endswith(" Failed")

--- a/tests/test_mass_selection.py
+++ b/tests/test_mass_selection.py
@@ -184,6 +184,7 @@ class _Panel:
     _on_mass_save_messages = ConversationsPanel._on_mass_save_messages
     _on_mass_delete_messages = ConversationsPanel._on_mass_delete_messages
     _confirm_local_only_delete = ConversationsPanel._confirm_local_only_delete
+    _delete_target_jid = ConversationsPanel._delete_target_jid
     _on_mass_copy_messages = ConversationsPanel._on_mass_copy_messages
     _on_mass_star_messages = ConversationsPanel._on_mass_star_messages
     _on_mass_pin_messages = ConversationsPanel._on_mass_pin_messages
@@ -1134,6 +1135,25 @@ class TestSelfChatBulkDelete:
         # this dialog is one keystroke away from a focused message.
         assert fake_confirm_dialog["style"] & wx.CANCEL
         assert fake_confirm_dialog["style"] & wx.CANCEL_DEFAULT
+
+    def test_an_unrewritten_artifact_key_is_deleted_against_the_chat(
+        self, fake_confirm_dialog, run_threads_inline
+    ):
+        """A self-chat record can still carry the raw "<my digits>@g.us"
+        artifact JID in its key (_redirect_self_chat_artifact() files it under
+        my_jid, deduplicate_chats()'s Pass 0a merges a stored phantom chat's
+        records in, and neither rewrites the key). Deleting against that key
+        addresses a chat that does not exist server-side, so the message came
+        back on the next resync — the issue #73 symptom."""
+        panel = _Panel(messages=[_msg("m1", jid="5511999999999@g.us", from_me=True)])
+        panel.conversation = {"remoteJid": "me@s.whatsapp.net"}
+        panel.main_window._is_self_jid = lambda jid: jid == "me@s.whatsapp.net"
+        panel.selected_messages = {"m1"}
+
+        panel._on_mass_delete_messages(None)
+
+        (jid, _key), = panel.main_window.deleted_messages
+        assert jid == "me@s.whatsapp.net"
 
     def test_declining_the_confirmation_deletes_nothing(self, fake_confirm_dialog, run_threads_inline):
         fake_confirm_dialog["result"] = wx.ID_CANCEL

--- a/tests/test_mass_selection.py
+++ b/tests/test_mass_selection.py
@@ -142,6 +142,12 @@ class _FakeMainWindow:
     def add_chats_to_ui(self):
         pass
 
+    def _is_self_jid(self, jid):
+        # Overridden per-test (monkeypatch/attribute set) for the self-chat
+        # ("Me") bulk-delete cases; every other test's conversation is a
+        # regular group/individual chat.
+        return False
+
 
 class _FakeEvent:
     def __init__(self, key, ctrl=False, shift=False):
@@ -177,6 +183,7 @@ class _Panel:
     _on_mass_forward_messages = ConversationsPanel._on_mass_forward_messages
     _on_mass_save_messages = ConversationsPanel._on_mass_save_messages
     _on_mass_delete_messages = ConversationsPanel._on_mass_delete_messages
+    _confirm_local_only_delete = ConversationsPanel._confirm_local_only_delete
     _on_mass_copy_messages = ConversationsPanel._on_mass_copy_messages
     _on_mass_star_messages = ConversationsPanel._on_mass_star_messages
     _on_mass_pin_messages = ConversationsPanel._on_mass_pin_messages
@@ -741,6 +748,33 @@ def fake_delete_dialog(monkeypatch):
     return state
 
 
+@pytest.fixture
+def fake_confirm_dialog(monkeypatch):
+    """Fakes the wx.MessageDialog _confirm_local_only_delete() builds (the
+    plain Delete/Cancel prompt for the "Me" chat's local-only delete — no
+    running wx.App needed). Returns a dict the test sets before calling the
+    handler: result (wx.ID_YES/wx.ID_NO, default YES) and captures the
+    prompt/title/labels actually passed in."""
+    state = {"result": wx.ID_YES, "prompt": None, "title": None, "labels": None}
+
+    class _FakeMessageDialog:
+        def __init__(self, parent, message, caption, style):
+            state["prompt"] = message
+            state["title"] = caption
+
+        def SetYesNoLabels(self, yes, no):
+            state["labels"] = (yes, no)
+
+        def ShowModal(self):
+            return state["result"]
+
+        def Destroy(self):
+            pass
+
+    monkeypatch.setattr(wx, "MessageDialog", _FakeMessageDialog)
+    return state
+
+
 class TestMassChatActions:
     def test_clearing_applies_to_every_selected_chat(self, confirm_yes):
         panel = _Panel()
@@ -1053,6 +1087,59 @@ class TestMassMessageActions:
         assert panel.removed_locally == []
         assert panel.starred == []
         assert panel.pinned == []
+
+
+class TestSelfChatBulkDelete:
+    """Issue #95: the "Me" chat has only one participant, so "delete for
+    everyone" is a no-op there for every message (same reasoning as issue
+    #73's single-message fix). Bulk delete on that chat must skip the
+    for-me/for-everyone dialog entirely and go straight to a plain
+    Delete/Cancel confirmation, always deleting locally only."""
+
+    def test_skips_the_scope_dialog_and_deletes_locally_only(
+        self, fake_confirm_dialog, run_threads_inline
+    ):
+        panel = _Panel(messages=[_msg("m1", jid="me@s.whatsapp.net", from_me=True),
+                                  _msg("m2", jid="me@s.whatsapp.net", from_me=True)])
+        panel.conversation = {"remoteJid": "me@s.whatsapp.net"}
+        panel.main_window._is_self_jid = lambda jid: True
+        panel.selected_messages = {"m1", "m2"}
+
+        panel._on_mass_delete_messages(None)
+
+        assert sorted(k["id"] for _jid, k in panel.main_window.deleted_messages) == ["m1", "m2"]
+        assert panel.main_window.deleted_for_everyone == []
+        (removed, focus_previous), = panel.removed_locally
+        assert removed == {"m1", "m2"}
+        assert focus_previous is True
+        assert panel.selected_messages == set()
+        assert panel.main_window.announced == ["success_delete"]
+
+    def test_confirmation_names_the_count_not_a_single_message(self, fake_confirm_dialog, run_threads_inline):
+        panel = _Panel(messages=[_msg("m1", jid="me@s.whatsapp.net", from_me=True),
+                                  _msg("m2", jid="me@s.whatsapp.net", from_me=True)])
+        panel.conversation = {"remoteJid": "me@s.whatsapp.net"}
+        panel.main_window._is_self_jid = lambda jid: True
+        panel.selected_messages = {"m1", "m2"}
+
+        panel._on_mass_delete_messages(None)
+
+        assert fake_confirm_dialog["prompt"] == "Delete 2 selected messages?"
+        assert fake_confirm_dialog["title"] == "delete_messages_bulk_title"
+        assert fake_confirm_dialog["labels"] == ("delete_message", "cancel")
+
+    def test_declining_the_confirmation_deletes_nothing(self, fake_confirm_dialog, run_threads_inline):
+        fake_confirm_dialog["result"] = wx.ID_NO
+        panel = _Panel(messages=[_msg("m1", jid="me@s.whatsapp.net", from_me=True)])
+        panel.conversation = {"remoteJid": "me@s.whatsapp.net"}
+        panel.main_window._is_self_jid = lambda jid: True
+        panel.selected_messages = {"m1"}
+
+        panel._on_mass_delete_messages(None)
+
+        assert panel.main_window.deleted_messages == []
+        assert panel.removed_locally == []
+        assert panel.selected_messages == {"m1"}
 
 
 class _CapturedThread:

--- a/tests/test_mass_selection.py
+++ b/tests/test_mass_selection.py
@@ -753,17 +753,19 @@ def fake_confirm_dialog(monkeypatch):
     """Fakes the wx.MessageDialog _confirm_local_only_delete() builds (the
     plain Delete/Cancel prompt for the "Me" chat's local-only delete — no
     running wx.App needed). Returns a dict the test sets before calling the
-    handler: result (wx.ID_YES/wx.ID_NO, default YES) and captures the
-    prompt/title/labels actually passed in."""
-    state = {"result": wx.ID_YES, "prompt": None, "title": None, "labels": None}
+    handler: result (wx.ID_OK/wx.ID_CANCEL, default OK) and captures the
+    prompt/title/labels/style actually passed in."""
+    state = {"result": wx.ID_OK, "prompt": None, "title": None,
+             "labels": None, "style": None}
 
     class _FakeMessageDialog:
         def __init__(self, parent, message, caption, style):
             state["prompt"] = message
             state["title"] = caption
+            state["style"] = style
 
-        def SetYesNoLabels(self, yes, no):
-            state["labels"] = (yes, no)
+        def SetOKCancelLabels(self, ok, cancel):
+            state["labels"] = (ok, cancel)
 
         def ShowModal(self):
             return state["result"]
@@ -1126,10 +1128,15 @@ class TestSelfChatBulkDelete:
 
         assert fake_confirm_dialog["prompt"] == "Delete 2 selected messages?"
         assert fake_confirm_dialog["title"] == "delete_messages_bulk_title"
-        assert fake_confirm_dialog["labels"] == ("delete_message", "cancel")
+        assert fake_confirm_dialog["labels"] == ("delete_msg_confirm_yes", "cancel")
+        # Escape must dismiss it (wxMSW only allows that when wx.CANCEL is
+        # present) and the destructive button must not be the default —
+        # this dialog is one keystroke away from a focused message.
+        assert fake_confirm_dialog["style"] & wx.CANCEL
+        assert fake_confirm_dialog["style"] & wx.CANCEL_DEFAULT
 
     def test_declining_the_confirmation_deletes_nothing(self, fake_confirm_dialog, run_threads_inline):
-        fake_confirm_dialog["result"] = wx.ID_NO
+        fake_confirm_dialog["result"] = wx.ID_CANCEL
         panel = _Panel(messages=[_msg("m1", jid="me@s.whatsapp.net", from_me=True)])
         panel.conversation = {"remoteJid": "me@s.whatsapp.net"}
         panel.main_window._is_self_jid = lambda jid: True

--- a/tests/test_message_status_history.py
+++ b/tests/test_message_status_history.py
@@ -175,8 +175,8 @@ OTHER_JID = "5511888888888@s.whatsapp.net"
 
 class TestStatusHistoryLinesSelfChat:
     """Issue #95: the "Me" chat has only one participant, so
-    sent/delivered/read are never a real receipt there — only the "played"
-    stage (and a genuine failure) can still appear in the timeline."""
+    sent/delivered/read/played are never a real receipt there — only a
+    genuine failure can still appear in the timeline."""
 
     def _msg(self, updates, from_me=True, remote_jid=SELF_JID):
         return {
@@ -193,13 +193,13 @@ class TestStatusHistoryLinesSelfChat:
         ])
         assert p._status_history_lines(msg) == []
 
-    def test_played_still_shows_in_the_self_chat(self):
+    def test_played_is_also_suppressed_in_the_self_chat(self):
         p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
         msg = self._msg([
             {"status": "2", "ts": _T0},
             {"status": "5", "ts": _T1},
         ])
-        assert p._status_history_lines(msg) == [f"Reproduzida: {_fmt(_T1)}"]
+        assert p._status_history_lines(msg) == []
 
     def test_failure_still_shows_in_the_self_chat(self):
         p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
@@ -233,18 +233,17 @@ class TestMapStatusSelfChat:
     def _msg(self, status, from_me=True, remote_jid=SELF_JID):
         return {"key": {"fromMe": from_me, "remoteJid": remote_jid}, "status": status}
 
-    @pytest.mark.parametrize("status", ["READ", "DELIVERED", "SENT"])
+    @pytest.mark.parametrize("status", ["READ", "DELIVERED", "SENT", "PLAYED"])
     def test_receipt_statuses_are_suppressed_in_the_self_chat(self, status):
+        """Played is suppressed here too — it's just as much a receipt as
+        sent/delivered/read, and objectively meaningless when the only
+        participant is yourself."""
         p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
         assert p._map_status(self._msg(status)) == ""
 
     def test_failed_status_still_shows_in_the_self_chat(self):
         p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
         assert p._map_status(self._msg("-1")) == "Falha ao enviar"
-
-    def test_played_status_still_shows_in_the_self_chat(self):
-        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
-        assert p._map_status(self._msg("PLAYED")) == "Reproduzida"
 
     def test_pending_message_still_shows_in_the_self_chat(self):
         p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
@@ -257,9 +256,15 @@ class TestMapStatusSelfChat:
         msg = self._msg("READ", remote_jid=OTHER_JID)
         assert p._map_status(msg) == "Lida"
 
+    def test_a_different_chat_still_shows_played(self):
+        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        msg = self._msg("PLAYED", remote_jid=OTHER_JID)
+        assert p._map_status(msg) == "Reproduzida"
+
     def test_received_message_in_the_self_chat_is_unaffected(self):
-        """not from_me already returns "" before the self-chat check is ever
-        reached — this only pins that the two don't interact oddly."""
+        """not from_me already returns "" for a non-played status regardless
+        of the self-chat gate — this only pins that the two don't interact
+        oddly."""
         p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
         msg = self._msg("READ", from_me=False)
         assert p._map_status(msg) == ""

--- a/tests/test_message_status_history.py
+++ b/tests/test_message_status_history.py
@@ -67,9 +67,13 @@ def _panel():
     return ConversationsPanel.__new__(ConversationsPanel)
 
 
-def _stub(main_window=None):
+def _stub(main_window=None, conversation=None):
     p = _panel()
     p.main_window = main_window or _FakeMainWindow()
+    # The open conversation is what the self-chat receipt rule keys on when
+    # the caller doesn't name a chat explicitly (see
+    # ConversationsPanel._receipts_are_meaningless).
+    p.conversation = conversation
     return p
 
 
@@ -169,8 +173,25 @@ class TestStatusHistoryLines:
         assert lines == [f"Reproduzida: {_fmt(_T1)}"]
 
 
-SELF_JID = "5511999999999@s.whatsapp.net"
+SELF_JID  = "5511999999999@s.whatsapp.net"
 OTHER_JID = "5511888888888@s.whatsapp.net"
+# The "Me" chat also holds records whose key was never rewritten to my_jid:
+# _redirect_self_chat_artifact() files a self-chat artifact under my_jid and
+# deduplicate_chats()'s Pass 0a merges an already-stored phantom chat's
+# records into it, and neither touches msg["key"]. Those keys keep the
+# "@g.us" suffix, for which _is_self_jid() returns False by design — which
+# is why the receipt rule reads the chat, never the key.
+ARTIFACT_JID = "5511999999999@g.us"
+
+
+def _self_chat_stub():
+    """Panel whose open conversation is the "Me" chat."""
+    return _stub(_FakeMainWindow(self_jids={SELF_JID}), {"remoteJid": SELF_JID})
+
+
+def _other_chat_stub():
+    """Panel whose open conversation is an ordinary 1:1 chat."""
+    return _stub(_FakeMainWindow(self_jids={SELF_JID}), {"remoteJid": OTHER_JID})
 
 
 class TestStatusHistoryLinesSelfChat:
@@ -185,7 +206,7 @@ class TestStatusHistoryLinesSelfChat:
         }
 
     def test_sent_delivered_read_are_suppressed_in_the_self_chat(self):
-        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        p = _self_chat_stub()
         msg = self._msg([
             {"status": "2", "ts": _T0},
             {"status": "3", "ts": _T1},
@@ -194,15 +215,37 @@ class TestStatusHistoryLinesSelfChat:
         assert p._status_history_lines(msg) == []
 
     def test_played_is_also_suppressed_in_the_self_chat(self):
-        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        p = _self_chat_stub()
         msg = self._msg([
             {"status": "2", "ts": _T0},
             {"status": "5", "ts": _T1},
         ])
         assert p._status_history_lines(msg) == []
 
+    def test_a_received_shaped_self_chat_message_is_suppressed_too(self):
+        """A self-chat artifact can arrive with fromMe=False (on_new_message()
+        corrects only its own local variable, never msg["key"]["fromMe"]), and
+        mark_audio_message_played() records a timestamped "played" for exactly
+        those messages. Evaluating the not-from_me case first used to let that
+        through as "Reproduzida: hh:mm" here while _map_status() blanked the
+        very same message's row."""
+        p = _self_chat_stub()
+        msg = self._msg([{"status": "5", "ts": _T1}], from_me=False)
+        assert p._status_history_lines(msg) == []
+        assert p._map_status(msg) == ""
+
+    def test_an_unrewritten_artifact_key_is_still_the_self_chat(self):
+        """The chat decides, not the key: a record still carrying the raw
+        "<my digits>@g.us" artifact JID is in the "Me" chat like any other."""
+        p = _self_chat_stub()
+        msg = self._msg([
+            {"status": "2", "ts": _T0},
+            {"status": "4", "ts": _T1},
+        ], remote_jid=ARTIFACT_JID)
+        assert p._status_history_lines(msg) == []
+
     def test_failure_still_shows_in_the_self_chat(self):
-        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        p = _self_chat_stub()
         msg = self._msg([
             {"status": "2", "ts": _T0},
             {"status": "-1", "ts": _T1},
@@ -212,7 +255,7 @@ class TestStatusHistoryLinesSelfChat:
     def test_a_different_chat_still_shows_the_full_timeline(self):
         """Only the actual self-chat is affected — _is_self_jid returning
         False for a normal 1:1/group chat must not change anything."""
-        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        p = _other_chat_stub()
         msg = self._msg([
             {"status": "2", "ts": _T0},
             {"status": "3", "ts": _T1},
@@ -238,26 +281,30 @@ class TestMapStatusSelfChat:
         """Played is suppressed here too — it's just as much a receipt as
         sent/delivered/read, and objectively meaningless when the only
         participant is yourself."""
-        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        p = _self_chat_stub()
         assert p._map_status(self._msg(status)) == ""
 
+    def test_an_unrewritten_artifact_key_is_still_the_self_chat(self):
+        p = _self_chat_stub()
+        assert p._map_status(self._msg("READ", remote_jid=ARTIFACT_JID)) == ""
+
     def test_failed_status_still_shows_in_the_self_chat(self):
-        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        p = _self_chat_stub()
         assert p._map_status(self._msg("-1")) == "Falha ao enviar"
 
     def test_pending_message_still_shows_in_the_self_chat(self):
-        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        p = _self_chat_stub()
         msg = self._msg("READ")
         msg["_local_pending"] = True
         assert p._map_status(msg) == "Pendente"
 
     def test_a_different_chat_still_shows_read(self):
-        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        p = _other_chat_stub()
         msg = self._msg("READ", remote_jid=OTHER_JID)
         assert p._map_status(msg) == "Lida"
 
     def test_a_different_chat_still_shows_played(self):
-        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        p = _other_chat_stub()
         msg = self._msg("PLAYED", remote_jid=OTHER_JID)
         assert p._map_status(msg) == "Reproduzida"
 
@@ -265,6 +312,30 @@ class TestMapStatusSelfChat:
         """not from_me already returns "" for a non-played status regardless
         of the self-chat gate — this only pins that the two don't interact
         oddly."""
-        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        p = _self_chat_stub()
         msg = self._msg("READ", from_me=False)
         assert p._map_status(msg) == ""
+
+
+class TestReceiptRuleFollowsTheChatBeingRendered:
+    """The conversations list reuses the open conversation's panel to render
+    every row's preview line (MainWindow._last_msg_preview()), so the chat
+    has to be passed in — falling back to self.conversation there would
+    apply the open chat's receipt rule to somebody else's row."""
+
+    def _msg(self, remote_jid):
+        return {"key": {"fromMe": True, "remoteJid": remote_jid}, "status": "READ"}
+
+    def test_an_explicit_chat_jid_overrides_the_open_conversation(self):
+        p = _self_chat_stub()   # "Me" chat open
+        assert p._map_status(self._msg(OTHER_JID), OTHER_JID) == "Lida"
+
+    def test_the_self_chats_row_is_suppressed_while_another_chat_is_open(self):
+        p = _other_chat_stub()  # an ordinary chat open
+        assert p._map_status(self._msg(SELF_JID), SELF_JID) == ""
+
+    def test_no_open_conversation_shows_the_status(self):
+        """Nothing to fall back to must mean "not the self-chat", never a
+        crash — _last_msg_preview() runs before any chat is opened."""
+        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        assert p._map_status(self._msg(OTHER_JID)) == "Lida"

--- a/tests/test_message_status_history.py
+++ b/tests/test_message_status_history.py
@@ -44,6 +44,7 @@ class _FakeI18n:
         "status_read": "Lida",
         "status_played": "Reproduzida",
         "status_failed": "Falha ao enviar",
+        "status_pending": "Pendente",
         "time_fmt": "%H:%M",
         "datetime_fmt": "%d/%m/%Y %H:%M",
     }
@@ -53,8 +54,13 @@ class _FakeI18n:
 
 
 class _FakeMainWindow:
-    def __init__(self):
+    def __init__(self, self_jids=()):
         self.i18n = _FakeI18n()
+        # JIDs that should be treated as "me" — the self-chat ("Me") case.
+        self._self_jids = set(self_jids)
+
+    def _is_self_jid(self, jid):
+        return jid in self._self_jids
 
 
 def _panel():
@@ -161,3 +167,99 @@ class TestStatusHistoryLines:
         ], from_me=False)
         lines = p._status_history_lines(msg)
         assert lines == [f"Reproduzida: {_fmt(_T1)}"]
+
+
+SELF_JID = "5511999999999@s.whatsapp.net"
+OTHER_JID = "5511888888888@s.whatsapp.net"
+
+
+class TestStatusHistoryLinesSelfChat:
+    """Issue #95: the "Me" chat has only one participant, so
+    sent/delivered/read are never a real receipt there — only the "played"
+    stage (and a genuine failure) can still appear in the timeline."""
+
+    def _msg(self, updates, from_me=True, remote_jid=SELF_JID):
+        return {
+            "key": {"fromMe": from_me, "remoteJid": remote_jid},
+            "MessageUpdate": updates,
+        }
+
+    def test_sent_delivered_read_are_suppressed_in_the_self_chat(self):
+        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        msg = self._msg([
+            {"status": "2", "ts": _T0},
+            {"status": "3", "ts": _T1},
+            {"status": "4", "ts": _T2},
+        ])
+        assert p._status_history_lines(msg) == []
+
+    def test_played_still_shows_in_the_self_chat(self):
+        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        msg = self._msg([
+            {"status": "2", "ts": _T0},
+            {"status": "5", "ts": _T1},
+        ])
+        assert p._status_history_lines(msg) == [f"Reproduzida: {_fmt(_T1)}"]
+
+    def test_failure_still_shows_in_the_self_chat(self):
+        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        msg = self._msg([
+            {"status": "2", "ts": _T0},
+            {"status": "-1", "ts": _T1},
+        ])
+        assert p._status_history_lines(msg) == [f"Falha ao enviar: {_fmt(_T1)}"]
+
+    def test_a_different_chat_still_shows_the_full_timeline(self):
+        """Only the actual self-chat is affected — _is_self_jid returning
+        False for a normal 1:1/group chat must not change anything."""
+        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        msg = self._msg([
+            {"status": "2", "ts": _T0},
+            {"status": "3", "ts": _T1},
+            {"status": "4", "ts": _T2},
+        ], remote_jid=OTHER_JID)
+        assert p._status_history_lines(msg) == [
+            f"Enviada: {_fmt(_T0)}",
+            f"Entregue: {_fmt(_T1)}",
+            f"Lida: {_fmt(_T2)}",
+        ]
+
+
+class TestMapStatusSelfChat:
+    """Same issue #95 exception applied to _map_status() — the single-line
+    status shown in the message list, the chat list preview and (as a
+    fallback) the message data dialog."""
+
+    def _msg(self, status, from_me=True, remote_jid=SELF_JID):
+        return {"key": {"fromMe": from_me, "remoteJid": remote_jid}, "status": status}
+
+    @pytest.mark.parametrize("status", ["READ", "DELIVERED", "SENT"])
+    def test_receipt_statuses_are_suppressed_in_the_self_chat(self, status):
+        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        assert p._map_status(self._msg(status)) == ""
+
+    def test_failed_status_still_shows_in_the_self_chat(self):
+        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        assert p._map_status(self._msg("-1")) == "Falha ao enviar"
+
+    def test_played_status_still_shows_in_the_self_chat(self):
+        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        assert p._map_status(self._msg("PLAYED")) == "Reproduzida"
+
+    def test_pending_message_still_shows_in_the_self_chat(self):
+        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        msg = self._msg("READ")
+        msg["_local_pending"] = True
+        assert p._map_status(msg) == "Pendente"
+
+    def test_a_different_chat_still_shows_read(self):
+        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        msg = self._msg("READ", remote_jid=OTHER_JID)
+        assert p._map_status(msg) == "Lida"
+
+    def test_received_message_in_the_self_chat_is_unaffected(self):
+        """not from_me already returns "" before the self-chat check is ever
+        reached — this only pins that the two don't interact oddly."""
+        p = _stub(_FakeMainWindow(self_jids={SELF_JID}))
+        msg = self._msg("READ", from_me=False)
+        assert p._map_status(msg) == ""

--- a/tests/test_self_chat_delete_skips_everyone.py
+++ b/tests/test_self_chat_delete_skips_everyone.py
@@ -85,7 +85,7 @@ def _run_and_join_threads(fn):
 class TestSelfChatSkipsTheScopeDialog:
     def test_self_chat_deletes_locally_only_after_a_plain_confirm(self, monkeypatch):
         monkeypatch.setattr(wx, "MessageDialog",
-                             lambda *a, **k: _FakeMessageDialog(wx.ID_YES))
+                             lambda *a, **k: _FakeMessageDialog(wx.ID_OK))
         stub = _Stub(SELF_JID, is_self_chat=True)
 
         _run_and_join_threads(lambda: stub._on_menu_delete_message(0))
@@ -96,7 +96,7 @@ class TestSelfChatSkipsTheScopeDialog:
 
     def test_declining_the_confirmation_deletes_nothing(self, monkeypatch):
         monkeypatch.setattr(wx, "MessageDialog",
-                             lambda *a, **k: _FakeMessageDialog(wx.ID_NO))
+                             lambda *a, **k: _FakeMessageDialog(wx.ID_CANCEL))
         stub = _Stub(SELF_JID, is_self_chat=True)
 
         _run_and_join_threads(lambda: stub._on_menu_delete_message(0))
@@ -111,12 +111,13 @@ class TestSelfChatSkipsTheScopeDialog:
 
         class _CapturingDialog(_FakeMessageDialog):
             def __init__(self, parent, message, caption, style):
-                super().__init__(wx.ID_YES)
+                super().__init__(wx.ID_OK)
                 captured["message"] = message
                 captured["caption"] = caption
+                captured["style"] = style
 
-            def SetYesNoLabels(self, yes, no):
-                captured["labels"] = (yes, no)
+            def SetOKCancelLabels(self, ok, cancel):
+                captured["labels"] = (ok, cancel)
 
         monkeypatch.setattr(wx, "MessageDialog", _CapturingDialog)
         stub = _Stub(SELF_JID, is_self_chat=True)
@@ -125,14 +126,20 @@ class TestSelfChatSkipsTheScopeDialog:
 
         assert captured["message"] == "delete_msg_confirm"
         assert captured["caption"] == "delete_message"
-        assert captured["labels"] == ("delete_message", "cancel")
+        assert captured["labels"] == ("delete_msg_confirm_yes", "cancel")
+        # Escape has to dismiss it — wxMSW only allows the native dialog to be
+        # cancelled when wx.CANCEL is in the style — and the destructive
+        # button must not be the default, since this prompt is one keystroke
+        # away from a focused message.
+        assert captured["style"] & wx.CANCEL
+        assert captured["style"] & wx.CANCEL_DEFAULT
 
 
 class _FakeMessageDialog:
     def __init__(self, result):
         self._result = result
 
-    def SetYesNoLabels(self, yes, no):
+    def SetOKCancelLabels(self, ok, cancel):
         pass
 
     def ShowModal(self):

--- a/tests/test_self_chat_delete_skips_everyone.py
+++ b/tests/test_self_chat_delete_skips_everyone.py
@@ -4,22 +4,32 @@ no-op there (there's no one else to delete it for), so the message stayed
 on every other linked device and reappeared in WinZapp itself after the
 next resync, while the app had told the user it was gone for everyone.
 
-_on_menu_delete_message() now detects the self-chat up front and skips the
+_on_menu_delete_message() detects the self-chat up front and skips the
 whole "delete for me / for everyone" dialog entirely, going straight to a
 plain local delete (delete_message_for_me) — matching the reporter's own
 suggested fix.
 
+Issue #95: that self-chat path used to fire with zero confirmation at all.
+It now shows a plain Delete/Cancel prompt (_confirm_local_only_delete) —
+no scope choice, since "for everyone" was never real here, just a yes/no on
+the delete itself — before actually deleting.
+
 ConversationsPanel is a wx.Panel and can't be instantiated without a
-running wx.App. The self-chat path returns before touching anything
-wx-specific (no dialog, no wx.Dialog(...) construction), so it's safe to
-exercise directly against a plain stub without a wx.App fixture at all —
-unlike the non-self-chat path, which is left untested here since it builds
-a real modal dialog.
+running wx.App, so wx.MessageDialog (the confirmation) is faked below
+rather than exercised for real — unlike the non-self-chat path, which is
+left untested here since it builds a real modal dialog.
 """
 
 import threading
 
+import wx
+
 from ui.conversations import ConversationsPanel
+
+
+class _FakeI18n:
+    def t(self, key):
+        return key
 
 
 class _FakeMainWindow:
@@ -27,7 +37,7 @@ class _FakeMainWindow:
         self._is_self_chat = is_self_chat
         self.delete_for_me_calls = []
         self.delete_for_everyone_calls = []
-        self.i18n = None  # unused on the self-chat path (returns before it's read)
+        self.i18n = _FakeI18n()
 
     def _is_self_jid(self, jid):
         return self._is_self_chat
@@ -42,10 +52,11 @@ class _FakeMainWindow:
 
 
 class _Stub:
-    _on_menu_delete_message     = ConversationsPanel._on_menu_delete_message
-    _delete_message_for_me_only = ConversationsPanel._delete_message_for_me_only
+    _on_menu_delete_message      = ConversationsPanel._on_menu_delete_message
+    _delete_message_for_me_only  = ConversationsPanel._delete_message_for_me_only
+    _confirm_local_only_delete   = ConversationsPanel._confirm_local_only_delete
     _is_separator                = ConversationsPanel._is_separator
-    _is_system_event              = lambda self, msg: False
+    _is_system_event             = lambda self, msg: False
 
     def __init__(self, jid, is_self_chat):
         self.main_window = _FakeMainWindow(is_self_chat)
@@ -71,8 +82,10 @@ def _run_and_join_threads(fn):
         t.join(timeout=2)
 
 
-class TestSelfChatSkipsTheDialog:
-    def test_self_chat_deletes_locally_only_without_any_dialog(self):
+class TestSelfChatSkipsTheScopeDialog:
+    def test_self_chat_deletes_locally_only_after_a_plain_confirm(self, monkeypatch):
+        monkeypatch.setattr(wx, "MessageDialog",
+                             lambda *a, **k: _FakeMessageDialog(wx.ID_YES))
         stub = _Stub(SELF_JID, is_self_chat=True)
 
         _run_and_join_threads(lambda: stub._on_menu_delete_message(0))
@@ -80,3 +93,50 @@ class TestSelfChatSkipsTheDialog:
         assert stub.removed_ids == [{"m1"}]
         assert len(stub.main_window.delete_for_me_calls) == 1
         assert stub.main_window.delete_for_everyone_calls == []
+
+    def test_declining_the_confirmation_deletes_nothing(self, monkeypatch):
+        monkeypatch.setattr(wx, "MessageDialog",
+                             lambda *a, **k: _FakeMessageDialog(wx.ID_NO))
+        stub = _Stub(SELF_JID, is_self_chat=True)
+
+        _run_and_join_threads(lambda: stub._on_menu_delete_message(0))
+
+        assert stub.removed_ids == []
+        assert stub.main_window.delete_for_me_calls == []
+        assert stub.main_window.delete_for_everyone_calls == []
+
+    def test_confirmation_offers_no_scope_choice(self, monkeypatch):
+        """No radios, no "for everyone" option — just Delete/Cancel."""
+        captured = {}
+
+        class _CapturingDialog(_FakeMessageDialog):
+            def __init__(self, parent, message, caption, style):
+                super().__init__(wx.ID_YES)
+                captured["message"] = message
+                captured["caption"] = caption
+
+            def SetYesNoLabels(self, yes, no):
+                captured["labels"] = (yes, no)
+
+        monkeypatch.setattr(wx, "MessageDialog", _CapturingDialog)
+        stub = _Stub(SELF_JID, is_self_chat=True)
+
+        _run_and_join_threads(lambda: stub._on_menu_delete_message(0))
+
+        assert captured["message"] == "delete_msg_confirm"
+        assert captured["caption"] == "delete_message"
+        assert captured["labels"] == ("delete_message", "cancel")
+
+
+class _FakeMessageDialog:
+    def __init__(self, result):
+        self._result = result
+
+    def SetYesNoLabels(self, yes, no):
+        pass
+
+    def ShowModal(self):
+        return self._result
+
+    def Destroy(self):
+        pass

--- a/tests/test_self_chat_delete_skips_everyone.py
+++ b/tests/test_self_chat_delete_skips_everyone.py
@@ -55,12 +55,17 @@ class _Stub:
     _on_menu_delete_message      = ConversationsPanel._on_menu_delete_message
     _delete_message_for_me_only  = ConversationsPanel._delete_message_for_me_only
     _confirm_local_only_delete   = ConversationsPanel._confirm_local_only_delete
+    _delete_target_jid           = ConversationsPanel._delete_target_jid
     _is_separator                = ConversationsPanel._is_separator
     _is_system_event             = lambda self, msg: False
 
-    def __init__(self, jid, is_self_chat):
+    def __init__(self, jid, is_self_chat, key_jid=None):
         self.main_window = _FakeMainWindow(is_self_chat)
-        msg = {"key": {"id": "m1", "fromMe": True, "remoteJid": jid}}
+        # key_jid differs from the chat's own JID only for a self-chat
+        # artifact record whose key was never rewritten (see
+        # ConversationsPanel._delete_target_jid).
+        msg = {"key": {"id": "m1", "fromMe": True,
+                       "remoteJid": key_jid if key_jid is not None else jid}}
         self._sorted_messages = [msg]
         self.conversation = {"remoteJid": jid}
         self.removed_ids = []
@@ -147,3 +152,43 @@ class _FakeMessageDialog:
 
     def Destroy(self):
         pass
+
+
+class TestTheDeleteIsAddressedAtTheChat:
+    """A self-chat record can still carry the raw "<my digits>@g.us" artifact
+    JID in its key: _redirect_self_chat_artifact() files it under my_jid and
+    deduplicate_chats()'s Pass 0a merges a stored phantom chat's records into
+    the "Me" chat, and neither rewrites the key. Deleting against that key
+    builds phone="<my digits>@g.us", isGroup=True server-side — a chat that
+    does not exist — so the message came back on the next resync, which is
+    exactly the issue #73 symptom this path exists to fix."""
+
+    ARTIFACT_JID = "5511999999999@g.us"
+
+    def test_an_unrewritten_artifact_key_is_deleted_against_the_chat(self, monkeypatch):
+        monkeypatch.setattr(wx, "MessageDialog",
+                             lambda *a, **k: _FakeMessageDialog(wx.ID_OK))
+        stub = _Stub(SELF_JID, is_self_chat=True, key_jid=self.ARTIFACT_JID)
+
+        _run_and_join_threads(lambda: stub._on_menu_delete_message(0))
+
+        (jid, _key), = stub.main_window.delete_for_me_calls
+        assert jid == SELF_JID
+
+    def test_an_ordinary_chat_still_resolves_from_the_message_key(self, monkeypatch):
+        """The override is deliberately narrow — outside the "Me" chat the
+        key keeps deciding, exactly as before."""
+        monkeypatch.setattr(wx, "MessageDialog",
+                             lambda *a, **k: _FakeMessageDialog(wx.ID_OK))
+        stub = _Stub("group@g.us", is_self_chat=False)
+        stub._sorted_messages[0]["key"]["remoteJid"] = "group@g.us"
+
+        stub._delete_message_for_me_only(
+            stub._sorted_messages[0], "m1", 0
+        )
+        for t in list(threading.enumerate()):
+            if t is not threading.current_thread():
+                t.join(timeout=2)
+
+        (jid, _key), = stub.main_window.delete_for_me_calls
+        assert jid == "group@g.us"

--- a/tests/test_unconfirmed_send_recovery.py
+++ b/tests/test_unconfirmed_send_recovery.py
@@ -175,6 +175,7 @@ class _FakeMainWindow:
 class _DeleteStub:
     _on_menu_delete_message     = ConversationsPanel._on_menu_delete_message
     _delete_message_for_me_only = ConversationsPanel._delete_message_for_me_only
+    _delete_target_jid          = ConversationsPanel._delete_target_jid
     # The real helper, not a stand-in: the cancelled_pending branch delegates
     # to it, and what it does with a cancel() that could not stop the send is
     # exactly what these tests are about.


### PR DESCRIPTION
Closes #95.

The Me chat only has one participant, so WhatsApp's Sent, Delivered, Read and Played receipts never really apply there, only a stale ack that used to show up anyway. This hides that status wherever it appeared, in the message list, the chat list preview and the message data dialog, while keeping Pending and Failed visible since those still mean something. It also adds a simple Delete or Cancel confirmation before removing a message (or several) from that chat, since that delete used to happen instantly with no way to back out.