### PR TITLE
Stop asking the phone for history it already said it does not have

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,14 @@ So the rule: **only a genuine I/O fault belongs in `message_failures`.** A defin
 
 Both follow the same shape: subtracted from `successful_jids`, folded into the durable `_message_retry_jids`, **never** added to `failed_jids`. Both are bounded (3 attempts) so the persisted retry list cannot grow without bound. If you add a third such case, follow it — do not invent a fourth mechanism.
 
+### An on-demand history request is visible to the user's phone
+
+`request_older_messages()` → `requestOlderMessages` (`deviceController.ts`) sends a **peer-data-operation to the phone**, and the phone tells its owner: iOS puts "Synchronizing WhatsApp with Google Chrome (Windows)…" on the lock screen and follows it, when the request yields nothing, with "Sync paused. Open WhatsApp to resume." So this is not a free background call — every one of them is a notification on someone's phone, and a stream of them reads as WinZapp being broken even while it works perfectly (issue #108).
+
+**Treat the phone's own answer as authoritative and check it before sending.** WhatsApp Web computes `primaryHasMoreMessagesReadyToLoad(chat.endOfHistoryTransferType)`; the controller computed it, ignored it, and sent anyway, so `primaryHasMore` reached Python as a log field only. Measured on a real fully-synced account: **34 requests in one launch, 17 of them answered `primaryHasMore=false`**, and the same chats asked again in a later pass because nothing retired them. A short chat is indistinguishable from a truncated one from the local side alone — the phone's answer is the only thing that tells them apart, which is why ignoring it loops forever.
+
+Two rules hold the fix together. Only an explicit `false` refuses: `null` means the internal lookup failed, and refusing on unknown would silently stop all history backfill the day WhatsApp renames that module. And the refusal must return a non-`requested` body, because `_backfill_empty_chats()` reads that as the **terminal** "no older history" verdict and drops the chat from the persisted queue — which is what stops the re-asking, not the skipped send. A `None` there would keep it queued and ask again after `_OLDER_REQUEST_GRACE`, which is the loop itself.
+
 ### The incremental round (`client/core/incremental_sync.py`)
 
 `_capture_chat_sync_baseline()` snapshots `self.chats`, and `get_remote_chats()` merges the server's `t`/`lastReceivedKey` into those same dicts. **So the baseline is a copy of the previous list-chats snapshot, not a record of what was actually stored.** A round that commits an activity marker without the message it refers to poisons the next baseline with its own claim: every snapshot-vs-snapshot signal then agrees the chat is unchanged, forever, and only F5 repairs it. That state is reachable in normal operation (`_MAX_EMPTY_DELTA_RETRIES` commits the marker of a delta that never produced a message), and it was measured at 20 of 155 chats on a real install, one stuck for 15 days.

--- a/client/api_patches/src/controller/deviceController.ts
+++ b/client/api_patches/src/controller/deviceController.ts
@@ -2582,6 +2582,36 @@ export async function requestOlderMessages(req: Request, res: Response) {
           out.primaryHasMore = null;
         }
 
+        // WhatsApp Web has just told us the phone has nothing older for this
+        // chat. Asking anyway is not merely wasted — every on-demand request
+        // is a peer-data-operation the PHONE reacts to, and the phone tells
+        // its owner: iOS puts "Synchronizing WhatsApp with Google Chrome
+        // (Windows)…" on the lock screen and follows it, when the request
+        // yields nothing, with "Sync paused. Open WhatsApp to resume." The
+        // user sees an endless flicker of sync notifications while WinZapp
+        // works perfectly — which is exactly issue #108, and is the kind of
+        // report that makes someone stop trusting the app.
+        //
+        // This value was already computed here and then ignored: the send
+        // went out regardless and `primaryHasMore` reached Python as a log
+        // field only. Measured on a real, fully-synced account: 34 requests in
+        // one launch, SEVENTEEN of them answered primaryHasMore=false, and the
+        // same chats asked again in a later pass because nothing retired them.
+        //
+        // Refusing here is also what retires them. The Python caller already
+        // treats a non-`requested` answer as the terminal "this chat has no
+        // older history" verdict and drops it from the backfill queue
+        // (_backfill_empty_chats), so this closes the loop rather than just
+        // skipping one send.
+        //
+        // Only an explicit `false` refuses. null means the lookup failed —
+        // an unknown must keep the old behaviour, or a renamed internal module
+        // would silently stop all history backfill.
+        if (out.primaryHasMore === false) {
+          out.error = 'primary has no older messages for this chat';
+          return out;
+        }
+
         let wid;
         try {
           wid = (window as any).WPP.whatsapp.WidFactory.createWid(chatId);

--- a/client/main.py
+++ b/client/main.py
@@ -18230,6 +18230,26 @@ class MainWindow(wx.Frame):
                     "%s (primary_has_more=%s).", jid, payload.get("primaryHasMore"),
                 )
                 return True
+            if isinstance(payload, dict) and payload.get("primaryHasMore") is False:
+                # Not a failure, and the commonest answer there is: WhatsApp
+                # Web checked and the phone has nothing older for this chat, so
+                # the request was deliberately not sent (see requestOlderMessages
+                # in deviceController.ts — every one that IS sent lights up the
+                # phone's lock screen with a sync notification).
+                #
+                # Logged apart from the generic "did not go out" line below
+                # because it is the ordinary, expected outcome for roughly half
+                # the queue, and a log full of 500s that are really "nothing to
+                # do" costs a diagnosis the next time something is genuinely
+                # wrong here.
+                #
+                # Still False, which is the terminal verdict the caller wants:
+                # this chat leaves the backfill queue and is not asked again.
+                logging.info(
+                    "[history-sync] The phone has no older messages for %s — "
+                    "not asking, and retiring it from the backfill queue.", jid,
+                )
+                return False
             if isinstance(payload, dict) and "recent history sync" in str(
                     payload.get("error", "")).lower():
                 logging.info(

--- a/tests/test_history_sync_on_demand.py
+++ b/tests/test_history_sync_on_demand.py
@@ -865,3 +865,122 @@ class TestInteractiveHistoryWait:
             timeout=5, should_continue=lambda: False)
         assert got is None
         assert stub.calls == []
+
+
+class TestAPhoneWithNothingOlderIsNotAsked:
+    """Issue #108: the iPhone flickering sync notifications while WinZapp works.
+
+    Every on-demand request is a peer-data-operation the PHONE reacts to, and
+    the phone tells its owner about it — iOS shows "Synchronizing WhatsApp with
+    Google Chrome (Windows)…" on the lock screen and follows it, when the
+    request yields nothing, with "Sync paused. Open WhatsApp to resume."
+
+    WhatsApp Web already computes whether the phone has anything older
+    (`primaryHasMoreMessagesReadyToLoad`), and deviceController.ts computed it
+    and then sent the request anyway — `primaryHasMore` reached Python as a log
+    field and nothing else. Measured on a real, fully-synced account: 34
+    requests in one launch, SEVENTEEN answered primaryHasMore=false, and the
+    same chats asked again in a later pass because nothing retired them.
+
+    The verdict has to be False rather than None: False is the terminal answer
+    _backfill_empty_chats() reads as "this chat has no older history", which is
+    what drops it from the queue for good. None keeps it queued and asks again
+    after the grace period — which is the loop being fixed.
+    """
+
+    def test_a_refusal_for_lack_of_older_history_is_terminal(self, monkeypatch):
+        stub = _Stub()
+        monkeypatch.setattr(
+            "main.requests.post",
+            lambda *a, **k: _Response(500, {"status": "error", "response": {
+                "primaryHasMore": False,
+                "error": "primary has no older messages for this chat",
+            }}),
+        )
+        assert stub.request_older_messages("120363000000000000@g.us") is False
+
+    def test_it_is_logged_as_the_ordinary_outcome_it_is(self, monkeypatch, caplog):
+        """Roughly half the queue answers this way. A log full of 500s that are
+        really "nothing to do" costs a diagnosis the next time something here
+        is genuinely wrong."""
+        stub = _Stub()
+        monkeypatch.setattr(
+            "main.requests.post",
+            lambda *a, **k: _Response(500, {"status": "error", "response": {
+                "primaryHasMore": False,
+                "error": "primary has no older messages for this chat",
+            }}),
+        )
+        with caplog.at_level("INFO"):
+            stub.request_older_messages("120363000000000000@g.us")
+        assert any("no older messages" in r.message for r in caplog.records)
+        assert not any("did not go out" in r.message for r in caplog.records)
+
+    def test_an_unknown_answer_is_not_read_as_nothing_older(self, monkeypatch):
+        """null means the lookup failed, not that the phone is empty. Treating
+        it as terminal would silently write off chats that do have history."""
+        stub = _Stub()
+        monkeypatch.setattr(
+            "main.requests.post",
+            lambda *a, **k: _Response(200, {"status": "success", "response": {
+                "primaryHasMore": None, "requested": True,
+            }}),
+        )
+        assert stub.request_older_messages("120363000000000000@g.us") is True
+
+    def test_a_successful_send_still_reports_true(self, monkeypatch):
+        """primaryHasMore true is the case the request exists for."""
+        stub = _Stub()
+        monkeypatch.setattr(
+            "main.requests.post",
+            lambda *a, **k: _Response(200, {"status": "success", "response": {
+                "primaryHasMore": True, "requested": True,
+            }}),
+        )
+        assert stub.request_older_messages("120363000000000000@g.us") is True
+
+    def test_the_deferral_for_an_unfinished_recent_pass_still_wins(self, monkeypatch):
+        """That one must stay None — the chat has to be asked again once RECENT
+        finishes, so it may not be retired."""
+        stub = _Stub()
+        monkeypatch.setattr(
+            "main.requests.post",
+            lambda *a, **k: _Response(500, {"status": "error", "response": {
+                "error": "recent history sync is not complete yet",
+            }}),
+        )
+        assert stub.request_older_messages("120363000000000000@g.us") is None
+
+
+class TestTheNodeSideRefusesBeforeSending:
+    """The Python verdict above is only half of it: the point is that the
+    request never reaches the phone, because the notification is raised by the
+    send itself."""
+
+    @staticmethod
+    def _source():
+        from pathlib import Path
+        return (Path(__file__).resolve().parents[1] / "client" / "api_patches"
+                / "src" / "controller" / "deviceController.ts").read_text(
+                    encoding="utf-8")
+
+    def test_the_refusal_precedes_the_send(self):
+        # Scoped to requestOlderMessages' own body: the file mentions
+        # sendPeerDataOperationRequest elsewhere, and a whole-file index would
+        # compare against the wrong one.
+        source = self._source()
+        source = source[source.index("export async function requestOlderMessages("):]
+        refusal = source.index("primary has no older messages for this chat")
+        # The actual invocation, not the capability guard higher up that only
+        # checks `typeof sender?.sendPeerDataOperationRequest`.
+        send = source.index("await sender.sendPeerDataOperationRequest(")
+        assert refusal < send, (
+            "the primaryHasMore check must come before the send, or the phone "
+            "is notified anyway and only the bookkeeping changes"
+        )
+
+    def test_only_an_explicit_false_refuses(self):
+        """`null` is "the lookup failed". Refusing on it would silently stop
+        all history backfill the day WhatsApp renames that internal module."""
+        source = self._source()
+        assert "if (out.primaryHasMore === false) {" in source


### PR DESCRIPTION
Fixes #108 — the iPhone showing and retracting WhatsApp sync notifications while WinZapp works perfectly. Reproduced locally and traced to a value that was computed and then thrown away.

## Why the phone is the one complaining

`request_older_messages()` → `requestOlderMessages` sends a **peer-data-operation to the phone**, and the phone tells its owner about it: iOS puts *"Synchronizing WhatsApp with Google Chrome (Windows)…"* on the lock screen, then *"Sync paused. Open WhatsApp to resume."* when the request yields nothing.

So the notifications are not a cosmetic side effect to suppress. They are an accurate report that WinZapp is asking the phone for something — and half the time it was asking for something the phone had already said it does not have.

## The bug

In `deviceController.ts`, this sat immediately above an unconditional send:

```ts
out.primaryHasMore = req_('WAWebHistorySyncUtils')
  .primaryHasMoreMessagesReadyToLoad(chat?.endOfHistoryTransferType);
// ...
await sender.sendPeerDataOperationRequest(kind, { chatId: requestChatId });
```

The value reached Python as a log field and nothing else.

Measured on a real, fully-synced account (one launch, 50 backfill passes over 16 minutes):

```
17  primary_has_more=False     <- asked anyway, phone has nothing older
15  primary_has_more=True
 2  primary_has_more=None
```

…and the same chats asked **twice in the same launch**, including ones that had just answered `False`. Nothing retired them, so the queue is persisted and the whole thing repeats on the next launch.

The reason it loops rather than converging: a chat that is genuinely short is indistinguishable from a truncated one from the local side alone. The phone's answer is the only thing that tells them apart, so discarding it means the queue can never drain.

## The fix

Check before sending, and refuse only on an explicit `false`:

```ts
if (out.primaryHasMore === false) {
  out.error = 'primary has no older messages for this chat';
  return out;
}
```

`null` means the internal lookup failed. Refusing on unknown would silently stop **all** history backfill the day WhatsApp renames that module.

Refusing is also what retires the chat: `_backfill_empty_chats()` already reads a non-`requested` answer as the terminal "no older history" verdict and drops it from the persisted queue. That is the half that stops the re-asking — a `None` there would keep it queued and ask again after `_OLDER_REQUEST_GRACE`, which is the loop itself.

Python logs it as the ordinary outcome it is, rather than through the generic `did not go out (status=500)` line: roughly half the queue answers this way, and a log full of 500s that are really "nothing to do" costs a diagnosis the next time something here is genuinely wrong.

## What this does and does not fix

It removes the requests that could never succeed, and — because those chats now leave the queue permanently — later launches are quieter still.

The remaining requests (`primaryHasMore=true`) are the feature working: the phone really does have more, and it will notify while sending it. Those converge on their own, since the messages arriving make the chat grow and leave the queue. So expect fewer notifications and an end to the endless flicker, not silence during a genuine backfill.

## Tests

`tests/test_history_sync_on_demand.py`: the refusal is terminal (`False`, not `None`), an unknown answer is not read as "nothing older", the RECENT-pass deferral still returns `None` so its chat is not retired, the new log line replaces the generic one, and — on the Node source — the check precedes the actual `await sender.sendPeerDataOperationRequest(` rather than the capability guard above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)