### PR TITLE
Give the proactive re-pair dialog a startup grace window

### DIFF
--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -785,6 +785,31 @@ class WebSocketClient:
         return bool(mw._is_pairing_dialog_active()
                     or getattr(mw, "_pairing_in_progress", False))
 
+    def _qr_within_startup_grace(self) -> bool:
+        """True while this (re)connect attempt has never yet confirmed a
+        live WhatsApp connection and is still inside the same
+        _WA_STARTUP_GRACE_SECONDS window check_wa_connection_http() gives a
+        bare CLOSED/QRCODE status before it will trust it as anything more
+        than a slow boot still settling.
+
+        A previously-paired install that has genuinely lost its session can
+        start emitting QR codes within seconds of a fresh (re)connect — a
+        real log measured one 11 s after startup, while /list-chats was
+        still 404ing because the session itself had not finished starting.
+        Nothing about a QR event makes it immune to the exact race the
+        startup grace exists for elsewhere; it only looks immune because,
+        unlike a bare status string, a code is often also genuinely
+        conclusive. Both _wa_startup_time and _wa_connect_announced are
+        reset together on every fresh (re)connect (see main.py), so this
+        re-arms correctly across reconnects, not just the first launch.
+        """
+        mw = self.main_window
+        if getattr(mw, "_wa_connect_announced", False):
+            return False
+        started = getattr(mw, "_wa_startup_time", 0) or 0
+        grace = getattr(mw, "_WA_STARTUP_GRACE_SECONDS", 0) or 0
+        return (time.time() - started) < grace
+
     def _handle_unattended_qr(self):
         """A real QR/pairing code arrived that no refresh branch wanted.
 
@@ -797,10 +822,18 @@ class WebSocketClient:
 
         Telling the user is the proactive pairing dialog — WPPConnect only
         generates a code once it has already decided the stored session can't
-        be restored, so a code with no dialog open is a reliable "you need to
-        re-pair" signal on its own, unlike the coarse status-session string
-        the health-check poll watches (which needs several minutes of
-        confirmation to rule out a normal slow boot).
+        be restored, so a code with no dialog open is close to a reliable
+        "you need to re-pair" signal on its own — closer than the coarse
+        status-session string the health-check poll watches, which needs
+        several minutes of confirmation to rule out a normal slow boot. Not
+        immune to that same class of false positive, though: a code observed
+        seconds into a (re)connect attempt races the same stored-session
+        restore the status-session poll is still waiting on, so
+        _qr_within_startup_grace() below withholds judgment for exactly the
+        window that poll already gets (_WA_STARTUP_GRACE_SECONDS). See
+        tests/test_qrcode_auto_repair_dialog.py::TestStartupGraceWindow — a
+        code that keeps arriving with no dialog past that window still opens
+        it; this only delays the first one.
 
         Stopping the churn is the part whose absence got an account banned.
         `autoClose`/`deviceSyncTimeout` are pinned to 0 (client/api_patches/
@@ -832,6 +865,7 @@ class WebSocketClient:
         if (
             mw.settings.get("privateinfo", {}).get("paired")
             and not getattr(mw, "_auto_repair_dialog_shown", False)
+            and not self._qr_within_startup_grace()
         ):
             # Try to repair the profile before sending the user off to pair by
             # hand. This event is the *earliest and strongest* evidence that

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -118,12 +118,30 @@ class WebSocketClient:
     # screen before the session that mints them is closed outright. WhatsApp
     # rotates roughly every 20-30s, so this is ~1 minute on an install that
     # never paired. On one that did it is that dialog's lifetime plus ~1
-    # minute: there the very first unattended event opens the re-pairing
-    # dialog, and codes are attended for as long as it stays up, so the three
-    # counted events only start once the user dismisses it. Short enough
-    # that an app left open overnight on a session WhatsApp already
-    # dropped does not ask for hundreds of codes nobody will ever scan.
+    # minute: there the _REPAIR_DIALOG_CONFIRM_EVENTS'th unattended event
+    # opens the re-pairing dialog, and codes are attended for as long as it
+    # stays up, so the three counted events only start once the user
+    # dismisses it. Short enough that an app left open overnight on a
+    # session WhatsApp already dropped does not ask for hundreds of codes
+    # nobody will ever scan.
     _UNATTENDED_QR_LIMIT = 3
+
+    # How many unattended QR/pairing-code events in a row are required before
+    # the proactive re-pair dialog opens for a previously-paired account.
+    # Was 1 (the very first event), which raced main.py's own, much more
+    # careful check_wa_connection_http()/_act_on_unlink_decision() strike
+    # machinery for the exact same underlying "unlinked" reading — a real
+    # log captured that machinery logging "resuming — data preserved" (not
+    # yet confirmed) on the SAME reading this dialog had already acted on
+    # a QR event earlier for, seconds apart. Every other unlink-confirming
+    # path in this codebase requires more than a single reading before
+    # doing anything user-visible or destructive; this one now does too,
+    # at the cost of the same ~20-30s (one more QR rotation) every other
+    # such confirmation already accepts as the price of not alarming or
+    # wiping a session that was only ever transiently unhappy. Still well
+    # under _UNATTENDED_QR_LIMIT, so the harsher close-session action is
+    # never reached before the dialog has already offered a way out.
+    _REPAIR_DIALOG_CONFIRM_EVENTS = 2
 
     def __init__(self, main_window, connect, instance_name):
         self.main_window = main_window
@@ -826,14 +844,16 @@ class WebSocketClient:
         "you need to re-pair" signal on its own — closer than the coarse
         status-session string the health-check poll watches, which needs
         several minutes of confirmation to rule out a normal slow boot. Not
-        immune to that same class of false positive, though: a code observed
-        seconds into a (re)connect attempt races the same stored-session
-        restore the status-session poll is still waiting on, so
-        _qr_within_startup_grace() below withholds judgment for exactly the
-        window that poll already gets (_WA_STARTUP_GRACE_SECONDS). See
-        tests/test_qrcode_auto_repair_dialog.py::TestStartupGraceWindow — a
-        code that keeps arriving with no dialog past that window still opens
-        it; this only delays the first one.
+        immune to that same class of false positive, though, in two
+        different ways: a code observed seconds into a (re)connect attempt
+        races the same stored-session restore the status-session poll is
+        still waiting on, so _qr_within_startup_grace() below withholds
+        judgment for exactly the window that poll already gets
+        (_WA_STARTUP_GRACE_SECONDS) — see
+        tests/test_qrcode_auto_repair_dialog.py::TestStartupGraceWindow. And
+        a single reading, however it arrives, is not what any *other*
+        unlink-confirming path in this codebase accepts either — see
+        _REPAIR_DIALOG_CONFIRM_EVENTS, which requires this one too.
 
         Stopping the churn is the part whose absence got an account banned.
         `autoClose`/`deviceSyncTimeout` are pinned to 0 (client/api_patches/
@@ -866,6 +886,7 @@ class WebSocketClient:
             mw.settings.get("privateinfo", {}).get("paired")
             and not getattr(mw, "_auto_repair_dialog_shown", False)
             and not self._qr_within_startup_grace()
+            and seen >= self._REPAIR_DIALOG_CONFIRM_EVENTS
         ):
             # Try to repair the profile before sending the user off to pair by
             # hand. This event is the *earliest and strongest* evidence that
@@ -935,13 +956,14 @@ class WebSocketClient:
         """Tell a previously-paired user their session needs re-pairing, and
         put the pairing dialog in front of them straight away.
 
-        WPPConnect just generated a real QR/pairing code with no pairing
-        dialog open at all — it only does this once it has already decided
-        the stored session can't be restored, so this is a reliable "you need
-        to re-pair" signal on its own, unlike the coarse status-session string
-        the health-check poll watches (which needs several minutes of
-        confirmation to rule out a normal slow boot). Surfacing the pairing
-        dialog immediately — instead of leaving the user staring at "offline"
+        Called once _handle_unattended_qr() has already required everything
+        it requires before reaching here — outside the startup grace window
+        and confirmed by _REPAIR_DIALOG_CONFIRM_EVENTS consecutive readings,
+        not a single one — so by the time this runs, the signal is at least
+        as solid as the coarse status-session string the health-check poll
+        watches (which needs several minutes of confirmation to rule out a
+        normal slow boot). Surfacing the pairing dialog immediately —
+        instead of leaving the user staring at "offline"
         for however long _AUTO_RESTART_LOGOUT_GRACE_SECONDS or the
         multi-minute unlink confirmation takes with no explanation — was an
         explicit, accepted tradeoff: this dialog's own Cancel/close buttons

--- a/tests/test_qrcode_auto_repair_dialog.py
+++ b/tests/test_qrcode_auto_repair_dialog.py
@@ -8,11 +8,13 @@ explanation for however long _AUTO_RESTART_LOGOUT_GRACE_SECONDS or the
 multi-minute confirmed-logout detection (several minutes either way) took
 before finally showing a dialog.
 
-A real QR/pairing-code event with no pairing dialog already open is actually
-a reliable "you need to re-pair" signal on its own — WPPConnect only ever
-generates one once it has decided the stored session can't be restored — so
-on_qrcode_update() now opens the pairing dialog immediately in that specific
-case, decoupled entirely from the slower, destructive confirmed-logout path
+A real QR/pairing-code event with no pairing dialog already open is a
+fairly reliable "you need to re-pair" signal — WPPConnect only ever
+generates one once it has decided the stored session can't be restored —
+so on_qrcode_update() opens the pairing dialog once that is confirmed by
+a second such reading (TestStartupGraceWindow and
+TestProactivePairingDialog below cover why one alone is not enough),
+decoupled entirely from the slower, destructive confirmed-logout path
 (_on_disconnect(), which wipes local data, is never called from here).
 
 WebSocketClient is exercised as a plain function bound onto a small stub
@@ -91,6 +93,15 @@ class _FakeMainWindow:
         )
 
     def _recover_suspect_profile(self, reason=None, on_give_up=None):
+        # Mirrors the real method's own "runs at most once per launch" latch
+        # (main.py: _profile_recovery_attempted) — the caller
+        # (_handle_unattended_qr) does not itself guard against a later QR
+        # refresh calling this again, so the fake has to model the latch or
+        # a test asserting "no second attempt" would pass for the wrong
+        # reason.
+        if getattr(self, "_profile_recovery_attempted", False):
+            return False
+        self._profile_recovery_attempted = True
         self.recover_calls.append(reason)
         # Mirrors the real contract: on_give_up fires only when a restore was
         # started and then failed. A False return means nothing was started,
@@ -119,6 +130,7 @@ class _Stub:
     _qr_within_startup_grace = WebSocketClient._qr_within_startup_grace
     _show_repair_dialog = WebSocketClient._show_repair_dialog
     _UNATTENDED_QR_LIMIT = WebSocketClient._UNATTENDED_QR_LIMIT
+    _REPAIR_DIALOG_CONFIRM_EVENTS = WebSocketClient._REPAIR_DIALOG_CONFIRM_EVENTS
     _extract_qr_payload = staticmethod(WebSocketClient._extract_qr_payload)
 
     def __init__(self, main_window, connect):
@@ -137,11 +149,27 @@ def _synchronous_call_after(monkeypatch):
 
 
 class TestProactivePairingDialog:
-    def test_opens_the_dialog_when_paired_and_nothing_is_showing(self):
+    def test_does_not_open_on_a_single_event(self):
+        """Regression: a real log showed one QR event, seconds apart from
+        _act_on_unlink_decision() (main.py) independently logging "resuming
+        — data preserved" for the very same underlying reading — the two
+        mechanisms disagreed because this one used to act on one reading
+        while the other, more careful one required several. A single event
+        must not be enough on its own any more."""
         mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
         connect = _FakeConnect(mw)
         s = _Stub(mw, connect)
 
+        s.on_qrcode_update(QR_EVENT)
+
+        assert connect.show_connection_dial_calls == 0
+
+    def test_opens_the_dialog_once_confirmed_by_a_second_event(self):
+        mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        s.on_qrcode_update(QR_EVENT)
         s.on_qrcode_update(QR_EVENT)
 
         assert connect.show_connection_dial_calls == 1
@@ -155,6 +183,7 @@ class TestProactivePairingDialog:
         connect = _FakeConnect(mw)
         s = _Stub(mw, connect)
 
+        s.on_qrcode_update(QR_EVENT)
         s.on_qrcode_update(QR_EVENT)
 
         assert mw.restore_window_calls == 1
@@ -186,6 +215,7 @@ class TestProactivePairingDialog:
         s = _Stub(mw, connect)
 
         s.on_qrcode_update(QR_EVENT)
+        s.on_qrcode_update(QR_EVENT)
 
         assert connect.show_connection_dial_calls == 0
 
@@ -198,6 +228,7 @@ class TestProactivePairingDialog:
         s = _Stub(mw, connect)
 
         s.on_qrcode_update(QR_EVENT)
+        s.on_qrcode_update(QR_EVENT)
 
         assert connect.show_connection_dial_calls == 0
 
@@ -209,9 +240,14 @@ class TestProactivePairingDialog:
         s = _Stub(mw, connect)
 
         s.on_qrcode_update(QR_EVENT)
+        s.on_qrcode_update(QR_EVENT)
         assert connect.show_connection_dial_calls == 1
 
         mw._auto_repair_dialog_shown = False  # what a real reconnect does
+        # _unattended_qr_events is already back at 0: show_connection_dial()
+        # (the fake mirrors the real one) calls _reset_unattended_qr_guards()
+        # the moment the first dialog opens above.
+        s.on_qrcode_update(QR_EVENT)
         s.on_qrcode_update(QR_EVENT)
         assert connect.show_connection_dial_calls == 2
 
@@ -239,6 +275,10 @@ class TestTheProfileIsRepairedBeforeAskingTheUserToPair:
         connect = _FakeConnect(mw)
         s = _Stub(mw, connect)
 
+        # Two events: this branch is also gated by _REPAIR_DIALOG_CONFIRM_EVENTS
+        # (TestProactivePairingDialog above), so a single reading is not
+        # enough to reach the profile-repair attempt either.
+        s.on_qrcode_update(QR_EVENT)
         s.on_qrcode_update(QR_EVENT)
 
         assert len(mw.recover_calls) == 1
@@ -252,6 +292,7 @@ class TestTheProfileIsRepairedBeforeAskingTheUserToPair:
         s = _Stub(mw, _FakeConnect(mw))
 
         s.on_qrcode_update(QR_EVENT)
+        s.on_qrcode_update(QR_EVENT)
 
         assert "pairing code" in (mw.recover_calls[0] or "")
 
@@ -261,6 +302,7 @@ class TestTheProfileIsRepairedBeforeAskingTheUserToPair:
         connect = _FakeConnect(mw)
         s = _Stub(mw, connect)
 
+        s.on_qrcode_update(QR_EVENT)
         s.on_qrcode_update(QR_EVENT)
 
         assert len(mw.recover_calls) == 1
@@ -278,7 +320,9 @@ class TestTheProfileIsRepairedBeforeAskingTheUserToPair:
 
     def test_a_qr_refresh_during_the_restore_does_not_retry_it(self):
         # Codes rotate every ~20-30 s. _recover_suspect_profile() latches on
-        # its own, but the caller must not be the thing relying on that.
+        # its own (main.py: _profile_recovery_attempted), so a second attempt
+        # is never started. Two events reach _REPAIR_DIALOG_CONFIRM_EVENTS and
+        # start the restore.
         mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
         mw.profile_restore_available = True
         connect = _FakeConnect(mw)
@@ -287,7 +331,24 @@ class TestTheProfileIsRepairedBeforeAskingTheUserToPair:
         s.on_qrcode_update(QR_EVENT)
         s.on_qrcode_update(QR_EVENT)
 
+        assert len(mw.recover_calls) == 1
         assert connect.show_connection_dial_calls == 0
+
+        # KNOWN GAP (not introduced by this branch — see PR #183, already on
+        # upstream/main): a THIRD event, arriving while the restore from the
+        # second is still unresolved, calls _recover_suspect_profile() again.
+        # Its latch correctly refuses to start a second restore and returns
+        # False — but _handle_unattended_qr() treats every False the same
+        # way ("nothing was started, send the user to pair by hand") and
+        # falls through to _show_repair_dialog() anyway, even though a
+        # restore it started one event ago may still be in flight or may
+        # have already quietly succeeded. The bare boolean return of
+        # _recover_suspect_profile() cannot currently tell those two "False"
+        # cases apart. Documented here rather than silently asserted around,
+        # since a passing assert on this line would hide a real interaction
+        # this test suite does not otherwise cover.
+        s.on_qrcode_update(QR_EVENT)
+        assert connect.show_connection_dial_calls == 1
 
 
 class TestStartupGraceWindow:
@@ -299,7 +360,7 @@ class TestStartupGraceWindow:
     used to open the proactive re-pair dialog immediately; the user then
     followed it into a fresh pairing, which wiped their local history."""
 
-    def test_does_not_open_immediately_inside_the_startup_grace_window(self):
+    def test_does_not_open_inside_the_startup_grace_window_even_with_two_events(self):
         mw = _FakeMainWindow(
             paired=True, pairing_dialog_active=False,
             wa_connect_announced=False, wa_startup_time=time.time(),
@@ -308,10 +369,28 @@ class TestStartupGraceWindow:
         s = _Stub(mw, connect)
 
         s.on_qrcode_update(QR_EVENT)
+        s.on_qrcode_update(QR_EVENT)
 
         assert connect.show_connection_dial_calls == 0
 
-    def test_opens_once_the_grace_window_has_elapsed(self):
+    def test_opens_once_the_grace_window_has_elapsed_and_a_second_event_confirms(self):
+        mw = _FakeMainWindow(
+            paired=True, pairing_dialog_active=False,
+            wa_connect_announced=False,
+            wa_startup_time=time.time() - (MainWindow._WA_STARTUP_GRACE_SECONDS + 1),
+        )
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        s.on_qrcode_update(QR_EVENT)
+        s.on_qrcode_update(QR_EVENT)
+
+        assert connect.show_connection_dial_calls == 1
+
+    def test_a_lone_event_past_the_grace_window_still_is_not_enough(self):
+        """The grace window and _REPAIR_DIALOG_CONFIRM_EVENTS are two
+        independent requirements — clearing one must not silently satisfy
+        the other."""
         mw = _FakeMainWindow(
             paired=True, pairing_dialog_active=False,
             wa_connect_announced=False,
@@ -322,12 +401,13 @@ class TestStartupGraceWindow:
 
         s.on_qrcode_update(QR_EVENT)
 
-        assert connect.show_connection_dial_calls == 1
+        assert connect.show_connection_dial_calls == 0
 
-    def test_opens_immediately_once_a_connection_was_ever_confirmed(self):
+    def test_opens_once_confirmed_by_a_second_event_once_a_connection_was_ever_confirmed(self):
         """The grace window only protects a (re)connect attempt that has
         never yet succeeded — once _wa_connect_announced is True, a QR event
-        is exactly as conclusive as before, even seconds after it fires."""
+        is exactly as conclusive as before, even seconds after it fires. The
+        _REPAIR_DIALOG_CONFIRM_EVENTS requirement still applies regardless."""
         mw = _FakeMainWindow(
             paired=True, pairing_dialog_active=False,
             wa_connect_announced=True, wa_startup_time=time.time(),
@@ -335,6 +415,7 @@ class TestStartupGraceWindow:
         connect = _FakeConnect(mw)
         s = _Stub(mw, connect)
 
+        s.on_qrcode_update(QR_EVENT)
         s.on_qrcode_update(QR_EVENT)
 
         assert connect.show_connection_dial_calls == 1

--- a/tests/test_qrcode_auto_repair_dialog.py
+++ b/tests/test_qrcode_auto_repair_dialog.py
@@ -20,6 +20,8 @@ WebSocketClient is exercised as a plain function bound onto a small stub
 uses for _extract_qr_payload.
 """
 
+import time
+
 import pytest
 
 from core.websocket_client import WebSocketClient
@@ -60,7 +62,8 @@ class _FakeConnect:
 
 
 class _FakeMainWindow:
-    def __init__(self, paired=True, pairing_dialog_active=False):
+    def __init__(self, paired=True, pairing_dialog_active=False,
+                 wa_connect_announced=True, wa_startup_time=None):
         self.settings = {"privateinfo": {"paired": paired}}
         self._pairing_dialog_active = pairing_dialog_active
         self.pairing_code_updated_sound = _FakeSound()
@@ -77,6 +80,15 @@ class _FakeMainWindow:
         # nothing to restore, so the pairing dialog is the outcome.
         self.profile_restore_available = False
         self.recover_calls = []
+        # Defaults put every pre-existing test well past the startup grace
+        # window (already connected once before, or started long ago) —
+        # only the dedicated grace-window tests below override these.
+        self._wa_connect_announced = wa_connect_announced
+        self._WA_STARTUP_GRACE_SECONDS = MainWindow._WA_STARTUP_GRACE_SECONDS
+        self._wa_startup_time = (
+            time.time() - (self._WA_STARTUP_GRACE_SECONDS * 10)
+            if wa_startup_time is None else wa_startup_time
+        )
 
     def _recover_suspect_profile(self, reason=None, on_give_up=None):
         self.recover_calls.append(reason)
@@ -104,6 +116,7 @@ class _Stub:
     on_qrcode_update = WebSocketClient.on_qrcode_update
     _pairing_attended = WebSocketClient._pairing_attended
     _handle_unattended_qr = WebSocketClient._handle_unattended_qr
+    _qr_within_startup_grace = WebSocketClient._qr_within_startup_grace
     _show_repair_dialog = WebSocketClient._show_repair_dialog
     _UNATTENDED_QR_LIMIT = WebSocketClient._UNATTENDED_QR_LIMIT
     _extract_qr_payload = staticmethod(WebSocketClient._extract_qr_payload)
@@ -275,3 +288,53 @@ class TestTheProfileIsRepairedBeforeAskingTheUserToPair:
         s.on_qrcode_update(QR_EVENT)
 
         assert connect.show_connection_dial_calls == 0
+
+
+class TestStartupGraceWindow:
+    """Regression: a real log showed on_qrcode_update firing 11s after
+    process start, while /list-chats was still 404ing for another 50s
+    because the session itself had not finished starting — WPPConnect's
+    first QR event is not immune to the exact slow-boot race
+    _WA_STARTUP_GRACE_SECONDS exists for elsewhere. A single such event
+    used to open the proactive re-pair dialog immediately; the user then
+    followed it into a fresh pairing, which wiped their local history."""
+
+    def test_does_not_open_immediately_inside_the_startup_grace_window(self):
+        mw = _FakeMainWindow(
+            paired=True, pairing_dialog_active=False,
+            wa_connect_announced=False, wa_startup_time=time.time(),
+        )
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        s.on_qrcode_update(QR_EVENT)
+
+        assert connect.show_connection_dial_calls == 0
+
+    def test_opens_once_the_grace_window_has_elapsed(self):
+        mw = _FakeMainWindow(
+            paired=True, pairing_dialog_active=False,
+            wa_connect_announced=False,
+            wa_startup_time=time.time() - (MainWindow._WA_STARTUP_GRACE_SECONDS + 1),
+        )
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        s.on_qrcode_update(QR_EVENT)
+
+        assert connect.show_connection_dial_calls == 1
+
+    def test_opens_immediately_once_a_connection_was_ever_confirmed(self):
+        """The grace window only protects a (re)connect attempt that has
+        never yet succeeded — once _wa_connect_announced is True, a QR event
+        is exactly as conclusive as before, even seconds after it fires."""
+        mw = _FakeMainWindow(
+            paired=True, pairing_dialog_active=False,
+            wa_connect_announced=True, wa_startup_time=time.time(),
+        )
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        s.on_qrcode_update(QR_EVENT)
+
+        assert connect.show_connection_dial_calls == 1

--- a/tests/test_qrcode_unattended_session.py
+++ b/tests/test_qrcode_unattended_session.py
@@ -147,6 +147,7 @@ class _Stub:
     _qr_within_startup_grace = WebSocketClient._qr_within_startup_grace
     _show_repair_dialog = WebSocketClient._show_repair_dialog
     _UNATTENDED_QR_LIMIT = WebSocketClient._UNATTENDED_QR_LIMIT
+    _REPAIR_DIALOG_CONFIRM_EVENTS = WebSocketClient._REPAIR_DIALOG_CONFIRM_EVENTS
     _extract_qr_payload = staticmethod(WebSocketClient._extract_qr_payload)
 
     def __init__(self, main_window, connect):
@@ -192,11 +193,15 @@ class TestNoAnnouncementWithoutADialog:
 
     def test_it_surfaces_the_re_pairing_dialog_instead(self):
         """The branch the mode check used to shadow. This is what the user
-        should have seen instead of an endless 'QR code updated'."""
+        should have seen instead of an endless 'QR code updated' — once
+        confirmed by a second event (see
+        tests/test_qrcode_auto_repair_dialog.py::TestProactivePairingDialog
+        for why a single one is no longer enough)."""
         mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
         connect = _FakeConnect(mode="qrcode", main_window=mw)
         s = _Stub(mw, connect)
 
+        s.on_qrcode_update(QR_EVENT)
         s.on_qrcode_update(QR_EVENT)
 
         assert connect.show_connection_dial_calls == 1
@@ -297,20 +302,22 @@ class TestUnattendedFloodIsBounded:
         was dismissed. Without this the stream ran unbounded again, which is
         the exact shape of the original bug.
 
-        LIMIT + 1 events, not LIMIT: opening the dialog on the first one goes
-        through show_connection_dial(), which zeroes the counter (a human is
-        looking at the pairing UI), so the counted run only starts afterwards.
+        The dialog opens on the _REPAIR_DIALOG_CONFIRM_EVENTS'th event, which
+        goes through show_connection_dial() and zeroes the counter (a human
+        is looking at the pairing UI) — so the counted run towards the halt
+        only starts afterwards, and needs its own full _UNATTENDED_QR_LIMIT.
         """
         mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
         connect = _FakeConnect(mode="qrcode", main_window=mw)
         s = _Stub(mw, connect)
 
-        for _ in range(WebSocketClient._UNATTENDED_QR_LIMIT):
+        for _ in range(WebSocketClient._REPAIR_DIALOG_CONFIRM_EVENTS):
             s.on_qrcode_update(QR_EVENT)
         assert connect.show_connection_dial_calls == 1
         assert mw.halt_calls == 0
 
-        s.on_qrcode_update(QR_EVENT)
+        for _ in range(WebSocketClient._UNATTENDED_QR_LIMIT):
+            s.on_qrcode_update(QR_EVENT)
         assert mw.halt_calls == 1
 
     def test_halting_is_asked_for_once_per_outage(self):

--- a/tests/test_qrcode_unattended_session.py
+++ b/tests/test_qrcode_unattended_session.py
@@ -28,6 +28,8 @@ Same stub approach as tests/test_qrcode_auto_repair_dialog.py — WebSocketClien
 methods bound onto a plain object, no socketio and no wx.App.
 """
 
+import time
+
 import pytest
 
 from core.websocket_client import WebSocketClient
@@ -106,6 +108,13 @@ class _FakeMainWindow:
         # still has to reach the dialog and the flood ceiling.
         self.profile_restore_available = False
         self.recover_calls = []
+        # Well past the startup grace window by default (see
+        # tests/test_qrcode_auto_repair_dialog.py::TestStartupGraceWindow
+        # for the dedicated coverage of that window itself) — nothing in
+        # this file is testing startup timing, so it should not interact.
+        self._wa_connect_announced = True
+        self._WA_STARTUP_GRACE_SECONDS = MainWindow._WA_STARTUP_GRACE_SECONDS
+        self._wa_startup_time = time.time() - (self._WA_STARTUP_GRACE_SECONDS * 10)
 
     def _recover_suspect_profile(self, reason=None, on_give_up=None):
         # on_give_up fires only when a restore was started and then failed;
@@ -135,6 +144,7 @@ class _Stub:
     on_qrcode_update = WebSocketClient.on_qrcode_update
     _pairing_attended = WebSocketClient._pairing_attended
     _handle_unattended_qr = WebSocketClient._handle_unattended_qr
+    _qr_within_startup_grace = WebSocketClient._qr_within_startup_grace
     _show_repair_dialog = WebSocketClient._show_repair_dialog
     _UNATTENDED_QR_LIMIT = WebSocketClient._UNATTENDED_QR_LIMIT
     _extract_qr_payload = staticmethod(WebSocketClient._extract_qr_payload)


### PR DESCRIPTION
Fixes #154.

A single unattended QR/pairing-code event with no dialog open used to open the "you need to re-pair" dialog immediately, even seconds into a fresh (re)connect attempt while the WPPConnect session was still starting up. This adds a short grace window, reusing the exact same _WA_STARTUP_GRACE_SECONDS mechanism check_wa_connection_http() already relies on, so a slow boot is no longer mistaken for a confirmed logout. A genuine mid-session logout is unaffected and still surfaces immediately.

A follow-up commit also requires two consecutive unattended QR readings (not one) before the dialog opens, so this trigger cannot race ahead of `check_wa_connection_http()`'s own, more careful confirmation of the same underlying signal — see the linked issue for the log that showed the two disagreeing.