### PR TITLE
Don't lose a live WhatsApp session when the pairing dialog closes

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -9528,6 +9528,58 @@ class MainWindow(wx.Frame):
                 "[sessions] recording an abandoned session failed (non-fatal)"
             )
 
+    def _abandon_closed_session(self, token: str) -> None:
+        """Mark a session we have just deliberately CLOSED as abandoned in
+        this account's SessionStore.
+
+        Distinct from _register_abandoned_session() above, which deliberately
+        refuses to touch an entry the store still holds as 'active' (it is
+        meant for pairing attempts that failed, where an active entry means a
+        reused, possibly live session it must not disturb). Here the opposite
+        is true: we sent /close-session ourselves, so the 'active' entry is
+        precisely the one that has to go.
+
+        Leaving it 'active' is what makes _recover_active_session_token()
+        unsafe — a session the user closed on purpose would come back as the
+        single "unambiguous" candidate on the next launch, and the app would
+        start attached to a session that is already dead instead of showing
+        the pairing dialog.
+        """
+        if not token:
+            return
+        try:
+            store = self._get_session_store()
+            if store is None:
+                return
+            name = token.replace("/", "_").replace("+", "-").split(":")[0]
+            if not name or store.get(name) is None:
+                return
+
+            from coord_locks import sessions_lock, LockTimeout
+            gd = getattr(self, "global_dir", None)
+
+            def _commit():
+                store.set_status(name, "abandoned")
+                logging.info(
+                    "[sessions] marked closed session %s as abandoned", name[:12],
+                )
+
+            if gd:
+                try:
+                    with sessions_lock(gd):
+                        _commit()
+                except LockTimeout:
+                    logging.warning(
+                        "[sessions] sessions_lock busy — could not mark closed "
+                        "session %s as abandoned", name[:12],
+                    )
+            else:
+                _commit()
+        except Exception:
+            logging.exception(
+                "[sessions] marking a closed session as abandoned failed (non-fatal)"
+            )
+
     def _recover_active_session_token(self) -> str:
         """Recover a lost WA_token reference from this account's own
         SessionStore, when exactly one active, decryptable entry exists to
@@ -9555,6 +9607,13 @@ class MainWindow(wx.Frame):
         its own, and guessing among several candidates could just as
         easily hand back the wrong session.
         """
+        if not self.settings.get("privateinfo", {}).get("paired"):
+            # An account that never finished pairing has nothing to recover:
+            # any 'active' entry it owns belongs to an attempt that never
+            # became a usable session. Enforced here rather than only at the
+            # call site so the contract in the docstring above cannot be lost
+            # by a future second caller.
+            return ""
         store = self._get_session_store()
         if store is None:
             return ""

--- a/client/main.py
+++ b/client/main.py
@@ -9528,6 +9528,53 @@ class MainWindow(wx.Frame):
                 "[sessions] recording an abandoned session failed (non-fatal)"
             )
 
+    def _recover_active_session_token(self) -> str:
+        """Recover a lost WA_token reference from this account's own
+        SessionStore, when exactly one active, decryptable entry exists to
+        recover it from.
+
+        `paired=True` with an empty/absent token can happen while the
+        underlying WPPConnect session, its Chrome userDataDir profile, and
+        its SessionStore entry are all still completely intact — reported
+        live (issue #155): a session that worked normally for an entire run
+        showed the pairing dialog again on the very next launch, with
+        sessions.json still listing that session as active and its
+        token_enc still decrypting successfully. _set_wa_token("") clears
+        only the settings.json reference (see that method) — it was never
+        the SessionStore's job to track that, so a caller clearing the
+        reference alone (connect.py's on_dialog_close()/
+        on_quit_from_connect(), before they learned to leave a currently
+        connected session alone) leaves this exact, recoverable state
+        behind.
+
+        Deliberately narrow: only restores when the store leaves no
+        ambiguity — exactly one 'active' entry, and its token decrypts
+        under this account's own secret.key. No entries, several, or one
+        that fails to decrypt are all left alone; the normal pairing flow
+        is the correct, safe fallback for a state this cannot resolve on
+        its own, and guessing among several candidates could just as
+        easily hand back the wrong session.
+        """
+        store = self._get_session_store()
+        if store is None:
+            return ""
+        try:
+            active = [s for s in store.list()
+                      if s.get("status") == "active" and s.get("token")]
+        except Exception:
+            logging.exception("[token-recovery] Failed to read the session store")
+            return ""
+        if len(active) != 1:
+            return ""
+        token = active[0]["token"]
+        logging.warning(
+            "[token-recovery] paired=True with no saved token, but exactly "
+            "one active, decryptable session was found in the store — "
+            "restoring it instead of asking to pair again."
+        )
+        self._set_wa_token(token)
+        return token
+
     def _session_crypto(self):
         """Adapter exposing .encrypt/.decrypt over token_vault + this account's
         secret.key, for SessionStore (per-account WPPConnect session isolation)."""

--- a/client/ui/dialogs/connect.py
+++ b/client/ui/dialogs/connect.py
@@ -240,6 +240,15 @@ class Connect:
         private_info = self.main_window.settings.get("privateinfo", {})
         token = self.main_window._get_wa_token()
 
+        if not token and private_info.get("paired"):
+            # paired=True with no token can mean the reference itself was
+            # lost while the actual WPPConnect session survived untouched
+            # (see MainWindow._recover_active_session_token() for why and
+            # how) — try to recover it before falling through to the
+            # pairing dialog. A never-paired account has nothing to
+            # recover and is deliberately excluded.
+            token = self.main_window._recover_active_session_token()
+
         # Legacy fallback: token.tk file means old-format paired session.
         if not token:
             return os.path.exists(data_path("token.tk"))
@@ -1719,6 +1728,27 @@ class Connect:
         # Invalidate any in-flight _bg_pairing_flow() — see on_continue().
         self._pairing_attempt_id += 1
         self.main_window._pairing_in_progress = False
+        if getattr(self.main_window, "_wa_connected", False):
+            # This dialog can now open on its own while already paired (the
+            # proactive re-pair dialog — websocket_client.py's
+            # _show_repair_dialog()), and WhatsApp can genuinely reconnect
+            # in the background — via the normal health check, independent
+            # of this dialog — before the user ever reacts to it. Below,
+            # every close path assumes the opposite: that a dialog on
+            # screen means nothing usable exists yet, so it always
+            # disconnects the live socket and clears the saved token.
+            # Reported live: an account that was working the entire session
+            # showed the pairing dialog again on the very next launch, with
+            # its WPPConnect session and Chrome profile completely intact —
+            # only the stored token reference had been wiped, by exactly
+            # this path, closing a dialog that should never have treated a
+            # live connection as disposable.
+            logging.info(
+                "[on_dialog_close] WhatsApp is connected — closing without "
+                "disconnecting the socket or clearing the saved session."
+            )
+            event.Skip()
+            return
         # Disconnect WebSocket if connected
         if hasattr(self.main_window, 'ws') and self.main_window.ws:
             try:
@@ -1738,6 +1768,19 @@ class Connect:
             return
         self._pairing_attempt_id += 1
         self.main_window._pairing_in_progress = False
+        if getattr(self.main_window, "_wa_connected", False):
+            # Same reasoning as on_dialog_close() above: WhatsApp is
+            # genuinely connected right now, so "Quit" here means exactly
+            # what it means from the main window — close the app through
+            # the normal graceful teardown, and do not disconnect the live
+            # socket or wipe the saved session first.
+            logging.info(
+                "[on_quit_from_connect] WhatsApp is connected — quitting "
+                "via the normal graceful shutdown instead of tearing down "
+                "the active session."
+            )
+            self.main_window.real_exit()
+            return
         if hasattr(self.main_window, 'ws') and self.main_window.ws:
             try:
                 logging.info("[on_quit_from_connect] Disconnecting WebSocket...")

--- a/client/ui/dialogs/connect.py
+++ b/client/ui/dialogs/connect.py
@@ -121,6 +121,15 @@ class Connect:
         # dialogs — see on_continue()'s docstring for why this exists.
         self._pairing_attempt_id: int = 0
 
+        # Token of a BRAND-NEW WPPConnect session this dialog started itself
+        # (empty whenever it reused an existing one, or closed the one it
+        # started). Minting a new session overwrites the settings token and,
+        # via _set_wa_token(), abandons whatever the store held as active —
+        # so while this is set the dialog owns state that must be torn down
+        # on close even if WhatsApp reports itself connected. See
+        # on_dialog_close().
+        self._started_new_session_token: str = ""
+
     # ── Helpers ────────────────────────────────────────────────────────────
 
     def _wpp_headers(self, use_global_key=False):
@@ -633,6 +642,11 @@ class Connect:
             # Clear reference so we don't try to reuse/double-close this token
             self.raw_token = None
             self._last_started_qr_token = None
+            self._started_new_session_token = ""
+            # The store still holds this session as 'active'. We are closing
+            # it on purpose, so it must not stay a recovery candidate — see
+            # MainWindow._abandon_closed_session() for the failure it causes.
+            self.main_window._abandon_closed_session(token)
             mw_token = getattr(self.main_window, 'token', '')
             if mw_token.startswith(session_name):
                 if hasattr(self.main_window, 'token'):
@@ -756,6 +770,7 @@ class Connect:
                 # instead of an opaque 401 from _create_instance.
                 self.main_window.token = _generate_hash(raw_token)
                 self.main_window._set_wa_token(self.main_window.token)
+                self._started_new_session_token = self.main_window.token
 
             # Close any previous session that may still be alive on the server
             # (different token from the one we're about to start). This prevents
@@ -1067,6 +1082,8 @@ class Connect:
                         self.main_window.token = raw_token
 
                 _attempt_token = self.main_window.token or ""
+                if not _instance_exists:
+                    self._started_new_session_token = _attempt_token
 
                 # Terminate any existing session running on the server. If a session is already
                 # active/initializing in QR code mode (e.g. from the startup check), WPPConnect
@@ -1728,7 +1745,8 @@ class Connect:
         # Invalidate any in-flight _bg_pairing_flow() — see on_continue().
         self._pairing_attempt_id += 1
         self.main_window._pairing_in_progress = False
-        if getattr(self.main_window, "_wa_connected", False):
+        if (getattr(self.main_window, "_wa_connected", False)
+                and not self._started_new_session_token):
             # This dialog can now open on its own while already paired (the
             # proactive re-pair dialog — websocket_client.py's
             # _show_repair_dialog()), and WhatsApp can genuinely reconnect
@@ -1743,6 +1761,18 @@ class Connect:
             # only the stored token reference had been wiped, by exactly
             # this path, closing a dialog that should never have treated a
             # live connection as disposable.
+            #
+            # The second half of the condition is what keeps this from
+            # becoming a worse bug than the one it fixes. If the user
+            # actually started a NEW session from this dialog, minting it
+            # already overwrote the settings token and abandoned the live
+            # session's store entry — so skipping the teardown here would
+            # leave a half-paired session registered as the account's active
+            # one AND leave its Chrome alive, minting QR codes that
+            # on_qrcode_update() ignores while _wa_connected is True, which
+            # is exactly the unattended code stream that gets accounts
+            # banned. In that case we fall through to the normal teardown:
+            # no better than before this fix, but no worse either.
             logging.info(
                 "[on_dialog_close] WhatsApp is connected — closing without "
                 "disconnecting the socket or clearing the saved session."
@@ -1768,8 +1798,10 @@ class Connect:
             return
         self._pairing_attempt_id += 1
         self.main_window._pairing_in_progress = False
-        if getattr(self.main_window, "_wa_connected", False):
-            # Same reasoning as on_dialog_close() above: WhatsApp is
+        if (getattr(self.main_window, "_wa_connected", False)
+                and not self._started_new_session_token):
+            # Same reasoning as on_dialog_close() above, including why a
+            # session this dialog started itself is excluded: WhatsApp is
             # genuinely connected right now, so "Quit" here means exactly
             # what it means from the main window — close the app through
             # the normal graceful teardown, and do not disconnect the live
@@ -1779,6 +1811,20 @@ class Connect:
                 "via the normal graceful shutdown instead of tearing down "
                 "the active session."
             )
+            # real_exit() hides the main frame so quitting looks instant, but
+            # this modal dialog is not the frame: without hiding it too, it
+            # stays on screen and keyboard-focused, inert, for the whole
+            # graceful-stop budget (_stop_wpp_server() waits out the session
+            # flush). Hide(), never EndModal() — that would unwind into
+            # show_connection_dial()'s caller and run the post-dialog
+            # check_connection_status() path underneath a shutdown already in
+            # flight.
+            try:
+                self.connection_dial.Hide()
+            except Exception:
+                logging.exception(
+                    "[on_quit_from_connect] Could not hide the dialog before exit"
+                )
             self.main_window.real_exit()
             return
         if hasattr(self.main_window, 'ws') and self.main_window.ws:

--- a/tests/test_check_connection_status_recovers_token.py
+++ b/tests/test_check_connection_status_recovers_token.py
@@ -1,0 +1,96 @@
+"""Tests for check_connection_status() calling
+MainWindow._recover_active_session_token() when paired=True but no token
+is saved — the wiring half of the issue #155 fix (see
+tests/test_session_token_recovery.py for the recovery method itself and
+tests/test_dialog_close_preserves_live_session.py for the code path that
+used to lose the token reference while leaving the session recoverable).
+
+Connect is a plain class — same approach as tests/test_pairing_startup_grace.py.
+"""
+
+import pytest
+
+import ui.dialogs.connect as connect_module
+from ui.dialogs.connect import Connect
+
+
+class _Response:
+    def __init__(self, status_code=200, body=None):
+        self.status_code = status_code
+        self._body = body or {}
+
+    def json(self):
+        return self._body
+
+
+class _FakeMainWindow:
+    def __init__(self, paired, stored_token, recovered_token):
+        self.settings = {
+            "general": {"language": "pt-BR"},
+            "privateinfo": {"paired": paired},
+        }
+        self._token = stored_token
+        self._recovered_token = recovered_token
+        self.wpp_server = "http://127.0.0.1"
+        self.wpp_port = 6300
+        self.recover_calls = 0
+
+    def _get_wa_token(self):
+        return self._token
+
+    def _recover_active_session_token(self):
+        self.recover_calls += 1
+        if self._recovered_token:
+            self._token = self._recovered_token
+        return self._recovered_token
+
+
+@pytest.fixture(autouse=True)
+def _connected_api(monkeypatch):
+    monkeypatch.setattr(connect_module, "api_get",
+                         lambda *a, **kw: _Response(200, {"status": True}))
+
+
+class TestPairedWithNoToken:
+    def test_calls_recovery_and_uses_the_result(self):
+        mw = _FakeMainWindow(paired=True, stored_token="", recovered_token="sess1:hash1")
+        c = Connect(mw)
+
+        result = c.check_connection_status()
+
+        assert mw.recover_calls == 1
+        assert result is True
+
+    def test_recovery_finding_nothing_falls_back_to_token_tk_check(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(connect_module, "data_path", lambda *parts: str(tmp_path.joinpath(*parts)))
+        mw = _FakeMainWindow(paired=True, stored_token="", recovered_token="")
+
+        result = Connect(mw).check_connection_status()
+
+        assert mw.recover_calls == 1
+        assert result is False  # no token.tk in the empty tmp_path either
+
+
+class TestNeverPairedWithNoToken:
+    def test_recovery_is_never_attempted(self, monkeypatch, tmp_path):
+        """Nothing to recover for an account that never finished pairing —
+        matches _recover_active_session_token()'s own callers-must-check
+        contract and avoids restoring a stray abandoned/pairing session as
+        if it were a real account."""
+        monkeypatch.setattr(connect_module, "data_path", lambda *parts: str(tmp_path.joinpath(*parts)))
+        mw = _FakeMainWindow(paired=False, stored_token="", recovered_token="sess1:hash1")
+
+        result = Connect(mw).check_connection_status()
+
+        assert mw.recover_calls == 0
+        assert result is False
+
+
+class TestTokenAlreadyPresent:
+    def test_recovery_is_never_attempted(self):
+        mw = _FakeMainWindow(paired=True, stored_token="sess1:hash1", recovered_token="")
+
+        result = Connect(mw).check_connection_status()
+
+        assert mw.recover_calls == 0
+        assert result is True

--- a/tests/test_dialog_close_preserves_live_session.py
+++ b/tests/test_dialog_close_preserves_live_session.py
@@ -73,12 +73,16 @@ class _FakeMainWindow:
         self.wpp_port = 6300
         self.real_exit_calls = 0
         self.close_active_session_calls = 0
+        self.abandoned = []
 
     def output(self, *a, **kw):
         pass
 
     def real_exit(self):
         self.real_exit_calls += 1
+
+    def _abandon_closed_session(self, token):
+        self.abandoned.append(token)
 
 
 @pytest.fixture(autouse=True)
@@ -89,8 +93,18 @@ def _no_sys_exit(monkeypatch):
     monkeypatch.setattr(connect_module.sys, "exit", lambda: (_ for _ in ()).throw(SystemExit))
 
 
-def _make_connect(mw):
+class _FakeDialog:
+    def __init__(self):
+        self.hide_calls = 0
+
+    def Hide(self):
+        self.hide_calls += 1
+
+
+def _make_connect(mw, started_new_session=""):
     c = Connect(mw)
+    c.connection_dial = _FakeDialog()
+    c._started_new_session_token = started_new_session
     calls = []
     c._close_active_session = lambda *a, **kw: calls.append((a, kw))
     return c, calls
@@ -151,3 +165,87 @@ class TestOnQuitFromConnectWhileNotConnected:
         assert close_calls[0] == ((), {"sync": True})
         assert mw.ws is None
         assert mw.real_exit_calls == 0
+
+
+class TestADialogThatStartedItsOwnSessionIsStillTornDown:
+    """The guard above is deliberately narrower than "WhatsApp is connected".
+
+    Starting a new pairing attempt from this dialog mints a fresh session and
+    hands it to _set_wa_token(), which points settings.json at it AND marks
+    the previously-active store entry abandoned. If the old session then
+    reconnects in the background (the premise of this whole fix) and the
+    guard skipped the teardown, the account would be left pointing at a
+    half-paired session that is not even the live one, with its Chrome still
+    running and minting QR codes that on_qrcode_update() ignores while
+    _wa_connected is True — the unattended code stream that gets accounts
+    banned. Falling through to the normal teardown is no better than the
+    pre-fix behaviour for this case, but it is no worse either.
+    """
+
+    def test_close_still_tears_down_when_this_dialog_started_a_session(self):
+        mw = _FakeMainWindow(wa_connected=True)
+        c, close_calls = _make_connect(mw, started_new_session="sess2:hash2")
+        event = _FakeCloseEvent()
+
+        c.on_dialog_close(event)
+
+        assert len(close_calls) == 1
+        assert mw.ws is None
+        assert event.skip_calls == 1
+
+    def test_quit_still_tears_down_when_this_dialog_started_a_session(self):
+        mw = _FakeMainWindow(wa_connected=True)
+        c, close_calls = _make_connect(mw, started_new_session="sess2:hash2")
+
+        with pytest.raises(SystemExit):
+            c.on_quit_from_connect(None)
+
+        assert len(close_calls) == 1
+        assert mw.real_exit_calls == 0
+
+
+class TestTheGuardsLeaveThePairingStateConsistent:
+    """Both guards return early from handlers whose remaining body is what
+    normally clears the pairing bookkeeping; the two lines that matter run
+    before the guard, and _pairing_attended() reads both."""
+
+    def test_close_clears_pairing_in_progress_and_bumps_the_attempt_id(self):
+        mw = _FakeMainWindow(wa_connected=True, pairing_in_progress=True)
+        c, _ = _make_connect(mw)
+        # The startup grace is a separate mechanism with its own tests; take
+        # it out of the way so this asserts the bookkeeping, not the wait.
+        c._pairing_startup_wait_done = True
+        before = c._pairing_attempt_id
+
+        c.on_dialog_close(_FakeCloseEvent(can_veto=False))
+
+        assert mw._pairing_in_progress is False
+        assert c._pairing_attempt_id == before + 1
+
+    def test_quit_clears_pairing_in_progress_and_bumps_the_attempt_id(self):
+        mw = _FakeMainWindow(wa_connected=True, pairing_in_progress=True)
+        c, _ = _make_connect(mw)
+        # The startup grace is a separate mechanism with its own tests; take
+        # it out of the way so this asserts the bookkeeping, not the wait.
+        c._pairing_startup_wait_done = True
+        before = c._pairing_attempt_id
+
+        c.on_quit_from_connect(None)
+
+        assert mw._pairing_in_progress is False
+        assert c._pairing_attempt_id == before + 1
+
+
+class TestQuitLeavesNothingOnScreen:
+    def test_the_modal_dialog_is_hidden_before_the_graceful_shutdown(self):
+        """real_exit() hides the main frame, not this dialog, and then takes
+        the whole graceful-stop budget (the session flush) before the process
+        goes. Without hiding it, a screen-reader user presses "Sair" and is
+        left focused on an inert dialog with nothing said."""
+        mw = _FakeMainWindow(wa_connected=True)
+        c, _ = _make_connect(mw)
+
+        c.on_quit_from_connect(None)
+
+        assert c.connection_dial.hide_calls == 1
+        assert mw.real_exit_calls == 1

--- a/tests/test_dialog_close_preserves_live_session.py
+++ b/tests/test_dialog_close_preserves_live_session.py
@@ -1,0 +1,153 @@
+"""Tests for Connect.on_dialog_close()/on_quit_from_connect() not tearing
+down a currently-live WhatsApp connection.
+
+Reported live (issue #155): an account paired and worked normally for an
+entire session — messages synced, nothing visibly wrong — yet the very next
+launch showed the pairing dialog again, as if never paired. The account's
+WPPConnect session, its Chrome userDataDir profile, and its sessions.json
+entry were all still intact and reusable (confirmed by manually restoring
+the encrypted token from sessions.json into settings.json, after which the
+same session kept working across further restarts) — only the token
+reference in settings.json had disappeared, with `paired` left `true`.
+
+The connection dialog (client/ui/dialogs/connect.py) can now open on its
+own while an account is already paired — websocket_client.py's
+_show_repair_dialog(), the proactive re-pair dialog — and WhatsApp can
+reconnect in the background in the time before a user reacts to it (the
+dialog is sometimes not even seen for many seconds — see
+tests/test_qrcode_auto_repair_dialog.py). Both on_dialog_close() and
+on_quit_from_connect() used to assume the opposite: that a dialog on screen
+always means nothing usable is connected yet, so closing or quitting from
+it unconditionally disconnected the live WebSocket and cleared the saved
+token via _close_active_session() — exactly the observed symptom, since
+_close_active_session() never touches `paired` or the SessionStore entry,
+only the token reference (see _set_wa_token("") in main.py).
+
+Connect is a plain class — same approach as tests/test_pairing_startup_grace.py.
+"""
+
+import pytest
+
+import ui.dialogs.connect as connect_module
+from ui.dialogs.connect import Connect
+
+
+class _FakeSio:
+    def __init__(self):
+        self.connected = True
+        self.disconnect_calls = 0
+
+    def disconnect(self):
+        self.disconnect_calls += 1
+
+
+class _FakeWs:
+    def __init__(self):
+        self.sio = _FakeSio()
+
+
+class _FakeCloseEvent:
+    def __init__(self, can_veto=True):
+        self._can_veto = can_veto
+        self.skip_calls = 0
+        self.veto_calls = 0
+
+    def CanVeto(self):
+        return self._can_veto
+
+    def Skip(self):
+        self.skip_calls += 1
+
+    def Veto(self):
+        self.veto_calls += 1
+
+
+class _FakeMainWindow:
+    def __init__(self, wa_connected, pairing_in_progress=False):
+        self.settings = {"general": {"language": "pt-BR"}}
+        self._wa_connected = wa_connected
+        self._pairing_in_progress = pairing_in_progress
+        self.ws = _FakeWs()
+        self.token = "sess1:hash1"
+        self.wpp_server = "http://127.0.0.1"
+        self.wpp_port = 6300
+        self.real_exit_calls = 0
+        self.close_active_session_calls = 0
+
+    def output(self, *a, **kw):
+        pass
+
+    def real_exit(self):
+        self.real_exit_calls += 1
+
+
+@pytest.fixture(autouse=True)
+def _no_sys_exit(monkeypatch):
+    """on_quit_from_connect()'s not-connected branch really does call
+    sys.exit() — that is the behaviour under test in that branch, but it
+    must not actually kill the test process."""
+    monkeypatch.setattr(connect_module.sys, "exit", lambda: (_ for _ in ()).throw(SystemExit))
+
+
+def _make_connect(mw):
+    c = Connect(mw)
+    calls = []
+    c._close_active_session = lambda *a, **kw: calls.append((a, kw))
+    return c, calls
+
+
+class TestOnDialogCloseWhileConnected:
+    def test_does_not_disconnect_or_clear_the_session(self):
+        mw = _FakeMainWindow(wa_connected=True)
+        c, close_calls = _make_connect(mw)
+        event = _FakeCloseEvent()
+
+        c.on_dialog_close(event)
+
+        assert close_calls == []
+        assert mw.ws is not None
+        assert mw.ws.sio.disconnect_calls == 0
+        assert event.skip_calls == 1
+        assert event.veto_calls == 0
+
+
+class TestOnDialogCloseWhileNotConnected:
+    def test_disconnects_and_clears_as_before(self):
+        """Unchanged behaviour: nothing usable is connected, so closing the
+        dialog still tears the attempt down."""
+        mw = _FakeMainWindow(wa_connected=False)
+        c, close_calls = _make_connect(mw)
+        event = _FakeCloseEvent()
+
+        c.on_dialog_close(event)
+
+        assert len(close_calls) == 1
+        assert mw.ws is None
+        assert event.skip_calls == 1
+
+
+class TestOnQuitFromConnectWhileConnected:
+    def test_quits_via_real_exit_without_tearing_down_the_session(self):
+        mw = _FakeMainWindow(wa_connected=True)
+        c, close_calls = _make_connect(mw)
+
+        c.on_quit_from_connect(None)
+
+        assert close_calls == []
+        assert mw.ws is not None
+        assert mw.ws.sio.disconnect_calls == 0
+        assert mw.real_exit_calls == 1
+
+
+class TestOnQuitFromConnectWhileNotConnected:
+    def test_disconnects_clears_and_exits_as_before(self):
+        mw = _FakeMainWindow(wa_connected=False)
+        c, close_calls = _make_connect(mw)
+
+        with pytest.raises(SystemExit):
+            c.on_quit_from_connect(None)
+
+        assert len(close_calls) == 1
+        assert close_calls[0] == ((), {"sync": True})
+        assert mw.ws is None
+        assert mw.real_exit_calls == 0

--- a/tests/test_session_token_recovery.py
+++ b/tests/test_session_token_recovery.py
@@ -19,8 +19,6 @@ against a stub carrying only what it touches — same approach as
 tests/test_abandoned_pairing_session.py.
 """
 
-import pytest
-
 from main import MainWindow
 
 
@@ -35,8 +33,9 @@ class _FakeStore:
 class _Stub:
     _recover_active_session_token = MainWindow._recover_active_session_token
 
-    def __init__(self, store):
+    def __init__(self, store, paired=True):
         self._store = store
+        self.settings = {"privateinfo": {"paired": paired}}
         self.set_token_calls = []
 
     def _get_session_store(self):
@@ -69,6 +68,8 @@ class TestNoRecoverableSession:
     def test_no_store_available_recovers_nothing(self):
         class _NoStoreStub:
             _recover_active_session_token = MainWindow._recover_active_session_token
+
+            settings = {"privateinfo": {"paired": True}}
 
             def _get_session_store(self):
                 return None
@@ -126,6 +127,22 @@ class TestStoreReadFailureIsNonFatal:
                 raise RuntimeError("disk error")
 
         s = _Stub(_BrokenStore())
+
+        assert s._recover_active_session_token() == ""
+        assert s.set_token_calls == []
+
+
+class TestNeverPairedIsNeverRecovered:
+    def test_an_account_that_never_paired_recovers_nothing(self):
+        """The store of an account that never finished pairing can still hold
+        an 'active' entry — every pairing attempt registers one — but it
+        belongs to an attempt that never became a usable session. The guard
+        lives inside the method rather than only at its call site so a future
+        second caller cannot lose it."""
+        store = _FakeStore([
+            {"name": "sess1", "status": "active", "token": "sess1:hash1"},
+        ])
+        s = _Stub(store, paired=False)
 
         assert s._recover_active_session_token() == ""
         assert s.set_token_calls == []

--- a/tests/test_session_token_recovery.py
+++ b/tests/test_session_token_recovery.py
@@ -1,0 +1,131 @@
+"""Tests for MainWindow._recover_active_session_token().
+
+Reported live (issue #155): an account paired and worked normally for an
+entire session, then showed the pairing dialog again on the very next
+launch — with settings.json holding `paired: true` but no usable token
+(WA_token_protected absent, WA_token empty). The account's own
+sessions.json still listed one 'active' session whose encrypted token
+still decrypted successfully with the account's own secret.key, and its
+Chrome userDataDir profile was untouched — manually copying that
+decrypted token back into settings.json restored the session, which then
+survived further normal restarts. _recover_active_session_token() is that
+same recovery, run automatically by check_connection_status() before it
+gives up and shows the pairing dialog (see
+tests/test_dialog_close_preserves_live_session.py for the code path that
+used to cause the loss in the first place).
+
+MainWindow is a wx.Frame, so the method is exercised as a plain function
+against a stub carrying only what it touches — same approach as
+tests/test_abandoned_pairing_session.py.
+"""
+
+import pytest
+
+from main import MainWindow
+
+
+class _FakeStore:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def list(self):
+        return list(self._entries)
+
+
+class _Stub:
+    _recover_active_session_token = MainWindow._recover_active_session_token
+
+    def __init__(self, store):
+        self._store = store
+        self.set_token_calls = []
+
+    def _get_session_store(self):
+        return self._store
+
+    def _set_wa_token(self, token):
+        self.set_token_calls.append(token)
+
+
+class TestExactlyOneRecoverableSession:
+    def test_restores_the_token(self):
+        store = _FakeStore([
+            {"name": "sess1", "status": "active", "token": "sess1:hash1"},
+        ])
+        s = _Stub(store)
+
+        result = s._recover_active_session_token()
+
+        assert result == "sess1:hash1"
+        assert s.set_token_calls == ["sess1:hash1"]
+
+
+class TestNoRecoverableSession:
+    def test_empty_store_recovers_nothing(self):
+        s = _Stub(_FakeStore([]))
+
+        assert s._recover_active_session_token() == ""
+        assert s.set_token_calls == []
+
+    def test_no_store_available_recovers_nothing(self):
+        class _NoStoreStub:
+            _recover_active_session_token = MainWindow._recover_active_session_token
+
+            def _get_session_store(self):
+                return None
+
+        assert _NoStoreStub()._recover_active_session_token() == ""
+
+    def test_only_abandoned_sessions_recover_nothing(self):
+        store = _FakeStore([
+            {"name": "sess1", "status": "abandoned", "token": "sess1:hash1"},
+        ])
+        s = _Stub(store)
+
+        assert s._recover_active_session_token() == ""
+        assert s.set_token_calls == []
+
+    def test_an_active_entry_with_an_undecryptable_token_recovers_nothing(self):
+        """SessionStore.list() already returns token=None for anything that
+        failed to decrypt — see session_store.py's _decrypt()."""
+        store = _FakeStore([
+            {"name": "sess1", "status": "active", "token": None},
+        ])
+        s = _Stub(store)
+
+        assert s._recover_active_session_token() == ""
+        assert s.set_token_calls == []
+
+
+class TestAmbiguousStoreIsNeverGuessed:
+    def test_two_active_sessions_recover_nothing(self):
+        """Guessing among several candidates could hand back the wrong
+        session — the normal pairing flow is the safe fallback here."""
+        store = _FakeStore([
+            {"name": "sess1", "status": "active", "token": "sess1:hash1"},
+            {"name": "sess2", "status": "active", "token": "sess2:hash2"},
+        ])
+        s = _Stub(store)
+
+        assert s._recover_active_session_token() == ""
+        assert s.set_token_calls == []
+
+    def test_one_active_and_one_abandoned_still_recovers_the_active_one(self):
+        store = _FakeStore([
+            {"name": "sess1", "status": "active", "token": "sess1:hash1"},
+            {"name": "sess0", "status": "abandoned", "token": "sess0:hash0"},
+        ])
+        s = _Stub(store)
+
+        assert s._recover_active_session_token() == "sess1:hash1"
+
+
+class TestStoreReadFailureIsNonFatal:
+    def test_an_exception_reading_the_store_recovers_nothing(self):
+        class _BrokenStore:
+            def list(self):
+                raise RuntimeError("disk error")
+
+        s = _Stub(_BrokenStore())
+
+        assert s._recover_active_session_token() == ""
+        assert s.set_token_calls == []

--- a/tests/test_token_not_logged.py
+++ b/tests/test_token_not_logged.py
@@ -99,12 +99,18 @@ class _MainWindow:
     def _set_wa_token(self, value):
         self._wa_token = value
 
+    def _abandon_closed_session(self, token):
+        # _close_active_session() now marks the store entry of the session it
+        # just closed as abandoned; this stub only has to accept the call.
+        self.abandoned = token
+
 
 class _ConnectStub:
     def __init__(self, main_window):
         self.main_window = main_window
         self.raw_token = None
         self._last_started_qr_token = None
+        self._started_new_session_token = ""
 
     def _wpp_headers(self, use_global_key=False):
         return {}


### PR DESCRIPTION
Fixes #155.

`on_dialog_close()` and `on_quit_from_connect()` always disconnected the WebSocket and cleared the saved token when the connection dialog was dismissed, an assumption that broke once that same dialog started opening proactively while an account was already paired and possibly already reconnected in the background, closing it then silently destroyed a perfectly healthy session, leaving `settings.json` with `paired: true` but no usable token while the WPPConnect session, Chrome profile and SessionStore entry all stayed intact (matching a real report with a clean shutdown_audit.log and a manually-verified recoverable session). Both handlers now check whether WhatsApp is currently connected first, and leave a live session alone; `on_quit_from_connect()` quits through the normal graceful `real_exit()` path instead in that case. A new `MainWindow._recover_active_session_token()`, wired into `check_connection_status()`, also self-heals accounts already left in this state: it restores the token automatically, but only when the account's own SessionStore holds exactly one active, decryptable session to recover it from. Anything ambiguous still falls back to the normal pairing dialog.