### PR TITLE
Copy a voice message from where it is actually cached

### DIFF
--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -163,6 +163,46 @@ def local_media_cache_paths(voice_dir: str, media_dir: str, msg_id: str) -> list
     ]
 
 
+def media_cache_id(msg_id: str) -> str:
+    """The id a message's cached media file is actually named after.
+
+    Some ids arrive in WhatsApp's composite `false_<jid>_<id>` form, and the
+    file on disk is named after the last component only. Playback, Save As and
+    the download button all reduced it with this same three-line rule, each
+    keeping its own copy.
+    """
+    if "_" in msg_id:
+        parts = msg_id.split("_")
+        return parts[2] if len(parts) > 2 else parts[-1]
+    return msg_id
+
+
+def cached_media_path(msg_type: str, msg_id: str) -> str:
+    """The one file this message's media is cached at, if it is cached at all.
+
+    **Voice notes and audio files do not live where the other media do.**
+    `handle_audio_message()` writes `voice_messages/<id>.msv`;
+    `handle_media_message()` writes `media/<id>.wzmedia`. Anything that answers
+    "where is this message's file" by hardcoding the second one is wrong for
+    every audio message — and wrong in the worst way, because the file IS on
+    disk: the caller concludes it is missing, downloads it (into the .msv path
+    it is not looking at), re-checks the .wzmedia path, finds nothing, and
+    tells the user the media could not be downloaded and the link may have
+    expired. Reported against Ctrl+C on a voice message that played perfectly
+    a second earlier.
+
+    This is the same rule `local_media_cache_paths()` states for the Media
+    tab's downloaded/not-downloaded scan, in the form a caller wanting ONE
+    path needs. CLAUDE.md's warning applies to both: a second copy of this
+    answer is how one part of the app starts disagreeing with whatever wrote
+    the file.
+    """
+    cache_id = media_cache_id(msg_id)
+    if msg_type == "audioMessage":
+        return data_path("voice_messages", f"{cache_id}.msv")
+    return data_path("media", f"{cache_id}.wzmedia")
+
+
 def promote_local_media_cache(voice_dir: str, media_dir: str,
                               local_id: str, real_id: str) -> None:
     """Rename a message's cached copies from its local UUID to its real id."""
@@ -7392,14 +7432,7 @@ class ConversationsPanel(wx.Panel):
         """
         msg_type = msg.get("messageType", "")
         msg_id   = msg.get("key", {}).get("id", "")
-        clean_msg_id = msg_id
-        if "_" in msg_id:
-            parts = msg_id.split("_")
-            clean_msg_id = parts[2] if len(parts) > 2 else parts[-1]
-        if msg_type == "audioMessage":
-            media_path = data_path("voice_messages", f"{clean_msg_id}.msv")
-        else:
-            media_path = data_path("media", f"{clean_msg_id}.wzmedia")
+        media_path = cached_media_path(msg_type, msg_id)
 
         if not os.path.isfile(media_path):
             if not getattr(self.main_window, "_wa_connected", False):
@@ -7458,7 +7491,7 @@ class ConversationsPanel(wx.Panel):
         msg_id   = msg.get("key", {}).get("id", "")
         mw       = self.main_window
         i18n     = mw.i18n
-        media_path = data_path("media", f"{msg_id}.wzmedia")
+        media_path = cached_media_path(msg_type, msg_id)
 
         if not getattr(mw, "_wa_connected", False):
             mw.output(i18n.t("media_download_offline"))
@@ -10442,7 +10475,11 @@ class ConversationsPanel(wx.Panel):
             return
 
         default_file = self._resolve_media_filename(msg)
-        media_path = data_path("media", f"{msg_id}.wzmedia")
+        # Through the shared resolver: a voice note is cached under
+        # voice_messages/<id>.msv, and hardcoding the media/ path here is what
+        # made Ctrl+C on an already-downloaded audio announce "could not
+        # download this media file, the link may have expired".
+        media_path = cached_media_path(msg_type, msg_id)
 
         def _run():
             if not self._ensure_media_on_disk(msg, media_path):

--- a/tests/test_media_cache_path.py
+++ b/tests/test_media_cache_path.py
@@ -1,0 +1,131 @@
+"""Where a message's media is cached, answered in one place.
+
+Audio does not live where the other media do: `handle_audio_message()` writes
+`voice_messages/<id>.msv`, `handle_media_message()` writes
+`media/<id>.wzmedia`. Three call sites resolved that themselves and one of them
+— Ctrl+C — hardcoded the `media/` path for every type.
+
+The failure that produced is the nastiest shape available, because the file is
+right there on disk: the caller concludes it is missing, downloads it (into the
+`.msv` path it is not looking at), re-checks the `.wzmedia` path, still finds
+nothing, and tells the user
+
+    "Não foi possível baixar este arquivo de mídia. O link pode ter expirado
+     ou o WPPConnect está indisponível."
+
+on a voice note that played perfectly a second earlier. Reported live after
+v1.1.
+
+CLAUDE.md already carries the rule this enforces: "is this media downloaded?"
+spans two directories, and a second copy of that answer is how one part of the
+app starts disagreeing with whatever wrote the file.
+"""
+
+import inspect
+import re
+
+import pytest
+
+import app_paths
+from ui.conversations import (
+    ConversationsPanel,
+    cached_media_path,
+    local_media_cache_paths,
+    media_cache_id,
+)
+
+
+@pytest.fixture(autouse=True)
+def _account_scope():
+    """cached_media_path() goes through data_path(), which refuses to answer
+    without an active account — the same guard that keeps one account's media
+    out of another's folder."""
+    app_paths.set_active_account("acct-under-test")
+    yield
+    app_paths.set_active_account(None)
+
+
+class TestTheIdTheFileIsNamedAfter:
+    def test_a_plain_id_is_used_as_is(self):
+        assert media_cache_id("3EB0CB1BB426875ACCFB49") == "3EB0CB1BB426875ACCFB49"
+
+    def test_a_composite_id_reduces_to_its_last_component(self):
+        """WhatsApp's `false_<jid>_<id>` form: the file on disk is named after
+        the id alone."""
+        assert media_cache_id(
+            "false_120363151058129530@g.us_3EB0CB1BB426875ACCFB49"
+        ) == "3EB0CB1BB426875ACCFB49"
+
+    def test_a_two_part_id_falls_back_to_the_last_part(self):
+        assert media_cache_id("false_3EB0ABC") == "3EB0ABC"
+
+    def test_an_empty_id_is_left_alone(self):
+        assert media_cache_id("") == ""
+
+
+class TestAudioIsCachedSomewhereElse:
+    """The whole bug in one assertion."""
+
+    def test_audio_resolves_into_voice_messages(self):
+        path = cached_media_path("audioMessage", "ABC123")
+        assert path.endswith("ABC123.msv")
+        assert "voice_messages" in path
+
+    @pytest.mark.parametrize("msg_type", [
+        "imageMessage", "videoMessage", "documentMessage", "stickerMessage",
+    ])
+    def test_everything_else_resolves_into_media(self, msg_type):
+        path = cached_media_path(msg_type, "ABC123")
+        assert path.endswith("ABC123.wzmedia")
+        assert "voice_messages" not in path
+
+    def test_the_composite_id_is_reduced_for_both(self):
+        composite = "false_120363151058129530@g.us_ABC123"
+        assert cached_media_path("audioMessage", composite).endswith("ABC123.msv")
+        assert cached_media_path("imageMessage", composite).endswith("ABC123.wzmedia")
+
+    def test_it_agrees_with_the_media_tabs_own_scan(self):
+        """local_media_cache_paths() answers the same question for the
+        downloaded/not-downloaded scan. The two must never drift: one says a
+        file is there and the other goes looking somewhere else."""
+        both = local_media_cache_paths("voice", "media", "ABC123")
+        assert cached_media_path("audioMessage", "ABC123").endswith(
+            both[0].split("voice")[-1].lstrip("\\/"))
+        assert cached_media_path("imageMessage", "ABC123").endswith(
+            both[1].split("media")[-1].lstrip("\\/"))
+
+
+class TestEveryReaderGoesThroughIt:
+    """A reader that resolves the path itself is the bug coming back. These are
+    the three that read a cached file and download it when it is missing."""
+
+    @pytest.mark.parametrize("method_name", [
+        "_on_menu_copy_file",     # Ctrl+C — the one that was broken
+        "_on_action_download",    # the Download button, same shape
+        "_save_message_media",    # Save As, the one that was already right
+    ])
+    def test_the_reader_uses_the_shared_resolver(self, method_name):
+        source = inspect.getsource(getattr(ConversationsPanel, method_name))
+        assert "cached_media_path(" in source, (
+            f"{method_name} must resolve its path through cached_media_path()"
+        )
+
+    @pytest.mark.parametrize("method_name", [
+        "_on_menu_copy_file", "_on_action_download", "_save_message_media",
+    ])
+    def test_the_reader_never_builds_a_cache_path_itself(self, method_name):
+        source = inspect.getsource(getattr(ConversationsPanel, method_name))
+        inline = re.search(
+            r'data_path\(\s*"(?:media|voice_messages)"\s*,\s*f"\{[^}]+\}\.'
+            r'(?:wzmedia|msv)"', source)
+        assert inline is None, (
+            f"{method_name} builds its own cache path ({inline.group(0)!r}); "
+            "that is exactly how Ctrl+C ended up looking in media/ for a file "
+            "written to voice_messages/"
+        )
+
+    def test_copy_no_longer_hardcodes_the_media_directory(self):
+        """The literal regression: `data_path("media", f"{msg_id}.wzmedia")`
+        with the raw id, for every message type."""
+        source = inspect.getsource(ConversationsPanel._on_menu_copy_file)
+        assert 'data_path("media"' not in source


### PR DESCRIPTION
Ctrl+C on an audio message put up

> Não foi possível baixar este arquivo de mídia. O link pode ter expirado ou o WPPConnect está indisponível.

for a voice note that had **played perfectly a second earlier**. Reported after v1.1 and reproduced locally.

## Why

Audio is not cached where the other media are. `handle_audio_message()` writes `voice_messages/<id>.msv`; `handle_media_message()` writes `media/<id>.wzmedia`. `_on_menu_copy_file()` hardcoded the second one, for every message type, and with the raw key id rather than the reduced one the rest of the app uses:

```python
media_path = data_path("media", f"{msg_id}.wzmedia")
```

The resulting failure is the worst available shape, because the file is right there on disk:

1. `_ensure_media_on_disk()` checks `media/<id>.wzmedia` — nothing there;
2. it correctly downloads via `handle_audio_message()`, which writes the `.msv` the caller is not looking at;
3. it re-checks `media/<id>.wzmedia` — still nothing;
4. it concludes the download failed and tells the user the link may have expired.

So an expired-link message about a file that was never missing, on a message the user can play. `is_ptt` was even computed at the top of the method and never used.

## The fix

One resolver, `cached_media_path()`, placed beside `local_media_cache_paths()` — which already states this rule for the Media tab's downloaded/not-downloaded scan. CLAUDE.md's warning is precisely this case: *"a second copy of that answer is how the filter starts disagreeing with whatever wrote the file."*

Three readers now share it:

| | before | after |
| --- | --- | --- |
| `_on_menu_copy_file` (Ctrl+C) | `media/` + raw id — **broken for audio** | shared resolver |
| `_on_action_download` (Download button) | `media/` + raw id — same two mistakes | shared resolver |
| `_save_message_media` (Save As) | correct, with its own copy of the rule | shared resolver |

## Tests

`tests/test_media_cache_path.py`: the id reduction (`false_<jid>_<id>` → `<id>`), audio resolving into `voice_messages/` and everything else into `media/`, agreement with `local_media_cache_paths()`, and — for each of the three readers — that it goes through the resolver and does not build a cache path itself. That last one is what stops the bug coming back: it fails on any reader that reintroduces `data_path("media", f"{id}.wzmedia")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)