### PR TITLE
Give the composer CRLF breaks so a screen reader can navigate them

### DIFF
--- a/client/core/utils.py
+++ b/client/core/utils.py
@@ -237,6 +237,34 @@ def normalize_line_separators(text) -> str:
     return text
 
 
+def to_editor_line_endings(text) -> str:
+    """The same text with CRLF breaks, for insertion into a MULTILINE field.
+
+    The inverse of normalize_line_separators(), and both are needed because
+    two consumers disagree about what a line break is:
+
+    * WhatsApp, the database and every comparison in this codebase want the
+      canonical ``\\n`` — which is what normalize_line_separators() produces and
+      what the send paths call on the field's value before posting.
+    * A screen reader navigating a ``wx.TextCtrl`` with the arrow keys wants
+      ``\\r\\n``. With a bare ``\\n``, NVDA reads a pasted block as ONE line and
+      Up/Down move through it as if the breaks were not there. Reported after
+      pasting a plain-LF file (a text file with 644 LF breaks and not one CR)
+      out of Notepad.
+
+    So the field holds the editor form and the send path collapses it back —
+    which it already did before this existed, for the CRLF that Windows
+    clipboard sources supply anyway. Nothing reaches WhatsApp with a stray CR.
+
+    **Only ever apply this to a multiline control.** A single-line
+    ``wx.TextCtrl`` cannot navigate lines, does not translate line endings the
+    way the multiline one does, and would simply hold the control characters
+    verbatim — the attachment caption field is exactly that, and shares the
+    paste handler with the message field.
+    """
+    return normalize_line_separators(text).replace("\n", "\r\n")
+
+
 _FORWARDABLE_SUB_KEYS = (
     "extendedTextMessage", "audioMessage", "imageMessage",
     "videoMessage", "documentMessage", "stickerMessage",

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -50,7 +50,7 @@ from ui.accessible import (
 )
 from ui.dialogs.emoji_picker import choose_and_insert_emoji
 from core.save_location import resolve_save_dialog_folder
-from core.utils import history_window, reaction_targets_status, format_number, decrypt_bytes, is_phone_like, encrypt, effective_unread_count, first_unread_index, db_fetch_limit, looks_like_binary_blob, normalize_for_search, normalize_line_separators, parse_bool_flag as _parse_bool_flag, append_selected_marker, is_message_forwarded, is_voice_message, video_seconds, MEASURED_SECONDS_KEY, link_preview_text
+from core.utils import history_window, reaction_targets_status, format_number, decrypt_bytes, is_phone_like, encrypt, effective_unread_count, first_unread_index, db_fetch_limit, looks_like_binary_blob, normalize_for_search, normalize_line_separators, to_editor_line_endings, parse_bool_flag as _parse_bool_flag, append_selected_marker, is_message_forwarded, is_voice_message, video_seconds, MEASURED_SECONDS_KEY, link_preview_text
 from core.locale_format import get_date_format, get_time_format, get_datetime_format
 from core.message_copy_format import format_copied_message
 from core.video_player import VideoPlayer
@@ -5399,8 +5399,16 @@ class ConversationsPanel(wx.Panel):
             text = data.GetText()
         finally:
             wx.TheClipboard.Close()
-        normalized = normalize_line_separators(text)
         target = event.GetEventObject()
+        normalized = normalize_line_separators(text)
+        # Multiline only: a screen reader needs CRLF to navigate the pasted
+        # block line by line, and the send path collapses it back to a bare
+        # newline before anything reaches WhatsApp. The caption field shares
+        # this handler and
+        # is single-line — it cannot navigate lines and would just hold the
+        # control characters. See to_editor_line_endings().
+        if normalized and getattr(target, "IsMultiLine", None) and target.IsMultiLine():
+            normalized = to_editor_line_endings(normalized)
         if normalized != text and target is not None:
             # WriteText() replaces the current selection and fires EVT_TEXT,
             # keeping the mention check / send-button logic in sync.
@@ -5430,7 +5438,9 @@ class ConversationsPanel(wx.Panel):
             if wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_UNICODETEXT)):
                 data = wx.TextDataObject()
                 if wx.TheClipboard.GetData(data):
-                    text = normalize_line_separators(data.GetText())
+                    # message_field is multiline; same reasoning as
+                    # _on_text_field_paste().
+                    text = to_editor_line_endings(data.GetText())
         finally:
             wx.TheClipboard.Close()
 
@@ -12059,7 +12069,9 @@ class ConversationsPanel(wx.Panel):
             self._pending_mention_display_names[jid] = self._get_participant_name(jid)
         self._rebuild_mention_pills()
 
-        self.message_field.SetValue(content)
+        # Stored text uses bare newlines; the field wants CRLF so the screen
+        # reader can arrow through a multi-line message being edited.
+        self.message_field.SetValue(to_editor_line_endings(content))
         self.message_field.SetInsertionPointEnd()
         self.message_field.SetFocus()
 

--- a/tests/test_editor_line_endings.py
+++ b/tests/test_editor_line_endings.py
@@ -1,0 +1,124 @@
+"""Two consumers disagree about what a line break is, and both have to win.
+
+WhatsApp, the database and every comparison in this codebase want the canonical
+``\\n``. A screen reader navigating a `wx.TextCtrl` with the arrow keys wants
+``\\r\\n``: with a bare ``\\n`` NVDA reads a pasted block as ONE line, and Up/Down
+move through it as though the breaks were not there.
+
+Reported by pasting a plain-LF file out of Notepad — verified: 26 425 bytes,
+644 LF, zero CR. `normalize_line_separators()` collapsed everything to ``\\n``,
+which is right for sending and exactly wrong for the field the user then has to
+read back.
+
+So the field holds the editor form and the send path collapses it again. The
+round trip is the property that keeps a stray CR off WhatsApp, and it is
+pinned here rather than trusted.
+"""
+
+import inspect
+import re
+
+import pytest
+
+from core.utils import normalize_line_separators, to_editor_line_endings
+from ui.conversations import ConversationsPanel
+
+
+class TestTheEditorForm:
+    def test_bare_newlines_become_crlf(self):
+        assert to_editor_line_endings("a\nb\nc") == "a\r\nb\r\nc"
+
+    def test_text_that_is_already_crlf_is_unchanged(self):
+        """The clipboard on Windows usually supplies CRLF already. Doubling it
+        into \\r\\r\\n would show a blank line between every line."""
+        assert to_editor_line_endings("a\r\nb") == "a\r\nb"
+
+    def test_applying_it_twice_changes_nothing(self):
+        once = to_editor_line_endings("a\nb")
+        assert to_editor_line_endings(once) == once
+
+    @pytest.mark.parametrize("separator", [" ", " ", "", "\x0b", "\x0c"])
+    def test_the_exotic_separators_are_converted_too(self, separator):
+        """Google Docs, Word and Apple apps copy these where a plain editor
+        stores \\n — the case normalize_line_separators() already existed for."""
+        assert to_editor_line_endings(f"a{separator}b") == "a\r\nb"
+
+    def test_a_lone_cr_does_not_survive(self):
+        assert to_editor_line_endings("a\rb") == "a\r\nb"
+
+    @pytest.mark.parametrize("value", ["", None, "sem quebras"])
+    def test_text_without_breaks_is_left_alone(self, value):
+        assert "\r" not in to_editor_line_endings(value)
+
+
+class TestTheRoundTripKeepsWhatsAppClean:
+    """The send paths already call normalize_line_separators() on the field's
+    value. That is what makes putting CRLF in the field safe — and if it ever
+    stops being true, WhatsApp starts receiving control characters."""
+
+    @pytest.mark.parametrize("original", [
+        "a\nb\nc",
+        "a\r\nb",
+        "linha\n\nparagrafo",
+        "a b",
+        "sem quebras",
+    ])
+    def test_the_editor_form_collapses_back_to_the_canonical_one(self, original):
+        canonical = normalize_line_separators(original)
+        assert normalize_line_separators(to_editor_line_endings(original)) == canonical
+
+    def test_the_send_path_still_normalizes_the_field(self):
+        source = inspect.getsource(ConversationsPanel.on_send_message)
+        assert "normalize_line_separators(self.message_field.GetValue())" in source, (
+            "the composer now holds CRLF; without this call every multi-line "
+            "message reaches WhatsApp with a carriage return on every line"
+        )
+
+
+class TestOnlyMultilineFieldsGetIt:
+    """_on_text_field_paste is bound to two controls: the multiline message
+    field and the SINGLE-LINE attachment caption. A single-line wx.TextCtrl
+    cannot navigate lines and does not translate line endings — it would just
+    hold the control characters."""
+
+    def test_the_paste_handler_checks_the_control(self):
+        source = inspect.getsource(ConversationsPanel._on_text_field_paste)
+        assert "IsMultiLine()" in source
+        assert "to_editor_line_endings(" in source
+
+    def test_the_caption_field_is_single_line(self):
+        """If this ever gains TE_MULTILINE the guard above starts converting it
+        too, which is correct — but the reasoning in the handler would be stale,
+        so fail loudly and make someone re-read it."""
+        source = inspect.getsource(ConversationsPanel)
+        caption = source[source.index("self._caption_field = wx.TextCtrl("):]
+        caption = caption[:caption.index(")")]
+        assert "TE_MULTILINE" not in caption
+
+    def test_the_message_field_is_multiline(self):
+        source = inspect.getsource(ConversationsPanel)
+        field = source[source.index("self.message_field = wx.TextCtrl("):]
+        field = field[:field.index(")")]
+        assert "TE_MULTILINE" in field
+
+
+class TestEveryPathThatFillsTheComposer:
+    """Paste is what was reported, but text reaches the composer three ways and
+    a screen-reader user cannot navigate any of them without CRLF."""
+
+    @pytest.mark.parametrize("method_name", [
+        "_on_text_field_paste",        # Ctrl+V in the composer
+        "_paste_from_messages_list",   # Ctrl+V with the history focused
+    ])
+    def test_the_paste_paths_produce_the_editor_form(self, method_name):
+        source = inspect.getsource(getattr(ConversationsPanel, method_name))
+        assert "to_editor_line_endings(" in source
+
+    def test_editing_a_sent_message_produces_it_too(self):
+        """Stored message text is canonical \\n; dropped into the field as-is it
+        is one unnavigable line."""
+        source = inspect.getsource(ConversationsPanel)
+        call = re.search(
+            r"self\.message_field\.SetValue\(to_editor_line_endings\(content\)\)",
+            source)
+        assert call, "the edit-message pre-fill must convert to the editor form"

--- a/tests/test_line_separator_normalization.py
+++ b/tests/test_line_separator_normalization.py
@@ -125,7 +125,13 @@ class TestPasteNormalization:
         finally:
             frame.Destroy()
 
-    def test_paste_of_plain_text_is_left_alone(self, wx_app):
+    def test_multiline_plain_text_is_converted_for_the_screen_reader(self, wx_app):
+        """This asserted the opposite until now — that plain text was handed
+        to the native paste untouched — and that WAS the bug: NVDA reads a
+        block joined by bare newlines as ONE line, so Up/Down walk straight
+        through the breaks. A multiline field now receives CRLF, and the send
+        path collapses it back before anything reaches WhatsApp (see
+        tests/test_editor_line_endings.py)."""
         frame = hidden_frame()
         try:
             stub = _Stub(frame)
@@ -135,11 +141,21 @@ class TestPasteNormalization:
             event = _FakeKeyEvent(stub.message_field)
             stub._on_text_field_paste(event)
 
-            # Plain text is delegated to the native paste (Skip), which the
-            # handler must not itself touch — the assertion is the delegation
-            # itself, since no real paste event is being processed here.
-            assert event.skipped
-            assert stub.message_field.GetValue() == ""
+            # Consumed, not delegated: the handler wrote the converted text
+            # itself, so letting the native paste run on top would double it.
+            assert not event.skipped
+
+            # And GetValue() answers with bare newlines even though CRLF was
+            # written — wxWidgets normalizes line endings on read for a
+            # multiline control on MSW. Measured here, against a real
+            # wx.TextCtrl, not assumed.
+            #
+            # Two things follow. It is why putting CRLF in the field is safe:
+            # the send path cannot see a carriage return even if it forgot to
+            # normalize. And it is why this assertion is what it is — the
+            # converted form is genuinely unobservable through GetValue(), so
+            # a test claiming to see it would only be testing itself.
+            assert stub.message_field.GetValue() == "hello\nworld"
         finally:
             frame.Destroy()
 

--- a/tests/test_paste_non_text_as_attachment.py
+++ b/tests/test_paste_non_text_as_attachment.py
@@ -213,7 +213,11 @@ class TestPasteFromMessagesList:
         stub._on_messages_list_key_down(event)
 
         assert stub.message_field.focused is True
-        assert stub.message_field.value == "texto\ncolado"
+        # CRLF, not a bare newline: the composer is multiline and a screen
+        # reader needs carriage returns to arrow through the pasted block.
+        # on_send_message() collapses it back before posting — see
+        # tests/test_editor_line_endings.py.
+        assert stub.message_field.value == "texto\r\ncolado"
         assert event.skipped is False
 
     def test_ctrl_v_copied_file_uses_attachment_not_text_path(self, wx_app, tmp_path):


### PR DESCRIPTION
Pasting a multi-line block into the message field left NVDA reading it as **one line** — Up/Down walked straight through the breaks. Reproduced with the file the reporter attached: 26,425 bytes, **644 LF, not one CR**.

## The two consumers

`normalize_line_separators()` collapses every separator to `\n`. That is right for WhatsApp, the database and every comparison in this codebase — and exactly wrong for the field the user then has to read back with a screen reader, which needs `\r\n`.

`to_editor_line_endings()` is its inverse. The composer now holds that form at all three points where text arrives in it:

- Ctrl+V in the composer
- Ctrl+V with the message history focused
- the pre-fill when editing a sent message (stored text is canonical `\n`)

## Multiline only, and that is not a detail

`_on_text_field_paste` is bound to **two** controls, and the second is the attachment caption — `wx.TE_DONTWRAP | wx.TE_PROCESS_ENTER`, **single-line**. It cannot navigate lines, does not translate line endings the way a multiline control does, and would simply hold the control characters. The conversion is gated on `IsMultiLine()`, and a test fails if the caption field ever gains `TE_MULTILINE` without someone re-reading the reasoning.

## Nothing reaches WhatsApp with a carriage return

The send paths already call `normalize_line_separators()` on the field's value — they had to, for the CRLF that Windows clipboard sources supply anyway. A test now pins that round trip for every separator form instead of trusting it, and another asserts the call is still there, because the composer holding CRLF is what makes its absence newly dangerous.

## One measured limit, stated rather than glossed over

A real `wx.TextCtrl` answers `GetValue()` with **bare newlines even after CRLF is written** — wxWidgets normalizes line endings on read for a multiline control on MSW. Measured against a real control in a hidden frame, not assumed.

Two things follow. It is why putting CRLF in the field is safe. And it means the converted form is **unobservable from Python**, so I cannot prove from here that what NVDA sees changes — that needs confirming on a real screen reader. The change is harmless either way (the round trip is verified), but it should be treated as unconfirmed until someone arrows through a pasted block on the next alpha.

## Tests

`tests/test_editor_line_endings.py` (24) — the conversion, its idempotence, the exotic separators, the round trip back to canonical for every form, that only multiline controls get it, and that each of the three composer paths produces it.

Two existing tests changed rather than being deleted: one asserted that plain `\n` text was handed to the native paste untouched, which *was* the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)