### PR TITLE
Make force-reinstall fetch the newest server, and let the version gate run

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -7263,8 +7263,20 @@ class MainWindow(wx.Frame):
         if self.background_mode:
             return
 
-        dist_main = resource_path("api", "dist", "main.js")
-        if not os.path.isfile(dist_main):
+        # dist/server.js, which is what `npm run build` actually produces and
+        # what package.json's start script runs.
+        #
+        # This read `dist/main.js` for as long as the check has existed, and
+        # WPPConnect Server has never built a file by that name — so the guard
+        # was always false, the method always returned here, and the whole
+        # outdated-version prompt below has never run for anyone. Found by a
+        # user who set client/wpp_minimum_version.txt to a newer release,
+        # restarted, and watched WinZapp come up on the old one without a word.
+        #
+        # Note what that means for the code below: it is being reached for the
+        # first time now, not merely fixed.
+        dist_server = resource_path("api", "dist", "server.js")
+        if not os.path.isfile(dist_server):
             return  # API not installed yet — setup dialog will handle it
 
         minimum  = self._read_wpp_minimum_version()
@@ -7297,13 +7309,25 @@ class MainWindow(wx.Frame):
         if result == RESULT_CONTINUE:
             return  # Proceed with the outdated version — user's choice
 
-        # RESULT_UPDATE: re-download and rebuild using the minimum-version tag
+        # RESULT_UPDATE: re-download and rebuild using the minimum-version tag.
+        #
+        # As a TAG, not the bare version. `minimum` is what
+        # read_homologated_wpp_version() returns — "2.10.18" — while the
+        # release is tagged "v2.10.18", and ApiSetupDialog drops forced_tag
+        # straight into .../archive/refs/tags/{tag}.zip. Passing the bare
+        # number built a 404 URL, so this button could never have worked.
+        # Nobody found out because the guard at the top of this method named a
+        # file WPPConnect Server does not build, so nothing below it ever ran.
+        # homologated_wpp_tag() is the shared helper every other install path
+        # already uses for exactly this conversion.
+        from core.wpp_runtime import homologated_wpp_tag
         from ui.dialogs.api_setup import ApiSetupDialog
+        minimum_tag = homologated_wpp_tag(resource_path("wpp_minimum_version.txt"))
         def _show_update_dlg():
             update_dlg = ApiSetupDialog(
                 self,
                 title_override=self.i18n.t("api_update_dialog_title"),
-                forced_tag=minimum,
+                forced_tag=minimum_tag or f"v{minimum.lstrip('vV')}",
             )
             res = update_dlg.ShowModal()
             update_dlg.Destroy()

--- a/client/updater.py
+++ b/client/updater.py
@@ -113,6 +113,20 @@ _PRE_ORDER = {"dev": 0, "alpha": 1, "beta": 2, "": 3}
 _VER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)\.(\d+)(dev|alpha|beta)?$", re.IGNORECASE)
 
 
+def _version_is_older(candidate: str, reference: str) -> bool:
+    """Is `candidate` strictly older than `reference`, as release tags?
+
+    Used only to stop force-reinstall going backwards. Unparseable input
+    answers False — "I cannot tell" must not become "downgrade", and the
+    caller's fallback is the homologated tag either way.
+    """
+    try:
+        from packaging.version import Version
+        return Version(candidate.lstrip("vV")) < Version(reference.lstrip("vV"))
+    except Exception:
+        return False
+
+
 def parse_version(v: str):
     """Parse "1.2.3.4suffix" -> ((1,2,3,4), suffix) or None on failure."""
     if not v:
@@ -1258,12 +1272,57 @@ class WppUpdateChecker:
     # ── Internal ──────────────────────────────────────────────────────────────
 
     @staticmethod
-    def _fetch_latest_tag() -> str:
+    def _homologated_or_latest_tag() -> str:
+        """The tag the PERIODIC check compares against: the homologated server
+        release, falling back to GitHub's latest when none is bundled.
+
+        Deliberately not "whatever is newest". WinZapp ships a homologated pair
+        (see tests/test_wpp_homologated_runtime_pin.py), and prompting every
+        user onto every wppconnect-server release the day it appears is how a
+        patch set that no longer matches reaches people — which is the failure
+        wppconnect 2.3.2 produced. Raising client/wpp_minimum_version.txt is the
+        deliberate act that offers an update.
+
+        Renamed from _fetch_latest_tag(): it never fetched the latest anything
+        when a homologated tag was bundled, which is always in a release build,
+        and the force-reinstall path below trusted the name.
+        """
         homologated = homologated_wpp_tag(resource_path("wpp_minimum_version.txt"))
         if homologated:
             return homologated
         from ui.dialogs.api_setup import fetch_latest_wpp_tag
         return fetch_latest_wpp_tag()
+
+    @staticmethod
+    def _newest_available_tag() -> str:
+        """The tag FORCE-REINSTALL uses: genuinely the newest release.
+
+        Both this method's caller and the menu item that reaches it have always
+        documented "always fetches whatever is currently the latest release,
+        regardless of version". They called _fetch_latest_tag(), which returned
+        the homologated tag whenever one was bundled — so a user forcing a
+        reinstall to move off a stale server reinstalled the exact same version,
+        repeatedly, with the dialog cheerfully naming it. Reported live: three
+        forced reinstalls, each "successful", package.json unchanged at 2.10.16.
+
+        Floored at the homologated tag rather than taken raw: this must be able
+        to move a user forward, never backward, and a GitHub hiccup answering
+        with something older must not silently downgrade an install below the
+        version WinZapp was built against.
+        """
+        from ui.dialogs.api_setup import fetch_latest_wpp_tag
+        latest = fetch_latest_wpp_tag()
+        homologated = homologated_wpp_tag(resource_path("wpp_minimum_version.txt"))
+        if not latest:
+            return homologated
+        if homologated and _version_is_older(latest, homologated):
+            logging.warning(
+                "[WppUpdateChecker] The latest published release (%s) is older "
+                "than the homologated one (%s) — reinstalling the homologated "
+                "tag instead of going backwards.", latest, homologated,
+            )
+            return homologated
+        return latest
 
     def _check_once(self):
         logging.info("[WppUpdateChecker] Checking for wppconnect-server updates...")
@@ -1275,7 +1334,7 @@ class WppUpdateChecker:
             self._schedule_retry()
             return
 
-        tag = self._fetch_latest_tag()
+        tag = self._homologated_or_latest_tag()
         if not tag:
             self._schedule_retry()
             return
@@ -1329,7 +1388,7 @@ class WppUpdateChecker:
 
     def _force_reinstall_worker(self):
         logging.info("[WppUpdateChecker] Force-reinstall requested — fetching latest release tag...")
-        tag = self._fetch_latest_tag()
+        tag = self._newest_available_tag()
         if not tag:
             wx.CallAfter(
                 wx.MessageBox,

--- a/tests/test_wpp_version_gate_and_reinstall.py
+++ b/tests/test_wpp_version_gate_and_reinstall.py
@@ -1,0 +1,135 @@
+"""Two user-visible promises about the WPPConnect version, both broken.
+
+Reported together by a user trying to move an install onto a newer
+wppconnect-server:
+
+1. **Force reinstall reinstalled the same version.** Help > "Forçar
+   reinstalação da WPPConnect" documents, in two places, "always fetches
+   whatever is currently the latest release, regardless of version". It called
+   `_fetch_latest_tag()`, which returned the *homologated* tag whenever one was
+   bundled — which is always, in a release build. Three forced reinstalls, each
+   reported successful, `package.json` unchanged at 2.10.16.
+
+2. **The outdated-version warning never appeared.** Raising
+   `client/wpp_minimum_version.txt` above the installed version produced no
+   prompt at all: WinZapp came up on the old server without a word.
+   `ensure_wpp_version()` guarded on `api/dist/main.js`, and WPPConnect Server
+   has never built a file by that name — `npm run build` produces
+   `dist/server.js`. The guard was always false, so the method always returned
+   on its first statement and the entire prompt has never run for anyone.
+
+Fixing (2) exposed a third defect underneath it, which is the reason a dead
+code path is worth being suspicious of rather than merely fixing: the prompt's
+own "Update now" button passed the bare version ("2.10.18") as
+ApiSetupDialog's forced_tag, which goes straight into
+`.../archive/refs/tags/{tag}.zip`. The release is tagged "v2.10.18", so that
+URL is a 404. The button could never have worked.
+"""
+
+import inspect
+import re
+
+import pytest
+
+import main
+import updater
+from main import MainWindow
+
+
+class TestForceReinstallGoesToTheNewestRelease:
+    def test_it_asks_for_the_newest_available_tag(self):
+        source = inspect.getsource(updater.WppUpdateChecker._force_reinstall_worker)
+        assert "_newest_available_tag()" in source, (
+            "force reinstall must resolve the newest release, not the "
+            "homologated one — reinstalling the same version is the bug"
+        )
+
+    def test_the_newest_lookup_actually_reaches_github(self):
+        source = inspect.getsource(updater.WppUpdateChecker._newest_available_tag)
+        assert "fetch_latest_wpp_tag()" in source
+
+    def test_it_never_downgrades_below_the_homologated_release(self, monkeypatch):
+        """It must be able to move a user forward, never backward — a GitHub
+        hiccup answering with something older must not silently downgrade an
+        install below what WinZapp was built against."""
+        monkeypatch.setattr(updater, "homologated_wpp_tag", lambda _p: "v2.10.18")
+        monkeypatch.setattr(
+            "ui.dialogs.api_setup.fetch_latest_wpp_tag", lambda: "v2.10.16")
+        assert updater.WppUpdateChecker._newest_available_tag() == "v2.10.18"
+
+    def test_a_newer_release_wins(self, monkeypatch):
+        monkeypatch.setattr(updater, "homologated_wpp_tag", lambda _p: "v2.10.16")
+        monkeypatch.setattr(
+            "ui.dialogs.api_setup.fetch_latest_wpp_tag", lambda: "v2.10.18")
+        assert updater.WppUpdateChecker._newest_available_tag() == "v2.10.18"
+
+    def test_an_unreachable_github_falls_back_to_the_homologated_tag(self, monkeypatch):
+        monkeypatch.setattr(updater, "homologated_wpp_tag", lambda _p: "v2.10.16")
+        monkeypatch.setattr("ui.dialogs.api_setup.fetch_latest_wpp_tag", lambda: "")
+        assert updater.WppUpdateChecker._newest_available_tag() == "v2.10.16"
+
+    def test_the_periodic_check_still_compares_against_the_homologated_release(self):
+        """Deliberately unchanged. Prompting every user onto every
+        wppconnect-server release the day it appears is how a patch set that no
+        longer matches reaches people — which is what 2.3.2 did. Raising
+        wpp_minimum_version.txt stays the deliberate act."""
+        source = inspect.getsource(updater.WppUpdateChecker._check_once)
+        assert "_homologated_or_latest_tag()" in source
+        assert "_newest_available_tag()" not in source
+
+
+class TestVersionComparisonForTheFloor:
+    @pytest.mark.parametrize("candidate, reference, expected", [
+        ("v2.10.16", "v2.10.18", True),
+        ("2.10.16", "v2.10.18", True),
+        ("v2.10.18", "v2.10.18", False),
+        ("v2.10.19", "v2.10.18", False),
+        ("v2.11.0", "v2.10.18", False),
+    ])
+    def test_ordering(self, candidate, reference, expected):
+        assert updater._version_is_older(candidate, reference) is expected
+
+    @pytest.mark.parametrize("candidate, reference", [
+        ("not-a-version", "v2.10.18"),
+        ("v2.10.18", ""),
+        ("", "v2.10.18"),
+    ])
+    def test_unparseable_input_never_means_downgrade(self, candidate, reference):
+        """"I cannot tell" must not become "go backwards"."""
+        assert updater._version_is_older(candidate, reference) is False
+
+
+class TestTheStartupGateCanActuallyRun:
+    @staticmethod
+    def _source():
+        return inspect.getsource(MainWindow.ensure_wpp_version)
+
+    def test_it_no_longer_guards_on_a_file_that_is_never_built(self):
+        """`npm run build` produces dist/server.js. dist/main.js has never
+        existed, so this guard was always false and the whole method returned
+        on its first statement."""
+        source = self._source()
+        assert '"main.js"' not in source
+
+    def test_it_guards_on_the_built_entry_point(self):
+        source = self._source()
+        assert re.search(r'resource_path\(\s*"api",\s*"dist",\s*"server\.js"\s*\)',
+                         source)
+
+    def test_the_update_button_passes_a_real_git_tag(self):
+        """forced_tag goes straight into .../archive/refs/tags/{tag}.zip. The
+        bare version built a 404, which nobody could discover while the guard
+        above kept this code unreachable."""
+        source = self._source()
+        assert "homologated_wpp_tag(" in source
+        assert not re.search(r"forced_tag\s*=\s*minimum\s*,", source)
+
+
+class TestTheGuardMatchesWhatTheInstallerBuilds:
+    def test_the_setup_dialog_uses_the_same_file_as_its_built_marker(self):
+        """Both answer "is the API installed and built". Two different files
+        for one question is how the startup gate ended up watching a name that
+        is never produced."""
+        from ui.dialogs import api_setup
+        source = inspect.getsource(api_setup.ApiSetupDialog._run_setup)
+        assert '"dist", "server.js"' in source


### PR DESCRIPTION
Two promises the code did not keep, reported together by a user trying to move an install onto wppconnect-server 2.10.18.

## 1. Force reinstall reinstalled the same version

Help > *"Forçar reinstalação da WPPConnect"* documents, in **two** places, "always fetches whatever is currently the latest release, regardless of version". It called `_fetch_latest_tag()`:

```python
@staticmethod
def _fetch_latest_tag() -> str:
    homologated = homologated_wpp_tag(resource_path("wpp_minimum_version.txt"))
    if homologated:
        return homologated          # <- always, in a release build
    return fetch_latest_wpp_tag()
```

Named for the latest, returned the homologated. Reported live: three forced reinstalls, each finishing successfully and reconnecting fine, `package.json` unchanged at 2.10.16.

Split in two, each named for what it does:

- **`_newest_available_tag()`** — force reinstall. Genuinely resolves GitHub's latest, **floored at the homologated release**: this must move a user forward, never backward, and a GitHub hiccup answering with something older must not silently downgrade an install below what WinZapp was built against.
- **`_homologated_or_latest_tag()`** — the periodic check, behaviour unchanged and deliberately so. Prompting every user onto every upstream release the day it appears is how a patch set that no longer matches reaches people, which is precisely what 2.3.2 did. Raising `wpp_minimum_version.txt` stays the deliberate act.

## 2. The outdated-version warning has never appeared — for anyone

```python
dist_main = resource_path("api", "dist", "main.js")
if not os.path.isfile(dist_main):
    return  # API not installed yet
```

`npm run build` produces **`dist/server.js`**. WPPConnect Server has never built a `dist/main.js`. So this guard was always false, `ensure_wpp_version()` always returned on its first statement, and the whole outdated-version prompt has never run on any install since it was written.

That is why raising `client/wpp_minimum_version.txt` to 2.10.18 did nothing: WinZapp came up on 2.10.16 without a word.

## 3. …and what was hiding underneath it

Fixing the guard makes the code below it reachable **for the first time**, so it deserved reading rather than trusting. Its "Update now" button did:

```python
ApiSetupDialog(..., forced_tag=minimum)   # minimum == "2.10.18"
```

`forced_tag` goes straight into `.../archive/refs/tags/{tag}.zip`, and the release is tagged **`v2.10.18`** — a 404. The button could never have worked. It now converts through `homologated_wpp_tag()`, the shared helper every other install path already uses for exactly this.

## Tests

`tests/test_wpp_version_gate_and_reinstall.py` — force reinstall resolves the newest tag and never downgrades, unparseable versions never mean "go backwards", the periodic check still compares against the homologated release, the gate no longer names a file that is never built, and the update button passes a real git tag. Plus one that pins the gate's built-marker to the same file the installer itself uses, since two different answers to "is the API built" is how this happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)