### PR TITLE
Stop the phantom NVDA char from leaking in via the type-anywhere redirect

### DIFF
--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -1953,6 +1953,17 @@ class ConversationsPanel(wx.Panel):
         choose_and_insert_emoji(self, self.message_field, self.main_window.i18n)
 
     def _on_conversation_char_hook(self, event):
+        if self._is_phantom_nvda_char(event):
+            # Veto here too, not just in _on_message_field_char(): this hook
+            # runs for the whole panel regardless of which child control
+            # currently has focus, and the "type anywhere to reply" redirect
+            # below treats 'ÿ' as an ordinary alnum character — chr(0xFF)
+            # .isalnum() is True in Python — so with focus on the
+            # conversations/messages list (the common case while browsing
+            # with a screen reader) it was moving focus to message_field and
+            # writing 'ÿ' into it via WriteText(), bypassing that other
+            # veto entirely, since WriteText() never raises EVT_CHAR.
+            return  # consume — do not insert, do not Skip()
         kc = event.GetKeyCode()
         # Intercept Esc and Enter when the mention suggestion list has focus so
         # they are handled here, before the accelerator table fires
@@ -1999,6 +2010,11 @@ class ConversationsPanel(wx.Panel):
 
         key = event.GetUnicodeKey()
         if key == wx.WXK_NONE:
+            return False
+        if self._is_phantom_nvda_char(event):
+            # chr(0xFF).isalnum() is True in Python, so the alnum check
+            # below would otherwise wave this straight through — see
+            # _is_phantom_nvda_char()'s docstring.
             return False
         try:
             # Only redirect alphanumeric characters — this prevents special
@@ -5238,9 +5254,11 @@ class ConversationsPanel(wx.Panel):
 
     @staticmethod
     def _is_phantom_nvda_char(event) -> bool:
-        """True for the bogus U+00FF character NVDA's laptop-layout object
-        navigation gestures (Windows+NVDA+Left/Right and others — issue #71)
-        leak into whatever wx.TextCtrl happens to be focused.
+        """True for the bogus U+00FF character that a screen reader's own
+        modifier-key gestures (Windows+NVDA+Left/Right and others — issue
+        #71 — and reportedly Alt+Tab as well) leak into whatever control is
+        focused, or into the message field via the "type anywhere to reply"
+        redirect below when it isn't (see _on_conversation_char_hook()).
 
         Reported live: each press of Windows+NVDA+Left/Right inserted one
         literal 'ÿ' into the message field, even though no text key was
@@ -5251,7 +5269,10 @@ class ConversationsPanel(wx.Panel):
         the character U+00FF — not a value any real keyboard layout produces
         by pressing the Windows key plus an arrow. That makes it safe to
         veto unconditionally rather than trying to special-case NVDA's own
-        modifier state, which wx never sees.
+        modifier state, which wx never sees. Checked at every entry point
+        that can put a character into the message field — see
+        _on_conversation_char_hook() for the other one — because this exact
+        code point is never a legitimate keystroke.
         """
         return event.GetUnicodeKey() == 0xFF
 

--- a/tests/test_conversation_char_hook_phantom_veto.py
+++ b/tests/test_conversation_char_hook_phantom_veto.py
@@ -1,0 +1,108 @@
+"""Issue #71 follow-up: _on_message_field_char()'s veto only stops the
+phantom U+00FF character ('ÿ') when the message field itself already has
+keyboard focus at the moment the bogus WM_CHAR arrives. In the common case
+of browsing a conversation with a screen reader — focus on the conversations
+list or the messages list, not the compose box — the same character instead
+reaches ConversationsPanel._on_conversation_char_hook(), a panel-level
+EVT_CHAR_HOOK used to redirect ordinary typing ("type anywhere to reply")
+into the message field regardless of which child control has focus.
+
+That redirect's own filter, _should_redirect_char_to_message(), only rejects
+non-alphanumeric characters — and chr(0xFF).isalnum() is True in Python — so
+the phantom character sailed through, moved focus to the message field with
+SetFocus(), and was written into it with WriteText(). WriteText() never
+raises EVT_CHAR, so _on_message_field_char()'s veto never even saw it. This
+is exactly the report: pressing Windows+NVDA+Left/Right (or, reportedly,
+Alt+Tab) while a list has focus left a literal 'ÿ' sitting in the message
+field once focus returned to the conversation.
+
+ConversationsPanel is a wx.Panel and can't be instantiated without a running
+wx.App, so _on_conversation_char_hook() is exercised as a plain function
+bound onto a stub carrying only what each test path touches — same approach
+as tests/test_message_field_phantom_char.py.
+"""
+
+from ui.conversations import ConversationsPanel
+
+
+class _FakeCharHookEvent:
+    def __init__(self, unicode_key, key_code=None):
+        self._unicode_key = unicode_key
+        self._key_code = key_code if key_code is not None else unicode_key
+        self.skipped = False
+
+    def GetUnicodeKey(self):
+        return self._unicode_key
+
+    def GetKeyCode(self):
+        return self._key_code
+
+    def Skip(self):
+        self.skipped = True
+
+
+class TestPhantomCharIsVetoedRegardlessOfFocus:
+    def test_phantom_character_is_consumed_before_any_redirect_logic_runs(self):
+        """No _mention_panel / _should_redirect_char_to_message / message_field
+        attributes exist on this stub at all — if the veto did not return
+        immediately, touching any of them would raise AttributeError instead
+        of the test merely failing an assertion."""
+        stub = type("Stub", (), {
+            "_on_conversation_char_hook": ConversationsPanel._on_conversation_char_hook,
+            "_is_phantom_nvda_char": staticmethod(ConversationsPanel._is_phantom_nvda_char),
+        })()
+        event = _FakeCharHookEvent(0xFF)
+
+        stub._on_conversation_char_hook(event)  # must not raise
+
+        assert event.skipped is False
+
+    def test_phantom_character_is_never_redirected_into_the_message_field(self, monkeypatch):
+        """Belt-and-suspenders: even if the top-of-function veto were ever
+        removed, _should_redirect_char_to_message() itself must not treat
+        U+00FF as an ordinary alphanumeric character to forward."""
+        import ui.conversations as conversations_module
+
+        class _AlwaysShownEnabled:
+            def IsShown(self):
+                return True
+
+            def IsEnabled(self):
+                return True
+
+        class _Stub:
+            _should_redirect_char_to_message = ConversationsPanel._should_redirect_char_to_message
+            _is_phantom_nvda_char = staticmethod(ConversationsPanel._is_phantom_nvda_char)
+
+            def __init__(self):
+                self.conversation = object()
+                self.conversation_panel = _AlwaysShownEnabled()
+                self.message_field = _AlwaysShownEnabled()
+                self._is_recording = False
+
+        # focus is on some non-TextCtrl control (e.g. the conversations
+        # list) — the case this bug actually reproduces under.
+        monkeypatch.setattr(conversations_module.wx.Window, "FindFocus", staticmethod(lambda: None))
+
+        event = _FakeCharHookEvent(0xFF)
+        event.ControlDown = lambda: False
+        event.AltDown = lambda: False
+
+        assert _Stub()._should_redirect_char_to_message(event) is False
+
+
+class TestRealCharacterStillFallsThroughUnaffected:
+    def test_a_real_typed_character_reaches_the_redirect_check(self):
+        calls = []
+
+        stub = type("Stub", (), {
+            "_on_conversation_char_hook": ConversationsPanel._on_conversation_char_hook,
+            "_is_phantom_nvda_char": staticmethod(ConversationsPanel._is_phantom_nvda_char),
+            "_should_redirect_char_to_message": lambda self, event: calls.append(event) or False,
+        })()
+        event = _FakeCharHookEvent(ord("y"))
+
+        stub._on_conversation_char_hook(event)
+
+        assert calls == [event]
+        assert event.skipped is True  # not redirected -> falls through normally


### PR DESCRIPTION
Issue #71 was only half-fixed: _on_message_field_char()'s veto against the bogus U+00FF ('ÿ') character that some screen-reader modifier-key gestures leak (and reportedly Alt+Tab too) only helps once the message field already has focus. ConversationsPanel also has a panel-wide "type anywhere to reply" redirect (_on_conversation_char_hook / _should_redirect_char_to_message) that moves focus to the message field and WriteText()s whatever was typed elsewhere — and its own alnum filter waves 0xFF straight through, since chr(0xFF).isalnum() is True in Python. WriteText() never raises EVT_CHAR, so the existing veto never even saw it. This is the common case: focus is normally on the conversations/messages list while browsing with a screen reader, not on the compose box. Both the hook itself and its redirect-decision helper now veto the same character, matching the existing "unconditional veto" precedent — the hook's own veto also stops the character from reaching whatever control's own default handling (e.g. list type-ahead) it was actually delivered to.