### PR TITLE
Prefer a stable WhatsApp Web build over alpha, and tolerate slow syncs before going offline

### DIFF
--- a/client/api_patches/start.js
+++ b/client/api_patches/start.js
@@ -399,11 +399,21 @@ function versionExpiry(catalogue, version) {
 // pre-release build that was nowhere near expired still got every
 // freshly-paired session unpaired by WhatsApp within minutes of the pinned
 // page loading ("Session Unpaired" in wppconnect.log, immediately followed by
-// "notLogged", repeating on every re-pair attempt). A catalogue with no
-// pre-release entries at all is unaffected: every version in it is "stable"
-// by this check, so the first pass of each tier already finds what the
-// second pass would have, and behaves exactly as before this distinction
-// existed.
+// "notLogged", repeating on every re-pair attempt).
+//
+// Be honest about what this buys TODAY, because it is easy to read it as the
+// fix for that unpairing and it is not: the catalogue @wppconnect/wa-version
+// currently ships (1.5.4763) is 100% pre-release — all 392 entries end in
+// "-alpha", every file under html/ is an *-alpha.html, currentVersion is
+// itself an alpha and currentBeta is null. So the stable pass of each tier
+// matches nothing at all, the second pass does all the work, and the version
+// selected is byte-for-byte the one selected before this distinction existed.
+// The preference only starts having an effect if and when a stable build is
+// actually cached in the catalogue (an `npm update` after Meta promotes one,
+// or an older install whose catalogue still holds stables). That is the point
+// of it: it is the safety net for a catalogue that has stables again, not the
+// thing that keeps a freshly-paired session paired right now. Whatever does
+// fix the unpairing has to work on an all-alpha catalogue too.
 //
 // Returns { version, expire, expired, total }, or null when the catalogue is
 // empty/unusable. `expired: true` means nothing valid was left and this is the
@@ -412,13 +422,25 @@ function versionExpiry(catalogue, version) {
 function selectServableVersion(catalogue, now) {
   const available = catalogue.getAvailableVersions();
   if (!Array.isArray(available) || available.length === 0) return null;
+  // Memoised per version, and that is not a micro-optimisation. The comment
+  // above about "minutes of I/O" is what is being protected here: each tier is
+  // walked twice (stable channel, then any channel), so without a cache the
+  // same entry can be handed to getPageContent up to four times — and one call
+  // is a readdirSync of html/ (392 files on the shipped package) plus a read of
+  // a ~600 KB HTML file. This runs inside session startup, so the passes added
+  // above must not put that cost back on the hot path they were written around.
+  const serveCache = new Map();
   const canServe = (version) => {
+    if (serveCache.has(version)) return serveCache.get(version);
+    let servable;
     try {
       catalogue.getPageContent(version);
-      return true;
+      servable = true;
     } catch (e) {
-      return false;
+      servable = false;
     }
+    serveCache.set(version, servable);
+    return servable;
   };
   const isStable = (version) => !/-alpha|-beta/i.test(version);
   for (const stableOnly of [true, false]) {
@@ -537,25 +559,51 @@ const LIVE_DOCUMENT_FETCH_TIMEOUT_MS = 10000;
 // another door; an unexpired pinned build is the known-good pairing. So this is
 // the expired branch's fallback, never the default.
 //
-// wa-version does the request itself (fetchLatestAlpha sends the user-agent,
+// wa-version does the request itself (its fetchers send the user-agent,
 // language and cache headers Meta expects, which a bare fetch here would get
-// wrong). Older copies of the package may not export it — hence the typeof
-// guard rather than a call that would throw at startup.
+// wrong). It exposes two channels: fetchLatest() is the stable one and
+// fetchLatestAlpha() the pre-release one, and this asks for them IN THAT ORDER.
+// The alpha channel used to be the only thing asked, which quietly reintroduced
+// the very problem the pin exists to avoid: if pre-release builds are what
+// unpair freshly-linked sessions, then the one branch guaranteed to hand the
+// browser a pre-release build was the "everything local has expired" branch —
+// i.e. exactly the user least able to diagnose it. Stable first, alpha only as
+// the last thing before falling back to an expired local build.
+//
+// Older copies of the package may not export one or the other — hence the
+// typeof guards rather than calls that would throw at startup.
 async function fetchLiveWhatsappDocument() {
-  if (!waVersion || typeof waVersion.fetchLatestAlpha !== 'function') return null;
+  if (!waVersion) return null;
   let timer = null;
   try {
     const timeout = new Promise((resolve) => {
       timer = setTimeout(() => resolve(null), LIVE_DOCUMENT_FETCH_TIMEOUT_MS);
     });
-    const html = await Promise.race([waVersion.fetchLatestAlpha(), timeout]);
     // Anything can answer an HTTP request — a captive portal, a proxy error
     // page, a consent interstitial. Serving one of those AS the WhatsApp Web
     // document would look like a WhatsApp bug rather than a network one, so
-    // require it to actually be the app shell before trusting it.
-    if (typeof html !== 'string' || html.length < 1000) return null;
-    if (!/web\.whatsapp\.com|WhatsApp/i.test(html)) return null;
-    return html;
+    // require it to actually be the app shell before trusting it. A stable
+    // response that fails this is not trusted and not fatal either: it just
+    // means the alpha channel gets its turn.
+    const isAppShell = (html) => (
+      typeof html === 'string'
+      && html.length >= 1000
+      && /web\.whatsapp\.com|WhatsApp/i.test(html)
+    );
+    // ONE budget covers BOTH attempts: `timeout` is a single promise raced
+    // against each channel in turn, so once it has resolved the second attempt
+    // is already over. Two channels must not mean twice the time a user on a
+    // dead network waits with pairing held hostage.
+    const attempt = async (channel) => {
+      if (typeof waVersion[channel] !== 'function') return null;
+      try {
+        const html = await Promise.race([waVersion[channel](), timeout]);
+        return isAppShell(html) ? html : null;
+      } catch (e) {
+        return null;
+      }
+    };
+    return (await attempt('fetchLatest')) || (await attempt('fetchLatestAlpha'));
   } catch (e) {
     return null;
   } finally {

--- a/client/api_patches/start.js
+++ b/client/api_patches/start.js
@@ -594,11 +594,18 @@ async function fetchLiveWhatsappDocument() {
     // against each channel in turn, so once it has resolved the second attempt
     // is already over. Two channels must not mean twice the time a user on a
     // dead network waits with pairing held hostage.
+    //
+    // Answers with the channel that produced the HTML, not the HTML alone,
+    // because the caller has to be able to log WHICH one served the session.
+    // The catalogue pin gets that for free — it prints a version string, and a
+    // pre-release build wears `-alpha` on its face — but "live from Meta" says
+    // nothing, and a user reporting "Session Unpaired" hours after pairing is
+    // exactly the case where stable-vs-alpha is the first thing to check.
     const attempt = async (channel) => {
       if (typeof waVersion[channel] !== 'function') return null;
       try {
         const html = await Promise.race([waVersion[channel](), timeout]);
-        return isAppShell(html) ? html : null;
+        return isAppShell(html) ? { channel, html } : null;
       } catch (e) {
         return null;
       }
@@ -764,13 +771,16 @@ function patchWppconnectVersionPinning() {
       if (pinnedCatalogueExpired) {
         const live = await fetchLiveWhatsappDocument();
         if (live) {
-          body = live;
-          source = 'live from Meta (local catalogue fully expired)';
+          body = live.html;
+          source = `live from Meta via ${live.channel} (local catalogue fully expired)`;
           console.warn(
             '[WinZapp] Every build in the local catalogue has expired; serving the ' +
-            'document Meta is currently returning instead. This keeps the page pinned ' +
-            'and the worker unblocked, but the bundled wa-js may lag that build — ' +
-            'run: npm update @wppconnect/wa-version (or reinstall the API from WinZapp).'
+            `document Meta is currently returning, fetched with ${live.channel}(). This ` +
+            'keeps the page pinned and the worker unblocked, but the bundled wa-js may ' +
+            'lag that build — and fetchLatestAlpha() means a PRE-RELEASE build, which is ' +
+            'what the stable-first order exists to avoid, so a session that unpairs later ' +
+            'starts here. Run: npm update @wppconnect/wa-version (or reinstall the API ' +
+            'from WinZapp).'
           );
         } else {
           console.warn(

--- a/client/api_patches/start.js
+++ b/client/api_patches/start.js
@@ -393,6 +393,18 @@ function versionExpiry(catalogue, version) {
 // locally. The expiry check comes first because it is the cheap one; reading
 // every HTML file down the list would be minutes of I/O.
 //
+// Each tier below is walked twice: stable channel first (no "-alpha"/"-beta"
+// in the version string), then any channel. Meta's expiry window is a good
+// proxy for "still served", but not for "safe to link a device against" — a
+// pre-release build that was nowhere near expired still got every
+// freshly-paired session unpaired by WhatsApp within minutes of the pinned
+// page loading ("Session Unpaired" in wppconnect.log, immediately followed by
+// "notLogged", repeating on every re-pair attempt). A catalogue with no
+// pre-release entries at all is unaffected: every version in it is "stable"
+// by this check, so the first pass of each tier already finds what the
+// second pass would have, and behaves exactly as before this distinction
+// existed.
+//
 // Returns { version, expire, expired, total }, or null when the catalogue is
 // empty/unusable. `expired: true` means nothing valid was left and this is the
 // newest servable build regardless — see the call site for why that is still
@@ -408,22 +420,29 @@ function selectServableVersion(catalogue, now) {
       return false;
     }
   };
-  for (let i = available.length - 1; i >= 0; i--) {
-    const version = available[i];
-    const expire = versionExpiry(catalogue, version);
-    if (expire !== null && expire <= now) continue;
-    if (!canServe(version)) continue;
-    return { version, expire, expired: false, total: available.length };
+  const isStable = (version) => !/-alpha|-beta/i.test(version);
+  for (const stableOnly of [true, false]) {
+    for (let i = available.length - 1; i >= 0; i--) {
+      const version = available[i];
+      if (stableOnly && !isStable(version)) continue;
+      const expire = versionExpiry(catalogue, version);
+      if (expire !== null && expire <= now) continue;
+      if (!canServe(version)) continue;
+      return { version, expire, expired: false, total: available.length };
+    }
   }
-  for (let i = available.length - 1; i >= 0; i--) {
-    const version = available[i];
-    if (canServe(version)) {
-      return {
-        version,
-        expire: versionExpiry(catalogue, version),
-        expired: true,
-        total: available.length,
-      };
+  for (const stableOnly of [true, false]) {
+    for (let i = available.length - 1; i >= 0; i--) {
+      const version = available[i];
+      if (stableOnly && !isStable(version)) continue;
+      if (canServe(version)) {
+        return {
+          version,
+          expire: versionExpiry(catalogue, version),
+          expired: true,
+          total: available.length,
+        };
+      }
     }
   }
   return null;

--- a/client/connection_state.py
+++ b/client/connection_state.py
@@ -225,12 +225,6 @@ def chrome_cmdline_owns_session(cmdline: str, session_name: str) -> bool:
 _RESET_ZERO_ATTRS = (
     "_wa_http_fail_strikes",
     "_offline_probe_strikes",
-    # When the current run of offline-probe strikes began, i.e. the clock
-    # probe_strike_budget()'s ceiling is measured against. It has to be zeroed
-    # wherever _offline_probe_strikes is, or a run that ended before the sleep
-    # leaves a stale start time behind and the first post-wake strike is
-    # already "too old" for the widened budget.
-    "_offline_probe_first_strike_ts",
     "_logout_strikes",
     "_resume_fail_strikes",
     # The host-device veto run (MainWindow._STILL_LINKED_VETO_LIMIT) counts
@@ -274,6 +268,14 @@ def reset_state_for_resume(obj, now: float) -> None:
         setattr(obj, attr, False)
     obj._wa_startup_time = now
     obj._last_strike_ts = 0.0
+    # When the current run of offline-probe strikes began, i.e. the clock
+    # probe_strike_budget()'s ceiling is measured against. It has to be zeroed
+    # wherever _offline_probe_strikes is, or a run that ended before the sleep
+    # leaves a stale start time behind and the first post-wake strike is
+    # already "too old" for the widened budget. Set here rather than listed in
+    # _RESET_ZERO_ATTRS because it is a timestamp, and that loop assigns int 0
+    # — same reason _last_strike_ts above is written out.
+    obj._offline_probe_first_strike_ts = 0.0
 
 
 

--- a/client/connection_state.py
+++ b/client/connection_state.py
@@ -93,6 +93,71 @@ def should_count_strike(now: float, last_strike_ts: float,
     return (now - last_strike_ts) >= min_interval
 
 
+# How much a probe's consecutive-strike budget is widened while an initial sync
+# is running. The factor was a bare literal 10 repeated at three call sites in
+# main.py (check_whatsapp_reachable()'s two branches and
+# check_wa_connection_http()'s except branch); it is named here because it is
+# one decision, not three.
+SYNC_TOLERANCE_FACTOR = 10
+
+# How long the widened budget is allowed to hold the old state before the base
+# budget comes back.
+#
+# The widening is generous on purpose, and generous in the wrong units: the
+# health checker runs every _HEALTH_CHECK_INTERVAL (30 s) and
+# _OFFLINE_PROBE_STRIKES is 2, so x10 is ~10 minutes of answering "still
+# connected" to a probe that has said otherwise every single time. During those
+# ten minutes check_wa_connection_http()'s CONNECTED branch never reaches
+# _nudge_whatsapp_socket_stream() or escalates to _restart_wpp_session(), and
+# _should_abort_sync_for_offline() never fires — which is the ghost
+# "conversations synchronized" bug documented at that call site. A real outage
+# in the middle of a sync would be held invisible for the whole window.
+#
+# 180 s is chosen from the two real durations either side of it: comfortably
+# past the measured 28-second WhatsApp Web page reload that this tolerance
+# exists to ride out (see check_whatsapp_reachable()'s session_down branch), and
+# nowhere near the ~10 minutes the raw factor buys. This is a CLOCK and not a
+# strike count for the reason main.py has already had to learn twice (the
+# startup grace window, and STRIKE_MIN_INTERVAL_SECONDS above): a reading count
+# is a proxy for elapsed time that breaks the moment something polls at a
+# different rate.
+SYNC_TOLERANCE_MAX_SECONDS = 180.0
+
+
+def probe_strike_budget(base_strikes: int, *,
+                        initial_sync_running: bool,
+                        first_strike_ts: float = 0.0,
+                        now: float = 0.0,
+                        max_seconds: float | None = SYNC_TOLERANCE_MAX_SECONDS) -> int:
+    """How many consecutive negative probe readings to require before believing
+    the connection is really down.
+
+    Outside an initial sync this is just ``base_strikes``. While one is running
+    it is widened by SYNC_TOLERANCE_FACTOR, because a history download for
+    hundreds of chats keeps the local Node process (and the machine's own
+    network stack) busy enough that a slow or failed probe is far more often
+    that load than a real outage — and reading it as an outage aborts the very
+    sync that caused it.
+
+    ``first_strike_ts`` is when the CURRENT run of consecutive strikes began (0
+    when there is no run yet, i.e. this reading is starting one). Once that run
+    is older than ``max_seconds`` the widened budget expires and the base one
+    comes back: the tolerance is for a busy sync, not for holding a genuine
+    outage invisible for as long as the sync happens to last.
+
+    ``max_seconds=None`` disables the ceiling. That asymmetry is deliberate and
+    only check_wa_connection_http()'s except branch uses it: its x10 is the one
+    already shipped and proven against a Node blocked by a history download,
+    and tightening it now would reintroduce that risk for no reported problem.
+    The two check_whatsapp_reachable() branches are new and take the ceiling.
+    """
+    if not initial_sync_running:
+        return base_strikes
+    if max_seconds is not None and first_strike_ts and (now - first_strike_ts) >= max_seconds:
+        return base_strikes
+    return base_strikes * SYNC_TOLERANCE_FACTOR
+
+
 def is_zombie_session_after_resume(wa_connected: bool, status: str,
                                    host_reachable: bool) -> bool:
     """Decide whether a post-wake session is a 'zombie CONNECTED' worth an
@@ -160,6 +225,12 @@ def chrome_cmdline_owns_session(cmdline: str, session_name: str) -> bool:
 _RESET_ZERO_ATTRS = (
     "_wa_http_fail_strikes",
     "_offline_probe_strikes",
+    # When the current run of offline-probe strikes began, i.e. the clock
+    # probe_strike_budget()'s ceiling is measured against. It has to be zeroed
+    # wherever _offline_probe_strikes is, or a run that ended before the sleep
+    # leaves a stale start time behind and the first post-wake strike is
+    # already "too old" for the widened budget.
+    "_offline_probe_first_strike_ts",
     "_logout_strikes",
     "_resume_fail_strikes",
     # The host-device veto run (MainWindow._STILL_LINKED_VETO_LIMIT) counts

--- a/client/main.py
+++ b/client/main.py
@@ -10550,7 +10550,12 @@ class MainWindow(wx.Frame):
 
         Both negatives require _OFFLINE_PROBE_STRIKES *consecutive* readings
         before they count — see the session-probe branch below for why the
-        first one is not proof of anything.
+        first one is not proof of anything. That threshold is widened the
+        same way check_wa_connection_http()'s except branch widens
+        _HTTP_PROBE_STRIKES while an initial sync is running, and for the
+        same reason: a long history sync can leave the local Node process too
+        busy to answer this probe quickly, and that must not be read as a
+        real outage.
         """
         last_live = getattr(self, "_last_live_wpp_event_ts", 0.0)
         if last_live and (time.time() - last_live) < self._LIVE_WPP_EVENT_FRESHNESS_SECONDS:
@@ -10596,21 +10601,36 @@ class MainWindow(wx.Frame):
             # Requiring the same consecutive strikes the host probe already
             # requires rides out a reload; a genuine outage still registers
             # on the next health-check tick ~30 s later.
+            # Same "initial sync can block the Node event loop for a long
+            # time" reasoning check_wa_connection_http()'s except branch
+            # already applies to _HTTP_PROBE_STRIKES — this probe never got
+            # the same tolerance, so a busy initial sync could trip it into
+            # declaring the connection down (and aborting the very sync that
+            # was keeping Node busy) well before that other, more tolerant
+            # check ever would. Observed live: a long initial sync ending in
+            # "modo offline" and then a full disconnect a health-check cycle
+            # or two later, with no real network interruption.
+            allowed_strikes = self._OFFLINE_PROBE_STRIKES
+            if getattr(self, "_initial_sync_running", False):
+                allowed_strikes = self._OFFLINE_PROBE_STRIKES * 10
             self._offline_probe_strikes = getattr(self, "_offline_probe_strikes", 0) + 1
-            if self._offline_probe_strikes >= self._OFFLINE_PROBE_STRIKES:
+            if self._offline_probe_strikes >= allowed_strikes:
                 return False
             logging.info(
                 "[check_whatsapp_reachable] session probe reports disconnected "
                 "(strike %d/%d) — holding the current state for one more cycle.",
-                self._offline_probe_strikes, self._OFFLINE_PROBE_STRIKES,
+                self._offline_probe_strikes, allowed_strikes,
             )
             return bool(getattr(self, "_wa_connected", False))
 
         if self._probe_whatsapp_host():
             self._offline_probe_strikes = 0
             return True
+        allowed_strikes = self._OFFLINE_PROBE_STRIKES
+        if getattr(self, "_initial_sync_running", False):
+            allowed_strikes = self._OFFLINE_PROBE_STRIKES * 10
         self._offline_probe_strikes = getattr(self, "_offline_probe_strikes", 0) + 1
-        if self._offline_probe_strikes >= self._OFFLINE_PROBE_STRIKES:
+        if self._offline_probe_strikes >= allowed_strikes:
             return False
         # First strike: give it one more cycle before going offline.
         return bool(getattr(self, "_wa_connected", False))

--- a/client/main.py
+++ b/client/main.py
@@ -1775,8 +1775,12 @@ class MainWindow(wx.Frame):
         # — rare, and correctness there matters more than another caller
         # waiting briefly. wx.CallAfter itself is non-blocking either way.
         self._unlink_decision_lock = threading.Lock()
-        # Consecutive failed network probes (see check_whatsapp_reachable).
+        # Consecutive failed network probes (see check_whatsapp_reachable),
+        # and when the current run of them started — the widened during-sync
+        # budget is capped in wall-clock time, not in readings (see
+        # connection_state.probe_strike_budget).
         self._offline_probe_strikes = 0
+        self._offline_probe_first_strike_ts = 0.0
         # Consecutive not-yet-connected results from _set_wa_connected() this
         # session, and when the session started — together these give the
         # first connection attempt a grace period before the UI is allowed to
@@ -10550,16 +10554,25 @@ class MainWindow(wx.Frame):
 
         Both negatives require _OFFLINE_PROBE_STRIKES *consecutive* readings
         before they count — see the session-probe branch below for why the
-        first one is not proof of anything. That threshold is widened the
-        same way check_wa_connection_http()'s except branch widens
-        _HTTP_PROBE_STRIKES while an initial sync is running, and for the
-        same reason: a long history sync can leave the local Node process too
-        busy to answer this probe quickly, and that must not be read as a
-        real outage.
+        first one is not proof of anything. While an initial sync is running
+        that budget is widened through connection_state.probe_strike_budget(),
+        each branch for its own reason (a WhatsApp Web page reload for the
+        session probe, resource/DNS contention for the host probe — both
+        spelled out at the branches themselves), and the widening is capped at
+        SYNC_TOLERANCE_MAX_SECONDS of wall clock so a real outage mid-sync is
+        not held invisible for the ten minutes the raw factor would buy.
+
+        Note what this widening is NOT for, because the obvious guess is
+        wrong: a Node too busy to answer at all never reaches either branch. A
+        request that times out raises, lands in the `except` below, and falls
+        through to _probe_whatsapp_host() without setting session_down or
+        counting a strike at all. Getting here means the local API *answered*.
         """
+        import connection_state as cs
         last_live = getattr(self, "_last_live_wpp_event_ts", 0.0)
         if last_live and (time.time() - last_live) < self._LIVE_WPP_EVENT_FRESHNESS_SECONDS:
             self._offline_probe_strikes = 0
+            self._offline_probe_first_strike_ts = 0.0
             return True
         url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/check-connection-session"
         session_down = False
@@ -10601,18 +10614,30 @@ class MainWindow(wx.Frame):
             # Requiring the same consecutive strikes the host probe already
             # requires rides out a reload; a genuine outage still registers
             # on the next health-check tick ~30 s later.
-            # Same "initial sync can block the Node event loop for a long
-            # time" reasoning check_wa_connection_http()'s except branch
-            # already applies to _HTTP_PROBE_STRIKES — this probe never got
-            # the same tolerance, so a busy initial sync could trip it into
-            # declaring the connection down (and aborting the very sync that
-            # was keeping Node busy) well before that other, more tolerant
-            # check ever would. Observed live: a long initial sync ending in
-            # "modo offline" and then a full disconnect a health-check cycle
-            # or two later, with no real network interruption.
-            allowed_strikes = self._OFFLINE_PROBE_STRIKES
-            if getattr(self, "_initial_sync_running", False):
-                allowed_strikes = self._OFFLINE_PROBE_STRIKES * 10
+            #
+            # And during an initial sync, two strikes / ~60 s is not enough of
+            # a window for it. This branch is reached only when the local API
+            # *answered* — with status:false, i.e. isConnected() threw inside
+            # the page — so the reason to be more patient here is the reload
+            # above, not a busy Node (a Node too busy to answer raises in the
+            # `except` and never gets this far). A reload is both likelier and
+            # slower to finish while WhatsApp Web is being driven through a
+            # long history download than it is on an idle session, and the
+            # measured one already lasted 28 s on its own. Observed live: a
+            # long initial sync ending in "modo offline" and then a full
+            # disconnect a health-check cycle or two later, with no real
+            # network interruption. The widened budget is capped in wall-clock
+            # time — see probe_strike_budget() for why ~10 minutes of holding
+            # a stale "connected" is its own bug.
+            now = time.time()
+            allowed_strikes = cs.probe_strike_budget(
+                self._OFFLINE_PROBE_STRIKES,
+                initial_sync_running=getattr(self, "_initial_sync_running", False),
+                first_strike_ts=getattr(self, "_offline_probe_first_strike_ts", 0.0),
+                now=now,
+            )
+            if not getattr(self, "_offline_probe_first_strike_ts", 0.0):
+                self._offline_probe_first_strike_ts = now
             self._offline_probe_strikes = getattr(self, "_offline_probe_strikes", 0) + 1
             if self._offline_probe_strikes >= allowed_strikes:
                 return False
@@ -10625,10 +10650,27 @@ class MainWindow(wx.Frame):
 
         if self._probe_whatsapp_host():
             self._offline_probe_strikes = 0
+            self._offline_probe_first_strike_ts = 0.0
             return True
-        allowed_strikes = self._OFFLINE_PROBE_STRIKES
-        if getattr(self, "_initial_sync_running", False):
-            allowed_strikes = self._OFFLINE_PROBE_STRIKES * 10
+        # This one is a HEAD straight at web.whatsapp.com — the local Node
+        # process is not on that route at all, so "Node is busy" explains
+        # nothing here. What an initial sync does explain is the machine
+        # itself being loaded: hundreds of media downloads in flight compete
+        # for sockets, DNS and CPU with a probe that has a short timeout, and
+        # a probe that loses that race is not an outage. That is a much
+        # weaker excuse than the session branch's reload, which is exactly
+        # why the ceiling matters more here: if the network really is gone,
+        # this is the signal that says so, and it must not stay muffled for
+        # the length of a sync.
+        now = time.time()
+        allowed_strikes = cs.probe_strike_budget(
+            self._OFFLINE_PROBE_STRIKES,
+            initial_sync_running=getattr(self, "_initial_sync_running", False),
+            first_strike_ts=getattr(self, "_offline_probe_first_strike_ts", 0.0),
+            now=now,
+        )
+        if not getattr(self, "_offline_probe_first_strike_ts", 0.0):
+            self._offline_probe_first_strike_ts = now
         self._offline_probe_strikes = getattr(self, "_offline_probe_strikes", 0) + 1
         if self._offline_probe_strikes >= allowed_strikes:
             return False
@@ -10989,12 +11031,22 @@ class MainWindow(wx.Frame):
             # process than a real outage.
             self._wa_http_fail_strikes = getattr(self, "_wa_http_fail_strikes", 0) + 1
 
-            allowed_strikes = self._HTTP_PROBE_STRIKES
             # If the initial sync is running and downloading history for hundreds of chats,
             # the Node.js server event loop can be blocked for >30s. Don't falsely declare
             # an offline outage just because of these timeouts.
-            if getattr(self, "_initial_sync_running", False):
-                allowed_strikes = self._HTTP_PROBE_STRIKES * 10
+            #
+            # max_seconds=None keeps this branch's behaviour exactly as it has
+            # shipped: no wall-clock ceiling, unlike check_whatsapp_reachable()'s
+            # two branches. Deliberate asymmetry — this x10 is the one already
+            # proven in the field against a Node blocked by a history download,
+            # and tightening a fix nobody has reported a problem with would be
+            # trading a known-good behaviour for a hypothetical one.
+            import connection_state as cs
+            allowed_strikes = cs.probe_strike_budget(
+                self._HTTP_PROBE_STRIKES,
+                initial_sync_running=getattr(self, "_initial_sync_running", False),
+                max_seconds=None,
+            )
 
             logging.warning(
                 "[check_wa_connection_http] Request failed (strike %d/%d): %s",

--- a/client/main.py
+++ b/client/main.py
@@ -10643,7 +10643,7 @@ class MainWindow(wx.Frame):
                 return False
             logging.info(
                 "[check_whatsapp_reachable] session probe reports disconnected "
-                "(strike %d/%d) — holding the current state for one more cycle.",
+                "(strike %d/%d) — holding the current state until the budget is spent.",
                 self._offline_probe_strikes, allowed_strikes,
             )
             return bool(getattr(self, "_wa_connected", False))
@@ -10674,7 +10674,11 @@ class MainWindow(wx.Frame):
         self._offline_probe_strikes = getattr(self, "_offline_probe_strikes", 0) + 1
         if self._offline_probe_strikes >= allowed_strikes:
             return False
-        # First strike: give it one more cycle before going offline.
+        # Budget not spent yet: hold the current state and let the next
+        # health-check tick decide. Outside a sync that is the single
+        # extra cycle _OFFLINE_PROBE_STRIKES buys; during one it is as
+        # many cycles as the widened budget still allows, which the
+        # SYNC_TOLERANCE_MAX_SECONDS ceiling above bounds in real time.
         return bool(getattr(self, "_wa_connected", False))
 
     def _is_pairing_dialog_active(self) -> bool:

--- a/tests/test_connection_state.py
+++ b/tests/test_connection_state.py
@@ -6,6 +6,8 @@ treat that as a logout and wipe the local database — even though the server wa
 logging back in (a real log showed 'inChat' the same second the client wiped).
 """
 
+import pathlib
+
 import connection_state as cs
 
 LOGOUT_CONFIRM = 4
@@ -151,6 +153,46 @@ def test_the_ceiling_can_be_disabled_for_the_branch_already_in_production():
         BUDGET_BASE, initial_sync_running=True, first_strike_ts=1000.0,
         now=1000.0 + 10_000, max_seconds=None
     ) == BUDGET_BASE * cs.SYNC_TOLERANCE_FACTOR
+
+
+def test_the_production_branch_really_asks_for_the_disabled_ceiling():
+    """The test above proves the function honours max_seconds=None; this proves
+    the one branch that wants it still passes it.
+
+    Nothing else pins that wiring: check_wa_connection_http()'s except branch is
+    not covered by a behavioural test (it needs the whole requests/wx stack),
+    so a later tidy-up that "removes the asymmetry" by dropping the argument
+    would leave the whole suite green while silently capping the branch at
+    SYNC_TOLERANCE_MAX_SECONDS — reintroducing the false offline against a Node
+    blocked by a history download that the x10 exists to prevent. Read as
+    source, the way tests/test_wa_version_expiry_pin.py checks the stable
+    channel is asked for first.
+    """
+    main_py = (pathlib.Path(__file__).resolve().parents[1]
+               / "client" / "main.py").read_text(encoding="utf-8")
+    method = main_py[main_py.index("    def check_wa_connection_http("):]
+    method = method[:method.index("\n    def ", 10)]
+    # The method's own except, at method indentation — not the two nested ones
+    # inside the CONNECTED branch.
+    branch = method[method.index("\n        except Exception as e:"):]
+    # Balanced-paren slice rather than a search for the closing line: the call
+    # already nests a getattr(), and reading to the first ")" would cut inside
+    # it and hide the very argument this is checking for.
+    call_start = branch.index("cs.probe_strike_budget(")
+    depth, end = 0, call_start
+    for end in range(call_start, len(branch)):
+        if branch[end] == "(":
+            depth += 1
+        elif branch[end] == ")":
+            depth -= 1
+            if depth == 0:
+                break
+    call = branch[call_start:end + 1]
+    assert "max_seconds=None" in call, (
+        "check_wa_connection_http()'s except branch must keep passing "
+        "max_seconds=None — see probe_strike_budget()'s docstring for why this "
+        f"asymmetry is deliberate. Found:\n{call}"
+    )
 
 
 def test_the_ceiling_sits_between_a_page_reload_and_the_raw_ten_minutes():

--- a/tests/test_connection_state.py
+++ b/tests/test_connection_state.py
@@ -96,6 +96,71 @@ class TestClassifyUnlinkCandidate:
         assert _classify_candidate(False, 1000, 0) == cs.RESUMING
 
 
+# ── the during-sync strike budget (probe_strike_budget) ──────────────────────
+# Three call sites in main.py used to carry the same `if initial_sync_running:
+# allowed = base * 10` by hand — check_whatsapp_reachable()'s session-probe and
+# host-probe branches, and check_wa_connection_http()'s except branch. The
+# factor is one decision, and the wall-clock ceiling on it is the part that
+# needs a test: x10 at a 30 s health cadence is ~10 minutes of answering "still
+# connected" to a probe that has said otherwise every single time.
+
+BUDGET_BASE = 2
+
+
+def test_budget_is_the_base_outside_a_sync():
+    assert cs.probe_strike_budget(BUDGET_BASE, initial_sync_running=False) == BUDGET_BASE
+    # ...even with an ancient strike run behind it: no sync, no widening, so
+    # the ceiling never enters into it.
+    assert cs.probe_strike_budget(
+        BUDGET_BASE, initial_sync_running=False,
+        first_strike_ts=1000.0, now=1000.0 + 10_000) == BUDGET_BASE
+
+
+def test_budget_widens_during_a_sync():
+    widened = BUDGET_BASE * cs.SYNC_TOLERANCE_FACTOR
+    # No run yet (ts 0) — this reading is starting one, so it gets the full
+    # window rather than being judged against a clock that has not started.
+    assert cs.probe_strike_budget(
+        BUDGET_BASE, initial_sync_running=True,
+        first_strike_ts=0.0, now=1000.0) == widened
+    # A run one health-check tick old is still well inside the window.
+    assert cs.probe_strike_budget(
+        BUDGET_BASE, initial_sync_running=True,
+        first_strike_ts=1000.0, now=1030.0) == widened
+
+
+def test_budget_returns_to_the_base_once_the_run_outlives_the_ceiling():
+    t0 = 1000.0
+    assert cs.probe_strike_budget(
+        BUDGET_BASE, initial_sync_running=True, first_strike_ts=t0,
+        now=t0 + cs.SYNC_TOLERANCE_MAX_SECONDS - 0.1
+    ) == BUDGET_BASE * cs.SYNC_TOLERANCE_FACTOR
+    # At the ceiling the sync stops being an excuse: a probe that has been
+    # negative for this long is an outage, and holding "connected" any longer
+    # keeps _should_abort_sync_for_offline() from ever firing.
+    assert cs.probe_strike_budget(
+        BUDGET_BASE, initial_sync_running=True, first_strike_ts=t0,
+        now=t0 + cs.SYNC_TOLERANCE_MAX_SECONDS) == BUDGET_BASE
+
+
+def test_the_ceiling_can_be_disabled_for_the_branch_already_in_production():
+    """check_wa_connection_http()'s except branch passes max_seconds=None: its
+    x10 is the one already proven against a Node blocked by a history download,
+    and tightening it now would trade a known-good behaviour for a guess."""
+    assert cs.probe_strike_budget(
+        BUDGET_BASE, initial_sync_running=True, first_strike_ts=1000.0,
+        now=1000.0 + 10_000, max_seconds=None
+    ) == BUDGET_BASE * cs.SYNC_TOLERANCE_FACTOR
+
+
+def test_the_ceiling_sits_between_a_page_reload_and_the_raw_ten_minutes():
+    """Both bounds are the numbers the constant was picked from: the measured
+    28-second WhatsApp Web reload it must ride out, and the ~10 minutes the raw
+    factor buys at the 30 s health-check cadence."""
+    assert cs.SYNC_TOLERANCE_MAX_SECONDS > 28.0 * 2
+    assert cs.SYNC_TOLERANCE_MAX_SECONDS < BUDGET_BASE * cs.SYNC_TOLERANCE_FACTOR * 30
+
+
 def test_wake_from_suspend_detects_long_gap():
     # A 30s loop that really took 5 minutes = the machine was asleep.
     assert cs.is_wake_from_suspend(300.0, 30, 90) is True

--- a/tests/test_session_probe_strikes.py
+++ b/tests/test_session_probe_strikes.py
@@ -25,8 +25,12 @@ so the method under test is exercised as a plain function against a small stub
 — same approach as tests/test_socket_stream_nudge.py.
 """
 
+import time
+import types
+
 import pytest
 
+import connection_state as cs
 from main import MainWindow
 
 
@@ -41,6 +45,7 @@ class _Resp:
 
 class _Stub:
     _OFFLINE_PROBE_STRIKES = MainWindow._OFFLINE_PROBE_STRIKES
+    _LIVE_WPP_EVENT_FRESHNESS_SECONDS = MainWindow._LIVE_WPP_EVENT_FRESHNESS_SECONDS
     check_whatsapp_reachable = MainWindow.check_whatsapp_reachable
 
     def __init__(self, connected=True, host_reachable=True):
@@ -49,6 +54,7 @@ class _Stub:
         self.token = "test-token"
         self._wa_connected = connected
         self._offline_probe_strikes = 0
+        self._offline_probe_first_strike_ts = 0.0
         self._host_reachable = host_reachable
         self.host_probes = 0
 
@@ -65,6 +71,22 @@ def _session_says(monkeypatch, *responses):
         return queue.pop(0) if len(queue) > 1 else queue[0]
 
     monkeypatch.setattr("main.requests.get", _fake_get)
+
+
+def _fake_clock(monkeypatch, start=1000.0):
+    """Drive the wall clock check_whatsapp_reachable() reads, so the ceiling on
+    the widened during-sync budget can be crossed without the test waiting
+    SYNC_TOLERANCE_MAX_SECONDS. Returns the dict to advance."""
+    state = {"now": start}
+    monkeypatch.setattr(
+        "main.time",
+        types.SimpleNamespace(
+            time=lambda: state["now"],
+            sleep=time.sleep,
+            monotonic=time.monotonic,
+        ),
+    )
+    return state
 
 
 class TestSessionProbeStrikes:
@@ -188,3 +210,88 @@ class TestOfflineProbeToleranceDuringInitialSync:
         s._initial_sync_running = False
         assert s.check_whatsapp_reachable() is True
         assert s.check_whatsapp_reachable() is False
+
+
+class TestTheWidenedToleranceHasATimeCeiling:
+    """The tenfold budget is measured in READINGS, and the health checker runs
+    every 30 s — so x10 on _OFFLINE_PROBE_STRIKES(2) is ~10 minutes of holding
+    _wa_connected True through a real outage in the middle of a sync. For those
+    ten minutes check_wa_connection_http()'s CONNECTED branch never reaches
+    _nudge_whatsapp_socket_stream() or escalates to _restart_wpp_session(), and
+    _should_abort_sync_for_offline() never fires — the ghost "conversations
+    synchronized" bug. So the widening is bounded by the clock as well
+    (connection_state.SYNC_TOLERANCE_MAX_SECONDS), which is the same lesson
+    main.py already records twice: a reading count is a bad proxy for elapsed
+    time."""
+
+    def test_the_session_probe_run_starts_the_clock_on_its_first_strike(self, monkeypatch):
+        clock = _fake_clock(monkeypatch)
+        _session_says(monkeypatch, _Resp(200, {"status": False}))
+        s = _Stub(connected=True)
+        s._initial_sync_running = True
+        assert s.check_whatsapp_reachable() is True
+        assert s._offline_probe_first_strike_ts == clock["now"]
+
+    def test_the_session_probe_falls_back_to_the_base_budget_past_the_ceiling(self, monkeypatch):
+        clock = _fake_clock(monkeypatch)
+        _session_says(monkeypatch, _Resp(200, {"status": False}))
+        s = _Stub(connected=True)
+        s._initial_sync_running = True
+        assert s.check_whatsapp_reachable() is True   # strike 1 — starts the run
+        # Still inside the window: the widened budget still holds the state.
+        clock["now"] += cs.SYNC_TOLERANCE_MAX_SECONDS - 1.0
+        assert s.check_whatsapp_reachable() is True   # strike 2, would be enough at base
+        # Past it: two strikes is the whole base budget, and this is the third.
+        clock["now"] += 2.0
+        assert s.check_whatsapp_reachable() is False
+
+    def test_the_host_probe_falls_back_to_the_base_budget_past_the_ceiling(self, monkeypatch):
+        """The host probe is a HEAD straight at web.whatsapp.com — a busy Node
+        is not even on that route, so its excuse (socket/DNS/CPU contention
+        during a heavy download) is the weaker of the two and the ceiling
+        matters more here."""
+        clock = _fake_clock(monkeypatch)
+        _session_says(monkeypatch, _Resp(200, {"status": True}))
+        s = _Stub(connected=True, host_reachable=False)
+        s._initial_sync_running = True
+        assert s.check_whatsapp_reachable() is True
+        clock["now"] += cs.SYNC_TOLERANCE_MAX_SECONDS
+        assert s.check_whatsapp_reachable() is False
+
+    def test_a_recovered_probe_restarts_the_clock_as_well_as_the_tally(self, monkeypatch):
+        """A healthy reading ends the run, so a later, unrelated blip gets its
+        own full window rather than inheriting an expired one."""
+        clock = _fake_clock(monkeypatch)
+        _session_says(
+            monkeypatch,
+            _Resp(200, {"status": False}),
+            _Resp(200, {"status": True}),
+        )
+        s = _Stub(connected=True)
+        s._initial_sync_running = True
+        assert s.check_whatsapp_reachable() is True
+        assert s._offline_probe_first_strike_ts == 1000.0
+        assert s.check_whatsapp_reachable() is True   # healthy again
+        assert s._offline_probe_strikes == 0
+        assert s._offline_probe_first_strike_ts == 0.0
+
+    def test_a_fresh_live_event_also_clears_the_clock(self, monkeypatch):
+        """The Socket.IO short-circuit at the top of the method is the other
+        place the strike tally is reset — the timestamp has to go with it."""
+        clock = _fake_clock(monkeypatch)
+        _session_says(monkeypatch, _Resp(200, {"status": False}))
+        s = _Stub(connected=True)
+        s._initial_sync_running = True
+        assert s.check_whatsapp_reachable() is True
+        assert s._offline_probe_first_strike_ts == 1000.0
+        s._last_live_wpp_event_ts = clock["now"]
+        assert s.check_whatsapp_reachable() is True
+        assert s._offline_probe_strikes == 0
+        assert s._offline_probe_first_strike_ts == 0.0
+
+    def test_the_timestamp_is_reset_by_a_wake_from_suspend(self, monkeypatch):
+        """reset_state_for_resume() zeroes every strike tally so a resume is
+        classified like a fresh start; a start time left behind would make the
+        first post-wake strike look like the tail of a run from before the
+        sleep."""
+        assert "_offline_probe_first_strike_ts" in cs._RESET_ZERO_ATTRS

--- a/tests/test_session_probe_strikes.py
+++ b/tests/test_session_probe_strikes.py
@@ -294,4 +294,15 @@ class TestTheWidenedToleranceHasATimeCeiling:
         classified like a fresh start; a start time left behind would make the
         first post-wake strike look like the tail of a run from before the
         sleep."""
-        assert "_offline_probe_first_strike_ts" in cs._RESET_ZERO_ATTRS
+        clock = _fake_clock(monkeypatch)
+        _session_says(monkeypatch, _Resp(200, {"status": False}))
+        s = _Stub(connected=True)
+        s._initial_sync_running = True
+        assert s.check_whatsapp_reachable() is True    # starts a run
+        assert s._offline_probe_first_strike_ts == 1000.0
+        cs.reset_state_for_resume(s, clock["now"] + 100_000)
+        assert s._offline_probe_first_strike_ts == 0.0
+        assert s._offline_probe_strikes == 0
+        # And a timestamp, not the int the strike tallies are reset to — the
+        # attribute is compared against time.time() everywhere else.
+        assert isinstance(s._offline_probe_first_strike_ts, float)

--- a/tests/test_session_probe_strikes.py
+++ b/tests/test_session_probe_strikes.py
@@ -143,3 +143,48 @@ class TestSessionProbeStrikes:
         s = _Stub(connected=True)
         assert s.check_whatsapp_reachable() is True
         assert s.host_probes == 1
+
+
+class TestOfflineProbeToleranceDuringInitialSync:
+    """Both strike counters in check_whatsapp_reachable() now widen tenfold
+    while an initial sync is running — the same reasoning, and the same *10
+    factor, check_wa_connection_http()'s except branch already applies to
+    _HTTP_PROBE_STRIKES. Reported live: a long history sync can leave the
+    local Node process too busy to answer this probe quickly, which used to
+    flip the app to "modo offline" and abort the very sync that was keeping
+    Node busy, well before the more tolerant HTTP check ever would."""
+
+    def test_session_probe_tolerates_ten_times_the_strikes_during_sync(self, monkeypatch):
+        _session_says(monkeypatch, _Resp(200, {"status": False}))
+        s = _Stub(connected=True)
+        s._initial_sync_running = True
+        for _ in range(19):
+            assert s.check_whatsapp_reachable() is True
+        assert s._offline_probe_strikes == 19
+        assert s.check_whatsapp_reachable() is False
+        assert s._offline_probe_strikes == 20
+
+    def test_host_probe_tolerates_ten_times_the_strikes_during_sync(self, monkeypatch):
+        _session_says(monkeypatch, _Resp(200, {"status": True}))
+        s = _Stub(connected=True, host_reachable=False)
+        s._initial_sync_running = True
+        for _ in range(19):
+            assert s.check_whatsapp_reachable() is True
+        assert s.check_whatsapp_reachable() is False
+
+    def test_outside_a_sync_the_tolerance_is_unchanged(self, monkeypatch):
+        """_initial_sync_running absent (the common case) must behave exactly
+        as before this change — two strikes, not twenty."""
+        _session_says(monkeypatch, _Resp(200, {"status": False}))
+        s = _Stub(connected=True)
+        assert s.check_whatsapp_reachable() is True
+        assert s.check_whatsapp_reachable() is False
+
+    def test_a_finished_sync_goes_back_to_the_normal_tolerance(self, monkeypatch):
+        """_initial_sync_running=False (sync completed/aborted) must not
+        leave the widened budget behind."""
+        _session_says(monkeypatch, _Resp(200, {"status": False}))
+        s = _Stub(connected=True)
+        s._initial_sync_running = False
+        assert s.check_whatsapp_reachable() is True
+        assert s.check_whatsapp_reachable() is False

--- a/tests/test_wa_version_expiry_pin.py
+++ b/tests/test_wa_version_expiry_pin.py
@@ -292,10 +292,12 @@ __HELPER_SOURCE__
 
 (async () => {
   const started = Date.now();
-  const html = await fetchLiveWhatsappDocument();
+  const live = await fetchLiveWhatsappDocument();
+  const html = live ? live.html : null;
   console.log('__RESULT__' + JSON.stringify({
     ok: typeof html === 'string',
     length: typeof html === 'string' ? html.length : 0,
+    channel: live ? live.channel : null,
     called,
     elapsed: Date.now() - started,
   }));
@@ -445,6 +447,53 @@ class TestTheLiveFetchAsksTheStableChannelFirst:
         stable = source.index("attempt('fetchLatest')")
         alpha = source.index("attempt('fetchLatestAlpha')")
         assert stable < alpha
+
+
+class TestTheLogSaysWhichChannelServedTheSession:
+    """The pin logs a version string, and a pre-release build wears `-alpha` on
+    its face — so for the catalogue path the channel is already visible in the
+    log. The live path had nothing equivalent: it said only "live from Meta",
+    and a user reporting "Session Unpaired" hours after pairing left no way to
+    tell whether fetchLatest() answered or whether the run fell through to
+    fetchLatestAlpha() — which is precisely the hypothesis the stable-first
+    order rests on."""
+
+    def test_the_stable_channel_is_named_when_it_answers(self, tmp_path):
+        result = _fetch_live(tmp_path, channels={
+            "fetchLatest": {"mode": "ok", "html": GOOD_HTML},
+            "fetchLatestAlpha": {"mode": "ok", "html": GOOD_HTML},
+        })
+        assert result["channel"] == "fetchLatest"
+
+    def test_the_alpha_channel_is_named_when_it_is_the_one_that_answered(self, tmp_path):
+        """The case worth reading a log for: stable failed, so this session is
+        running a pre-release build."""
+        result = _fetch_live(tmp_path, channels={
+            "fetchLatest": {"mode": "throws", "html": None},
+            "fetchLatestAlpha": {"mode": "ok", "html": GOOD_HTML},
+        })
+        assert result["called"] == ["fetchLatest", "fetchLatestAlpha"]
+        assert result["channel"] == "fetchLatestAlpha"
+
+    def test_nothing_is_named_when_nothing_answered(self, tmp_path):
+        """A failed fetch still answers a plain falsy value, because the caller
+        tests it with `if (live)` before falling back to the local build."""
+        assert _fetch_live(tmp_path, mode="throws")["channel"] is None
+
+    def test_the_caller_puts_the_channel_in_what_it_logs(self):
+        """The harness above proves the channel is reported; this proves it is
+        not then dropped on the floor at the one call site that has it."""
+        source = START_JS.read_text(encoding="utf-8")
+        start = source.index("const live = await fetchLiveWhatsappDocument();")
+        end = source.index("if (!body) {", start)
+        branch = source[start:end]
+        assert "body = live.html;" in branch
+        assert "live.channel" in branch
+        for line in branch.splitlines():
+            assert "= live;" not in line, (
+                "the live fetch answers {channel, html} now — assigning it whole "
+                "would serve the object as the document body"
+            )
 
 
 class TestTheFallbackIsWiredOnlyToTheExpiredBranch:

--- a/tests/test_wa_version_expiry_pin.py
+++ b/tests/test_wa_version_expiry_pin.py
@@ -150,6 +150,59 @@ class TestTheNewestStillValidBuildIsPinned:
         assert result["selected"]["version"] == "2.3000.1000000001"
 
 
+class TestTheStableChannelIsPreferredOverPreRelease:
+    """Meta's expiry window says "still served", not "safe to link a device
+    against": a pre-release build nowhere near expired still got every
+    freshly-paired session unpaired within minutes ("Session Unpaired" then
+    "notLogged", on every re-pair attempt). Each tier is therefore walked
+    stable-first — while being honest that on the catalogue shipping today it
+    changes nothing at all (see the second test)."""
+
+    def test_a_stable_build_wins_over_a_newer_alpha(self, tmp_path):
+        result = _select(tmp_path, [
+            _entry("2.3000.1000000001", 10),
+            _entry("2.3000.1000000002-alpha", 40),
+        ])
+        assert result["selected"]["version"] == "2.3000.1000000001"
+
+    def test_an_all_alpha_catalogue_still_pins_its_newest_entry(self, tmp_path):
+        """The real world today: @wppconnect/wa-version 1.5.4763 ships 392
+        entries and every one of them is an -alpha, so the stable pass matches
+        nothing and the selection is identical to before the preference
+        existed. It must be — the alternative is pinning nothing."""
+        result = _select(tmp_path, [
+            _entry("2.3000.1000000001-alpha", 10),
+            _entry("2.3000.1000000002-alpha", 40),
+        ])
+        assert result["selected"]["version"] == "2.3000.1000000002-alpha"
+        assert result["selected"]["expired"] is False
+
+    def test_the_preference_also_applies_once_everything_has_expired(self, tmp_path):
+        """The expired tier is the one a user who has not reinstalled the API
+        in months actually lands in — the channel preference is worth as much
+        there as anywhere."""
+        result = _select(tmp_path, [
+            _entry("2.3000.1000000001", -30),
+            _entry("2.3000.1000000002-alpha", -2),
+        ])
+        assert result["selected"]["version"] == "2.3000.1000000001"
+        assert result["selected"]["expired"] is True
+
+    def test_the_html_of_a_version_is_only_read_once(self, tmp_path):
+        """Each tier is walked twice, so without memoisation the same entry is
+        handed to getPageContent up to four times — and one call is a readdir
+        of html/ (392 files) plus a ~600 KB read, during session startup."""
+        result = _select(tmp_path, [
+            _entry("2.3000.1000000001-alpha", 10),
+            _entry("2.3000.1000000002", 40, html_missing=True),
+        ])
+        # The stable pass asks for the newest (stable) entry and is refused;
+        # the any-channel pass walks past it again and must not re-read it.
+        assert result["pageContentAsked"] == [
+            "2.3000.1000000002", "2.3000.1000000001-alpha"]
+        assert result["selected"]["version"] == "2.3000.1000000001-alpha"
+
+
 class TestACatalogueWithNothingValidLeft:
     """The state a user who has not rebuilt the API in months ends up in."""
 
@@ -221,14 +274,16 @@ LIVE_HARNESS = r"""
 'use strict';
 const scenario = JSON.parse(process.argv[2]);
 
+const called = [];
 let waVersion = null;
-if (scenario.mode !== 'no-package') {
+if (scenario.channels !== null) {
   waVersion = {};
-  if (scenario.mode !== 'no-method') {
-    waVersion.fetchLatestAlpha = () => {
-      if (scenario.mode === 'throws') return Promise.reject(new Error('offline'));
-      if (scenario.mode === 'hangs') return new Promise(() => {});
-      return Promise.resolve(scenario.html);
+  for (const [name, behaviour] of Object.entries(scenario.channels)) {
+    waVersion[name] = () => {
+      called.push(name);
+      if (behaviour.mode === 'throws') return Promise.reject(new Error('offline'));
+      if (behaviour.mode === 'hangs') return new Promise(() => {});
+      return Promise.resolve(behaviour.html);
     };
   }
 }
@@ -241,11 +296,14 @@ __HELPER_SOURCE__
   console.log('__RESULT__' + JSON.stringify({
     ok: typeof html === 'string',
     length: typeof html === 'string' ? html.length : 0,
+    called,
     elapsed: Date.now() - started,
   }));
   process.exit(0);
 })();
 """
+
+GOOD_HTML = "<!doctype html>" + ("x" * 2000) + "web.whatsapp.com"
 
 
 def _helper_source():
@@ -261,17 +319,32 @@ def _helper_source():
     return source[start:end]
 
 
-def _fetch_live(tmp_path, mode="ok", html=None):
+def _fetch_live(tmp_path, mode="ok", html=None, channels=None):
+    """Run the real fetchLiveWhatsappDocument() under node.
+
+    ``channels`` gives per-channel behaviour ({name: {"mode", "html"}}) for the
+    stable-vs-alpha ordering tests; ``mode``/``html`` is the older shorthand
+    that applies the same behaviour to both channels, so the cases written
+    before the stable channel existed keep reading the way they did.
+    """
     node = shutil.which("node")
     if node is None:
         pytest.skip("node is not on PATH")
-    if html is None:
-        html = "<!doctype html>" + ("x" * 2000) + "web.whatsapp.com"
+    if channels is None:
+        if html is None:
+            html = GOOD_HTML
+        behaviour = {"mode": mode, "html": html}
+        if mode == "no-package":
+            channels = None
+        elif mode == "no-method":
+            channels = {}
+        else:
+            channels = {"fetchLatest": behaviour, "fetchLatestAlpha": behaviour}
     harness = tmp_path / "live_harness.js"
     harness.write_text(
         LIVE_HARNESS.replace("__HELPER_SOURCE__", _helper_source()), encoding="utf-8")
     proc = subprocess.run(
-        [node, str(harness), json.dumps({"mode": mode, "html": html})],
+        [node, str(harness), json.dumps({"channels": channels})],
         capture_output=True, text=True, timeout=60,
     )
     for line in proc.stdout.splitlines():
@@ -317,6 +390,61 @@ class TestTheLiveDocumentFallback:
 
     def test_a_long_page_that_never_mentions_whatsapp_is_refused(self, tmp_path):
         assert _fetch_live(tmp_path, html="<html>" + ("y" * 5000) + "</html>")["ok"] is False
+
+
+class TestTheLiveFetchAsksTheStableChannelFirst:
+    """This branch only runs when the whole local catalogue has expired — i.e.
+    for the user least able to diagnose anything. Asking fetchLatestAlpha()
+    there, as this used to, handed exactly that user a pre-release build, which
+    is the thing the stable-first selection above exists to avoid. Stable
+    first; alpha only as the last step before falling back to an expired local
+    build."""
+
+    def test_the_stable_channel_is_used_when_it_answers(self, tmp_path):
+        result = _fetch_live(tmp_path, channels={
+            "fetchLatest": {"mode": "ok", "html": GOOD_HTML},
+            "fetchLatestAlpha": {"mode": "ok", "html": GOOD_HTML},
+        })
+        assert result["ok"] is True
+        assert result["called"] == ["fetchLatest"]
+
+    def test_the_alpha_channel_is_the_fallback_when_stable_is_missing(self, tmp_path):
+        """Older copies of the package may not export fetchLatest — the typeof
+        guard has to keep both directions working, not just the new one."""
+        result = _fetch_live(tmp_path, channels={
+            "fetchLatestAlpha": {"mode": "ok", "html": GOOD_HTML},
+        })
+        assert result["ok"] is True
+        assert result["called"] == ["fetchLatestAlpha"]
+
+    @pytest.mark.parametrize("stable_mode, stable_html, why", [
+        ("throws", None, "the stable request failed outright"),
+        ("ok", "<html>Sign in to the hotel wifi</html>", "a captive portal answered it"),
+    ])
+    def test_a_stable_answer_that_is_not_the_app_shell_falls_through(
+            self, tmp_path, stable_mode, stable_html, why):
+        result = _fetch_live(tmp_path, channels={
+            "fetchLatest": {"mode": stable_mode, "html": stable_html},
+            "fetchLatestAlpha": {"mode": "ok", "html": GOOD_HTML},
+        })
+        assert result["ok"] is True, why
+        assert result["called"] == ["fetchLatest", "fetchLatestAlpha"]
+
+    def test_two_channels_do_not_mean_two_timeout_windows(self, tmp_path):
+        """The 10 s budget covers the SET. A user on a dead network must not
+        wait twice as long for pairing now that there are two channels."""
+        result = _fetch_live(tmp_path, channels={
+            "fetchLatest": {"mode": "hangs", "html": None},
+            "fetchLatestAlpha": {"mode": "hangs", "html": None},
+        })
+        assert result["ok"] is False
+        assert result["elapsed"] < 15000, "the budget was spent per channel"
+
+    def test_the_source_asks_for_the_stable_channel(self):
+        source = START_JS.read_text(encoding="utf-8")
+        stable = source.index("attempt('fetchLatest')")
+        alpha = source.index("attempt('fetchLatestAlpha')")
+        assert stable < alpha
 
 
 class TestTheFallbackIsWiredOnlyToTheExpiredBranch:


### PR DESCRIPTION
WinZapp was pinning whatever WhatsApp Web build was newest in the local catalogue, which right now is an alpha release, and that got freshly paired sessions unpaired by WhatsApp within minutes. This makes it prefer the newest stable build when one is cached, and also widens check_whatsapp_reachable()'s offline-strike tolerance during the initial sync the same way the HTTP probe already is, so a slow sync no longer gets misread as an outage and aborted.
