### PR TITLE
Stop the npm health probe from failing builds on its own

### DIFF
--- a/setup_api.py
+++ b/setup_api.py
@@ -852,13 +852,45 @@ def main():
                 win_npm = os.path.join(ROOT_DIR, "client", "node", "node_modules", "npm", "bin", "npm-cli.js")
                 if os.path.isfile(win_npm):
                     npm_bin = win_npm
-                    npm_probe = subprocess.run(
-                        [node_bin, npm_bin, "install", "--help"],
-                        capture_output=True,
-                        text=True,
-                        timeout=10,
-                    )
-                    if npm_probe.returncode != 0:
+                    # A HEALTH PROBE MUST NEVER BE MORE FATAL THAN THE THING IT
+                    # STANDS IN FOR. This one asks "can the portable npm run at
+                    # all"; the real `npm install` two blocks below has no
+                    # timeout and fails loudly and informatively if npm is
+                    # genuinely broken. So a probe that does not answer in time
+                    # is "unknown", not "unhealthy" — and certainly not a reason
+                    # to abort the build.
+                    #
+                    # It was neither. At 10s, and with TimeoutExpired escaping
+                    # into the outer handler, a cold `npm install --help` on a
+                    # GitHub runner turned into
+                    #
+                    #   [ERROR] Node.js dependencies installation/build failed:
+                    #   Command '[... npm-cli.js, install, --help]' timed out
+                    #   after 10 seconds
+                    #
+                    # and no alpha was published (2026-09-07, run 34162896892),
+                    # on a commit whose two predecessors had built fine — the
+                    # signature of a threshold too close to the normal cost of
+                    # the operation, not of a broken runtime.
+                    #
+                    # 120s because this prints a help page: anything that slow
+                    # says something real about the machine, while ten seconds
+                    # says only that npm was cold.
+                    try:
+                        npm_probe = subprocess.run(
+                            [node_bin, npm_bin, "install", "--help"],
+                            capture_output=True,
+                            text=True,
+                            timeout=120,
+                        )
+                    except subprocess.TimeoutExpired:
+                        print(
+                            "[WARNING] The portable npm health probe timed out. "
+                            "Continuing with it anyway — the npm install below "
+                            "will report the real problem if there is one."
+                        )
+                        npm_probe = None
+                    if npm_probe is not None and npm_probe.returncode != 0:
                         system_node = shutil.which("node")
                         system_npm = shutil.which("npm.cmd") or shutil.which("npm")
                         if not system_node or not system_npm:

--- a/tests/test_npm_health_probe.py
+++ b/tests/test_npm_health_probe.py
@@ -1,0 +1,106 @@
+"""The portable-npm health probe must not be able to fail a build on its own.
+
+setup_api.py runs `npm install --help` before the real install to check the
+bundled Node runtime can execute npm at all. It ran with a 10-second timeout
+and no handler, so `subprocess.TimeoutExpired` escaped into the outer
+except-block that reports
+
+    [ERROR] Node.js dependencies installation/build failed: Command
+    '[... npm-cli.js, install, --help]' timed out after 10 seconds
+
+and exits 1. On 2026-09-07 (run 34162896892) that stopped an alpha from being
+published, on a commit whose two immediate predecessors had built fine — the
+signature of a threshold sitting too close to the normal cost of the operation
+rather than of a broken runtime.
+
+The principle this pins: **a health probe must never be more fatal than the
+operation it stands in for.** The real `npm install` a few lines below has no
+timeout at all and fails loudly and informatively when npm is genuinely broken,
+so a probe that merely fails to answer in time has learned nothing and must not
+decide anything.
+"""
+
+import importlib.util
+import inspect
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _setup_api():
+    spec = importlib.util.spec_from_file_location(
+        "winzapp_setup_api", ROOT / "setup_api.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _probe_source():
+    """The block around the health probe, read out of main()."""
+    source = inspect.getsource(_setup_api().main)
+    start = source.index('"install", "--help"')
+    return source[max(0, start - 2000):start + 2000]
+
+
+class TestATimeoutIsNotAVerdict:
+    def test_the_probe_is_wrapped(self):
+        block = _probe_source()
+        assert "except subprocess.TimeoutExpired:" in block, (
+            "an unhandled TimeoutExpired here reaches the outer handler and "
+            "aborts the whole build"
+        )
+
+    def test_a_timeout_does_not_fall_into_the_unhealthy_branch(self):
+        """The unhealthy branch can raise RuntimeError when no system Node is
+        available. A probe that timed out has not shown npm to be unhealthy."""
+        block = _probe_source()
+        assert "npm_probe is not None and npm_probe.returncode != 0" in block
+
+    def test_it_says_what_it_did(self):
+        block = _probe_source()
+        assert "[WARNING]" in block and "timed out" in block
+
+
+class TestTheBudgetIsNotSetToTheCostOfTheOperation:
+    def test_the_probe_gets_a_realistic_budget(self):
+        """A cold `npm install --help` on a CI runner routinely exceeds ten
+        seconds; it is printing a help page, so a slow answer says something
+        about the machine, not about npm."""
+        block = _probe_source()
+        timeout = re.search(r"timeout=(\d+)", block)
+        assert timeout, "the probe no longer passes a timeout"
+        assert int(timeout.group(1)) >= 60, (
+            f"timeout={timeout.group(1)}s is close enough to the normal cost of "
+            "this call to fail on an ordinary slow runner"
+        )
+
+
+class TestTheRealInstallStillDecides:
+    def test_npm_install_itself_is_not_given_a_timeout(self):
+        """It is the operation the probe stands in for. Capping it would move
+        the same flake onto the step that actually matters."""
+        source = inspect.getsource(_setup_api().main)
+        install = source.index('"install", "--no-audit"')
+        line_start = source.rindex("\n", 0, install)
+        line_end = source.index("\n", install)
+        assert "timeout" not in source[line_start:line_end]
+
+
+class TestTheProbeStillCatchesARealFailure:
+    """Softening the timeout must not soften the case it exists for."""
+
+    def test_a_nonzero_exit_with_no_system_node_still_aborts(self, monkeypatch):
+        module = _setup_api()
+        block = _probe_source()
+        assert "Portable npm is unhealthy" in block
+        assert "raise RuntimeError(" in block
+
+    def test_a_nonzero_exit_falls_back_to_system_node_when_there_is_one(self):
+        block = _probe_source()
+        assert "using the system" in block
+        assert "node_bin = system_node" in block


### PR DESCRIPTION
The alpha for `64f08b7f` was not published ([run 34162896892](https://github.com/gabrielhhaber/WinZapp_Python/actions/runs/34162896892)). The cause is not that commit:

```
[ERROR] Node.js dependencies installation/build failed: Command
'[... npm-cli.js, install, --help]' timed out after 10 seconds
```

`setup_api.py` runs `npm install --help` before the real install, to check the bundled Node runtime can execute npm at all. It ran with a **10-second timeout and no handler**, so `subprocess.TimeoutExpired` escaped into the outer `except` — the one that reports a failed dependency install and exits 1.

Its two immediate predecessors built fine on the same code. That is the signature of a threshold sitting too close to the normal cost of the call, not of a broken runtime: a cold `npm install --help` on a GitHub runner routinely takes longer than that.

## The principle

**A health probe must never be more fatal than the operation it stands in for.** The real `npm install` a few lines below has no timeout at all and fails loudly and informatively when npm is genuinely broken. A probe that merely failed to answer in time has learned nothing, so it may not decide anything: the timeout is now caught, reported as a warning, and the portable npm is used anyway.

The budget also goes to 120 s. This call prints a help page — anything that slow says something real about the machine, while ten seconds says only that npm was cold.

## What is deliberately unchanged

The case the probe exists for. A **nonzero exit** still means unhealthy: it falls back to the system Node when there is one, and still raises when there is not. Only "did not answer in time" changed meaning.

## Tests

`tests/test_npm_health_probe.py` — the timeout is handled, a timeout does not reach the unhealthy branch (which can raise), the budget is not set near the operation's own cost, the real `npm install` is still uncapped, and both halves of the genuine-failure path survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)