### PR TITLE
Report the transfer that actually takes time, in both directions

### DIFF
--- a/client/api_patches/src/controller/messageController.ts
+++ b/client/api_patches/src/controller/messageController.ts
@@ -131,21 +131,39 @@ async function watchMediaUpload(req: Request, uploadId: string, contact: string)
   await page.evaluate(({ uploadId, contact }: any) => {
     const onMessage = (message: any) => {
       if (!message?.isSentByMe || message?.to?.toString?.() !== contact) return;
+      // This used to emit ONLY when Number(progressiveStage) was finite, and
+      // on a current stack that is never: `progressiveStage` does not appear
+      // anywhere in @wppconnect/wa-js 4.6.0 — grepped, not guessed — and
+      // `mediaData.mediaStage`, the field wa-js itself listens to, carries a
+      // lifecycle STRING (its own handler logs "message file <id> is
+      // <stage>"). Number("ENCRYPT") is NaN, so the guard rejected every
+      // event and the upload gauge sat at zero until the send finished and
+      // the client forced it to 1.0. The bar was inert, not merely
+      // inaccurate.
+      //
+      // So: emit whatever arrives, and let the client decide what it means.
+      // The stage NAME goes across as well as any numeric value, because
+      // WhatsApp's stage vocabulary is its own and versioned — hardcoding a
+      // stage->fraction table here would be inventing semantics we cannot
+      // verify, and would rot silently the next time WhatsApp renames one.
+      // The client advances monotonically on each distinct stage it has not
+      // seen before, so an unrecognised vocabulary still moves the bar.
       const report = () => {
-        const stage = message.mediaData?.progressiveStage;
-        const numeric = Number(stage);
-        if (Number.isFinite(numeric)) {
-          (window as any).__winzappMediaProgress({
-            uploadId,
-            progress: numeric > 1 ? Math.min(numeric, 100) / 100 : numeric,
-          });
-        }
+        const stage = message.mediaData?.mediaStage;
+        const legacy = message.mediaData?.progressiveStage;
+        const numeric = Number(legacy);
+        (window as any).__winzappMediaProgress({
+          uploadId,
+          stage: stage === undefined || stage === null ? null : String(stage),
+          // Kept because it costs nothing and is the only real percentage
+          // available on any build that does expose it.
+          progress: Number.isFinite(numeric)
+            ? numeric > 1
+              ? Math.min(numeric, 100) / 100
+              : numeric
+            : null,
+        });
       };
-      // WA-JS' own sendFileMessage() uses mediaStage as the upload
-      // lifecycle signal.  progressiveStage still exists on MediaDataModel and
-      // can carry a numeric fraction on some WhatsApp builds, so listen to both:
-      // mediaStage guarantees that report() is re-run as the upload advances,
-      // while progressiveStage preserves the real numeric value where available.
       message.on('change:mediaData.mediaStage', report);
       message.on('change:mediaData.progressiveStage', report);
       report();

--- a/client/api_patches/src/controller/sessionController.ts
+++ b/client/api_patches/src/controller/sessionController.ts
@@ -644,6 +644,85 @@ export async function downloadMediaByMessage(req: Request, res: Response) {
 }
 
 /**
+ * Download a message's media while reporting real progress, then decrypt it.
+ *
+ * `client.decryptFile()` is a black box: one axios GET of the whole file from
+ * WhatsApp's CDN, then `magix()` to decrypt. Nothing observes the bytes, so
+ * WinZapp's download gauge had nothing to watch but the localhost hop that
+ * follows — which is the *fast* part. The bar sat at 0% for the entire real
+ * wait and then flashed to 100% as the finished file crossed a loopback
+ * socket. Users noticed, and they were right.
+ *
+ * This is the same two steps with the download counted. It reaches into
+ * wppconnect's own decrypt helper for `makeOptions`/`magix` rather than
+ * reimplementing either: that file is already one WinZapp patches by name
+ * (api_patches/decrypt.js), so the coupling exists and the exact-version pin
+ * on @wppconnect-team/wppconnect is what keeps it honest.
+ *
+ * Every failure falls back to `client.decryptFile()`. A progress bar is worth
+ * exactly nothing if wanting one can cost the download.
+ */
+async function downloadMediaWithProgress(
+  req: Request,
+  client: any,
+  message: any
+): Promise<Buffer> {
+  const progressId = req.body?.progressId;
+  const mediaUrl = message.clientUrl || message.deprecatedMms3Url;
+  if (!mediaUrl) return await client.decryptFile(message);
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const decrypt = require('@wppconnect-team/wppconnect/dist/api/helpers/decrypt');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const axios = require('axios').default;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    // Same two internals whatsapp.js's own decryptFile() uses, by the same
+    // paths — verified importable against the pinned runtime rather than
+    // assumed from the source.
+    const ua = require('@wppconnect-team/wppconnect/dist/config/WAuserAgente');
+    if (typeof decrypt?.magix !== 'function' ||
+        typeof decrypt?.makeOptions !== 'function') {
+      return await client.decryptFile(message);
+    }
+
+    const options = decrypt.makeOptions(ua?.useragentOverride);
+    let lastSent = 0;
+    if (progressId) {
+      // Throttled to whole percent AND to a minimum interval: a 200 MB file
+      // produces thousands of progress events, and every one of them would be
+      // a Socket.IO frame plus a wx.CallAfter on the UI thread of a client
+      // whose screen reader is already announcing the value.
+      options.onDownloadProgress = (event: any) => {
+        const total = Number(event?.total) || Number(message.size) || 0;
+        const loaded = Number(event?.loaded) || 0;
+        if (total <= 0 || loaded <= 0) return;
+        const fraction = Math.min(1, loaded / total);
+        const now = Date.now();
+        if (fraction < 1 && now - lastSent < 250) return;
+        lastSent = now;
+        req.io?.emit('media-download-progress', {
+          progressId,
+          progress: fraction,
+          session: client.session,
+        });
+      };
+    }
+
+    const response = await axios.get(String(mediaUrl).trim(), options);
+    if (response.status !== 200) return await client.decryptFile(message);
+    const buffer = Buffer.from(response.data, 'binary');
+    return decrypt.magix(buffer, message.mediaKey, message.type, message.size);
+  } catch (progressErr) {
+    req.logger.warn(
+      `[getMediaByMessage] progress-reporting download failed, falling back to ` +
+        `decryptFile: ${progressErr}`
+    );
+    return await client.decryptFile(message);
+  }
+}
+
+/**
  * Send a decrypted media buffer back, as raw bytes when the caller can take
  * them and as the historical base64 JSON otherwise.
  *
@@ -857,7 +936,7 @@ export async function getMediaByMessage(req: Request, res: Response) {
     }
 
     try {
-      const buffer = await client.decryptFile(message);
+      const buffer = await downloadMediaWithProgress(req, client, message);
       return sendMediaBuffer(req, res, buffer, message.mimetype);
     } catch (decryptErr) {
       req.logger.error(
@@ -896,7 +975,7 @@ export async function getMediaByMessage(req: Request, res: Response) {
           req.logger.info(
             `Found fresh message in browser for ${cleanMsgId}, attempting decryption...`
           );
-          const buffer = await client.decryptFile(freshMessage);
+          const buffer = await downloadMediaWithProgress(req, client, freshMessage);
           return sendMediaBuffer(req, res, buffer, freshMessage.mimetype);
         } catch (freshDecryptErr) {
           req.logger.error(

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -158,6 +158,7 @@ class WebSocketClient:
         self.sio.on("messages.update", self.on_messages_update)
         self.sio.on("onreactionmessage", self.on_wpp_reaction)
         self.sio.on("media-upload-progress", self.on_media_upload_progress)
+        self.sio.on("media-download-progress", self.on_media_download_progress)
         self.sio.on("incomingcall", self.on_wpp_incoming_call)
         # These two handlers existed but were never registered — contact
         # name/photo updates and presence changes only ever reached the app
@@ -1742,15 +1743,60 @@ class WebSocketClient:
             logging.exception("[WebSocketClient] on_wpp_message_received error")
 
     def on_media_upload_progress(self, data):
+        """Upload progress from inside WhatsApp Web.
+
+        `progress` is a real fraction when the build exposes one and None
+        otherwise; `stage` is WhatsApp's own lifecycle label. Both are
+        forwarded and the panel decides — see update_media_upload_progress().
+        Rejecting an event for having no number is what made this feature
+        inert: nothing on a current build ever carries one.
+        """
         if not isinstance(data, dict) or not self._belongs_to_this_session(data):
             return
+        upload_id = str(data.get("uploadId") or "")
+        if not upload_id:
+            return
+        progress = None
         try:
-            upload_id = str(data.get("uploadId") or "")
+            raw = data.get("progress")
+            if raw is not None:
+                value = float(raw)
+                if 0 <= value <= 1:
+                    progress = value
+        except (TypeError, ValueError):
+            progress = None
+        stage = data.get("stage")
+        stage = str(stage) if stage else ""
+        if progress is None and not stage:
+            return
+        logging.info(
+            "[media-progress] upload %s stage=%s progress=%s",
+            upload_id[:12], stage or "-",
+            f"{progress:.2f}" if progress is not None else "-",
+        )
+        wx.CallAfter(self.main_window.on_media_upload_progress,
+                     upload_id, progress, stage)
+
+    def on_media_download_progress(self, data):
+        """Bytes actually arriving from WhatsApp's CDN, counted server-side.
+
+        The old gauge watched the localhost hop instead, which only begins
+        once the whole file has already been fetched and decrypted — so it
+        showed 0% for the entire real wait and then jumped. This is the wait.
+        """
+        if not isinstance(data, dict) or not self._belongs_to_this_session(data):
+            return
+        progress_id = str(data.get("progressId") or "")
+        if not progress_id:
+            return
+        try:
             progress = float(data.get("progress"))
-            if upload_id and 0 <= progress <= 1:
-                wx.CallAfter(self.main_window.on_media_upload_progress, upload_id, progress)
         except (TypeError, ValueError):
             return
+        if not 0 <= progress <= 1:
+            return
+        wx.CallAfter(self.main_window.on_media_download_progress,
+                     progress_id, progress)
 
     def on_wpp_reaction(self, data):
         try:

--- a/client/main.py
+++ b/client/main.py
@@ -21989,6 +21989,13 @@ class MainWindow(wx.Frame):
         if msg_type:
             body_data["type"] = msg_type.replace("Message", "")
 
+        # Correlation id for the server's progress events. Deliberately the
+        # message's own key id rather than the serialized form sent in the URL:
+        # the panel keys its gauge by that, and the serialized form goes
+        # through @lid/@c.us rewriting on both sides, so matching on it would
+        # mean re-deriving the same guess in two places.
+        body_data["progressId"] = _key.get("id", "") or msg_id
+
         has_media_key = bool(body_data.get("mediaKey"))
         has_client_url = bool(body_data.get("clientUrl"))
         has_direct_path = bool(body_data.get("directPath"))
@@ -24841,9 +24848,17 @@ class MainWindow(wx.Frame):
                 except OSError:
                     pass
 
-    def on_media_upload_progress(self, upload_id: str, progress: float):
+    def on_media_upload_progress(self, upload_id: str, progress, stage: str = ""):
         if hasattr(self, "conversations_panel"):
-            self.conversations_panel.update_media_upload_progress(upload_id, progress)
+            self.conversations_panel.update_media_upload_progress(
+                upload_id, progress, stage)
+
+    def on_media_download_progress(self, progress_id: str, progress: float):
+        """Server-side CDN download progress, keyed by the id we sent with the
+        request. See _media_progress_id() for why the client picks that id."""
+        if hasattr(self, "conversations_panel"):
+            self.conversations_panel.update_message_download_progress(
+                progress_id, progress)
 
     def send_contact_attachment(self, remote_jid: str, contact_info: dict,
                                 quoted: dict = None):

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -533,6 +533,10 @@ class ConversationsPanel(wx.Panel):
         self._quoted_message: dict | None = None
         self._outgoing_virtual_messages: dict = {}
         self._media_upload_progress: dict = {}
+        # Stage names already seen per upload, so a re-reported stage is
+        # not mistaken for forward motion. See
+        # update_media_upload_progress().
+        self._upload_stages_seen: dict = {}
         self._media_transfer_started: set = set()
         # local_id → the virtual message dict of a row the user deleted while it
         # was still pending. Kept because cancelling an in-flight send is only
@@ -2567,6 +2571,7 @@ class ConversationsPanel(wx.Panel):
             if real_id and isinstance(real_id, str):
                 tracked.setdefault("key", {})["id"] = real_id
         self._media_upload_progress.pop(local_id, None)
+        self._upload_stages_seen.pop(local_id, None)
         # Panel-level guard: survive _sorted_messages rebuilds that replace dict
         # objects, keeping the per-dict _ui_sent flag from being seen by both callers.
         _played = getattr(self, "_played_sent_local_ids", None)
@@ -7509,6 +7514,10 @@ class ConversationsPanel(wx.Panel):
 
         mw.output(i18n.t("downloading"))
         self._action_download_btn.Hide()
+        # The gauge only moves forward now (see
+        # update_message_download_progress), so a previous attempt's value has
+        # to be cleared or this one starts wherever that one stopped.
+        self._download_progress.pop(msg_id, None)
         self._hide_media_transfer_gauge()
         self._show_media_transfer_gauge()
         self.conversation_panel.Layout()
@@ -9932,7 +9941,32 @@ class ConversationsPanel(wx.Panel):
         """
         Called from the main thread (via wx.CallAfter) when a media file's
         download progress changes.  Refreshes the relevant row in the list.
+
+        Two sources now feed this and they measure different things, which is
+        why it only ever moves forward. The server reports the real download
+        from WhatsApp's CDN — the part that actually takes minutes — and the
+        HTTP read of the finished file over loopback follows it, restarting
+        from near zero. Without the monotonic guard the bar would climb to
+        100%, drop, and climb again.
+
+        Keeping the second source rather than deleting it is deliberate:
+        client/api/ is reinstalled independently of this app, so a server that
+        has never heard of media-download-progress still has to move the bar,
+        and there it is the only signal there is.
         """
+        try:
+            progress = float(progress)
+        except (TypeError, ValueError):
+            return
+        # NaN would survive the clamp below and arrive as 1.0: min(1.0, nan)
+        # is 1.0, because every comparison with NaN is False. A malformed
+        # progress event would complete the bar over a download that has not
+        # started.
+        if progress != progress:
+            return
+        progress = max(0.0, min(1.0, progress))
+        if progress <= self._download_progress.get(msg_id, 0.0):
+            return
         self._download_progress[msg_id] = progress
         self._update_media_transfer_gauge(progress)
         for i, msg in enumerate(self._sorted_messages):
@@ -9940,11 +9974,42 @@ class ConversationsPanel(wx.Panel):
                 self.messages_list.SetItemText(i, self._render_message_line(msg))
                 break
 
-    def update_media_upload_progress(self, upload_id: str, progress: float):
+    #: How far each unrecognised upload stage advances the bar, and how far it
+    #: may get. WhatsApp's stage vocabulary is its own and versioned, so this
+    #: does not pretend to know what fraction "ENCRYPT" represents — it only
+    #: guarantees the bar MOVES on every distinct stage, which is the whole
+    #: complaint. Capped below 1.0 because only the send completing means done,
+    #: and a bar that reaches 100% while the file is still going up is a worse
+    #: lie than one that stops at 90%.
+    _UPLOAD_STAGE_STEP = 0.15
+    _UPLOAD_STAGE_CEILING = 0.9
+
+    def update_media_upload_progress(self, upload_id: str, progress=None,
+                                     stage: str = ""):
+        """Advance an upload's progress from a real fraction or a stage name.
+
+        `progress` is None on every current WhatsApp build: `progressiveStage`,
+        the only numeric source this ever had, does not exist in
+        @wppconnect/wa-js 4.6.0 at all. Refusing to act without a number is
+        exactly what left this feature inert — the bar sat at zero until the
+        send completed and something else forced it to 1.0.
+        """
+        if progress is None:
+            if not stage:
+                return
+            seen = self._upload_stages_seen.setdefault(upload_id, [])
+            if stage in seen:
+                return  # the same stage re-reported is not forward motion
+            seen.append(stage)
+            progress = min(self._UPLOAD_STAGE_CEILING,
+                           len(seen) * self._UPLOAD_STAGE_STEP)
         try:
-            progress = max(0.0, min(1.0, float(progress)))
+            progress = float(progress)
         except (TypeError, ValueError):
             return
+        if progress != progress:  # NaN — see update_message_download_progress
+            return
+        progress = max(0.0, min(1.0, progress))
         previous = self._media_upload_progress.get(upload_id, 0.0)
         progress = max(previous, progress)
         self._media_upload_progress[upload_id] = progress
@@ -11799,6 +11864,7 @@ class ConversationsPanel(wx.Panel):
         stopped = self.main_window.message_queue.cancel(pending_local_id)
         tracked = self._outgoing_virtual_messages.pop(pending_local_id, None)
         self._media_upload_progress.pop(pending_local_id, None)
+        self._upload_stages_seen.pop(pending_local_id, None)
         self._media_transfer_started.discard(pending_local_id)
         self._hide_media_transfer_gauge()
         record = tracked or msg

--- a/tests/test_duplicate_message_echo_matching.py
+++ b/tests/test_duplicate_message_echo_matching.py
@@ -71,6 +71,7 @@ def _make_panel(msg):
     panel._played_sent_local_ids = set()
     panel._outgoing_virtual_messages = {"loc-1": msg}
     panel._media_upload_progress = {}
+    panel._upload_stages_seen = {}
     panel._media_transfer_started = set()
     panel.gauge_hidden = False
     def _hide():

--- a/tests/test_forwarded_prefix_setting.py
+++ b/tests/test_forwarded_prefix_setting.py
@@ -40,6 +40,7 @@ class _Stub:
         })()
         self._message_list_mode = "classic"
         self._media_upload_progress = {}
+        self._upload_stages_seen = {}
         self.selected_messages = set()
 
     def _is_separator(self, msg):

--- a/tests/test_media_progress_reports_the_real_transfer.py
+++ b/tests/test_media_progress_reports_the_real_transfer.py
@@ -1,0 +1,224 @@
+"""Both progress bars measured the wrong thing, in different ways.
+
+**Download.** The gauge was fed by `iter_content` over the localhost hop
+between Node and Python — but WPPConnect fetches the whole file from WhatsApp's
+CDN and decrypts it *before* writing a single byte back. So the bar sat at 0%
+for the entire real wait, then flashed to 100% as the finished file crossed a
+loopback socket at gigabytes per second. It measured the fast part.
+
+**Upload.** The server only emitted when `Number(mediaData.progressiveStage)`
+was finite. Grepped, not guessed: `progressiveStage` does not appear anywhere
+in @wppconnect/wa-js 4.6.0, and `mediaData.mediaStage` — the field wa-js itself
+subscribes to — carries a lifecycle *string* (its own handler logs "message
+file <id> is <stage>"). `Number("ENCRYPT")` is NaN, so the guard rejected every
+event: the bar was inert, not merely inaccurate, and only moved when the send
+completed and something else forced it to 1.0.
+"""
+
+import inspect
+import re
+import types
+from pathlib import Path
+
+import pytest
+
+from ui.conversations import ConversationsPanel
+
+
+API = Path(__file__).resolve().parents[1] / "client" / "api_patches" / "src"
+
+
+def _panel():
+    panel = ConversationsPanel.__new__(ConversationsPanel)
+    panel._media_upload_progress = {}
+    panel._upload_stages_seen = {}
+    panel._download_progress = {}
+    panel._media_transfer_started = set()
+    panel._sorted_messages = []
+    panel.messages_list = types.SimpleNamespace(
+        SetItemText=lambda *a: None, Refresh=lambda: None)
+    panel._render_message_line = lambda msg: "rendered"
+    panel.gauge_values = []
+    panel._update_media_transfer_gauge = panel.gauge_values.append
+    return panel
+
+
+class TestUploadMovesWithoutANumber:
+    """The whole complaint: on a current build there is no number to move it."""
+
+    def test_a_stage_name_alone_advances_the_bar(self):
+        panel = _panel()
+        ConversationsPanel.update_media_upload_progress(
+            panel, "up-1", None, "ENCRYPT")
+        assert panel._media_upload_progress["up-1"] > 0
+
+    def test_each_new_stage_advances_it_further(self):
+        panel = _panel()
+        for stage in ("RESIZE", "ENCRYPT", "UPLOAD"):
+            ConversationsPanel.update_media_upload_progress(
+                panel, "up-1", None, stage)
+        assert panel._media_upload_progress["up-1"] == pytest.approx(0.45)
+
+    def test_the_same_stage_reported_twice_is_not_progress(self):
+        """WhatsApp re-fires the change event; a repeat is not forward motion."""
+        panel = _panel()
+        ConversationsPanel.update_media_upload_progress(panel, "up-1", None, "UPLOAD")
+        first = panel._media_upload_progress["up-1"]
+        ConversationsPanel.update_media_upload_progress(panel, "up-1", None, "UPLOAD")
+        assert panel._media_upload_progress["up-1"] == first
+
+    def test_stages_never_reach_completion_on_their_own(self):
+        """Only the send finishing means done. A bar at 100% while the file is
+        still going up is a worse lie than one that stops at 90%."""
+        panel = _panel()
+        for i in range(50):
+            ConversationsPanel.update_media_upload_progress(
+                panel, "up-1", None, f"STAGE_{i}")
+        assert panel._media_upload_progress["up-1"] <= 0.9
+
+    def test_a_real_number_still_wins_when_a_build_provides_one(self):
+        panel = _panel()
+        ConversationsPanel.update_media_upload_progress(panel, "up-1", 0.72, "UPLOAD")
+        assert panel._media_upload_progress["up-1"] == pytest.approx(0.72)
+
+    def test_neither_a_number_nor_a_stage_does_nothing(self):
+        panel = _panel()
+        ConversationsPanel.update_media_upload_progress(panel, "up-1", None, "")
+        assert "up-1" not in panel._media_upload_progress
+
+    def test_two_uploads_do_not_share_a_stage_history(self):
+        panel = _panel()
+        ConversationsPanel.update_media_upload_progress(panel, "up-1", None, "UPLOAD")
+        ConversationsPanel.update_media_upload_progress(panel, "up-2", None, "UPLOAD")
+        assert panel._media_upload_progress["up-2"] > 0
+
+
+class TestTheServerStopsDiscardingUploadEvents:
+    @staticmethod
+    def _watch_source():
+        source = (API / "controller" / "messageController.ts").read_text(
+            encoding="utf-8")
+        start = source.index("async function watchMediaUpload(")
+        return source[start:source.index("\nexport async function", start)]
+
+    def test_the_stage_name_is_sent(self):
+        assert "mediaData?.mediaStage" in self._watch_source()
+
+    def test_emission_is_no_longer_gated_on_a_finite_number(self):
+        """`if (Number.isFinite(numeric))` around the emit is what made this
+        inert — nothing on a current build ever satisfies it."""
+        body = self._watch_source()
+        emit = body.index("__winzappMediaProgress({")
+        guard = body.rfind("if (Number.isFinite", 0, emit)
+        # Either there is no guard before the emit at all, or it is closed
+        # before the emit begins (i.e. it guards a value, not the call).
+        assert guard == -1 or body.rfind("}", guard, emit) > guard
+
+    def test_a_numeric_source_is_still_preferred_when_present(self):
+        assert "Number.isFinite(numeric)" in self._watch_source()
+
+
+class TestDownloadProgressComesFromTheCdn:
+    @staticmethod
+    def _download_source():
+        source = (API / "controller" / "sessionController.ts").read_text(
+            encoding="utf-8")
+        start = source.index("async function downloadMediaWithProgress(")
+        return source[start:source.index("\n/**", start)]
+
+    def test_the_bytes_are_counted_as_they_arrive(self):
+        body = self._download_source()
+        assert "onDownloadProgress" in body
+        assert "media-download-progress" in body
+
+    def test_it_is_throttled(self):
+        """A 200 MB file produces thousands of events, and each one is a
+        Socket.IO frame plus a wx.CallAfter on a UI thread whose screen reader
+        is already announcing the value."""
+        body = self._download_source()
+        assert re.search(r"now - lastSent < \d+", body)
+
+    def test_every_failure_falls_back_to_the_original_download(self):
+        """A progress bar is worth nothing if wanting one can cost the file."""
+        body = self._download_source()
+        assert body.count("client.decryptFile(message)") >= 3
+
+    def test_both_decrypt_sites_use_it(self):
+        source = (API / "controller" / "sessionController.ts").read_text(
+            encoding="utf-8")
+        media = source[source.index("export async function getMediaByMessage("):]
+        assert media.count("downloadMediaWithProgress(req, client,") == 2
+
+
+class TestTheGaugeOnlyEverMovesForward:
+    """Two sources feed it and they measure different things: the CDN download
+    (minutes) and the loopback read of the finished file (instant), which
+    restarts from near zero. Without this the bar climbs, drops and climbs."""
+
+    def test_a_lower_reading_is_ignored(self):
+        panel = _panel()
+        ConversationsPanel.update_message_download_progress(panel, "m1", 0.8)
+        ConversationsPanel.update_message_download_progress(panel, "m1", 0.1)
+        assert panel._download_progress["m1"] == pytest.approx(0.8)
+
+    def test_a_higher_reading_is_taken(self):
+        panel = _panel()
+        ConversationsPanel.update_message_download_progress(panel, "m1", 0.3)
+        ConversationsPanel.update_message_download_progress(panel, "m1", 0.9)
+        assert panel._download_progress["m1"] == pytest.approx(0.9)
+
+    def test_the_loopback_source_is_kept_for_older_servers(self):
+        """client/api/ is reinstalled independently of this app; on a server
+        that has never heard of media-download-progress it is the only signal
+        there is."""
+        source = inspect.getsource(ConversationsPanel._on_action_download)
+        assert "progress_callback=_update_download_progress" in source
+
+    def test_a_new_attempt_starts_from_zero(self):
+        """Monotonic across one download, not across the button being pressed
+        twice — otherwise a retry starts wherever the failure stopped."""
+        source = inspect.getsource(ConversationsPanel._on_action_download)
+        assert "_download_progress.pop(msg_id, None)" in source
+
+    @pytest.mark.parametrize("bad", ["abc", None, float("nan")])
+    def test_unreadable_values_are_ignored(self, bad):
+        panel = _panel()
+        ConversationsPanel.update_message_download_progress(panel, "m1", 0.5)
+        ConversationsPanel.update_message_download_progress(panel, "m1", bad)
+        assert panel._download_progress["m1"] == pytest.approx(0.5)
+
+
+class TestTheCorrelationIdIsSentWithTheRequest:
+    def test_the_request_carries_one(self):
+        import main
+        source = inspect.getsource(main.MainWindow.get_base64_from_media)
+        assert 'body_data["progressId"]' in source
+
+    def test_the_client_subscribes_to_the_event(self):
+        from core import websocket_client
+        source = inspect.getsource(websocket_client.WebSocketClient)
+        assert '"media-download-progress"' in source
+        assert "def on_media_download_progress" in source
+
+
+class TestNaNCannotCompleteABar:
+    """min(1.0, nan) is 1.0 — every comparison with NaN is False, so the clamp
+    lets it through as a finished transfer. Found by the parametrised test
+    above, on real code: a malformed progress event would have shown 100% over
+    a download that had not started."""
+
+    def test_the_download_gauge_rejects_it(self):
+        panel = _panel()
+        ConversationsPanel.update_message_download_progress(panel, "m1", float("nan"))
+        assert "m1" not in panel._download_progress
+
+    def test_the_upload_gauge_rejects_it(self):
+        panel = _panel()
+        ConversationsPanel.update_media_upload_progress(panel, "up-1", float("nan"))
+        assert "up-1" not in panel._media_upload_progress
+
+    def test_infinity_is_still_only_clamped(self):
+        """Unlike NaN, an ordering exists — clamping is the right answer."""
+        panel = _panel()
+        ConversationsPanel.update_message_download_progress(panel, "m1", float("inf"))
+        assert panel._download_progress["m1"] == pytest.approx(1.0)

--- a/tests/test_media_upload_progress.py
+++ b/tests/test_media_upload_progress.py
@@ -15,6 +15,7 @@ class _ListBoxLike:
 def test_upload_progress_refreshes_listbox_compatible_control():
     panel = ConversationsPanel.__new__(ConversationsPanel)
     panel._media_upload_progress = {}
+    panel._upload_stages_seen = {}
     panel._media_transfer_started = set()
     panel._sorted_messages = [{"_local_id": "upload-1", "_local_pending": True}]
     panel.messages_list = _ListBoxLike()

--- a/tests/test_message_cancel_race.py
+++ b/tests/test_message_cancel_race.py
@@ -920,6 +920,7 @@ def _make_panel(main_window, msg=None):
     panel.main_window = main_window
     panel._outgoing_virtual_messages = {msg["_local_id"]: msg} if msg else {}
     panel._media_upload_progress = {}
+    panel._upload_stages_seen = {}
     panel._media_transfer_started = set()
     panel._cancelled_pending_messages = {}
     panel._hide_media_transfer_gauge = lambda: None

--- a/tests/test_outgoing_virtual_message_cleanup.py
+++ b/tests/test_outgoing_virtual_message_cleanup.py
@@ -47,6 +47,7 @@ def _make_panel(msg):
     panel._played_sent_local_ids = set()
     panel._outgoing_virtual_messages = {"loc-1": msg}
     panel._media_upload_progress = {}
+    panel._upload_stages_seen = {}
     panel._media_transfer_started = set()
     panel._hide_media_transfer_gauge = lambda: None
     panel.messages_list = _FakeList()

--- a/tests/test_quote_lost_drops_reply_header.py
+++ b/tests/test_quote_lost_drops_reply_header.py
@@ -60,6 +60,7 @@ def _make_panel(msg):
     panel._played_sent_local_ids = set()
     panel._outgoing_virtual_messages = {}
     panel._media_upload_progress = {}
+    panel._upload_stages_seen = {}
     panel._media_transfer_started = set()
     panel._hide_media_transfer_gauge = lambda: None
     panel.messages_list = _FakeList()

--- a/tests/test_selective_message_repaint.py
+++ b/tests/test_selective_message_repaint.py
@@ -707,6 +707,7 @@ class _RenderPanel(_PanelStub):
         super().__init__(messages, main_window=main_window or _RenderMainWindow())
         self.selected_messages = set()
         self._media_upload_progress = {}
+        self._upload_stages_seen = {}
         self._download_progress = {}
         self._message_list_mode = "classic"
         self._group_participants_cache = []

--- a/tests/test_unconfirmed_send_recovery.py
+++ b/tests/test_unconfirmed_send_recovery.py
@@ -189,6 +189,7 @@ class _DeleteStub:
         self.conversation = {"remoteJid": REMOTE}
         self._outgoing_virtual_messages = {msg.get("_local_id"): msg} if msg.get("_local_id") else {}
         self._media_upload_progress = {}
+        self._upload_stages_seen = {}
         self._media_transfer_started = set()
         self.removed_ids = []
         self.gauge_hidden = 0


### PR DESCRIPTION
Both progress bars measured the wrong thing, in different ways. The suspicion that they did was right.

## Download: it measured the fast part

The gauge was fed by `iter_content` over the **localhost** hop between Node and Python. But WPPConnect fetches the whole file from WhatsApp's CDN and decrypts it *before* writing a single byte back — so the bar sat at 0% for the entire real wait, then flashed to 100% as the finished file crossed a loopback socket at gigabytes per second.

`decryptFile()` turns out to be one axios GET followed by `magix()`, so the seam is clean. `downloadMediaWithProgress()` does the same two steps with the bytes counted, emitting `media-download-progress` over Socket.IO.

- **Throttled to 250 ms.** A 200 MB file otherwise produces thousands of frames, and as many `wx.CallAfter`s on a UI thread whose screen reader is already announcing the value.
- **Reaches into wppconnect's own decrypt helper** for `makeOptions`/`magix` rather than reimplementing either. That file is already one WinZapp patches by name (`api_patches/decrypt.js`), so the coupling exists, and the exact-version pin is what keeps it honest. Both imports and `onDownloadProgress` in Node were **verified against the pinned runtime**, not assumed from source.
- **Every failure falls back to `client.decryptFile()`.** A progress bar is worth nothing if wanting one can cost the file.

## Upload: it was inert, not inaccurate

The server only emitted when `Number(mediaData.progressiveStage)` was finite. Grepped, not guessed:

- `progressiveStage` **does not appear anywhere** in `@wppconnect/wa-js` 4.6.0.
- `mediaData.mediaStage` — the field wa-js itself subscribes to — carries a lifecycle **string**; wa-js's own handler logs `message file <id> is <stage>`.

`Number("ENCRYPT")` is NaN, so the guard rejected every event. The bar never moved until the send completed and something else forced it to 1.0.

It now emits whatever arrives, stage name included, and the client advances monotonically on each distinct stage it has not seen before. Hardcoding a stage→fraction table would be inventing semantics we cannot verify and would rot the next time WhatsApp renames one. Stages are capped below 1.0, because only the send completing means done — a bar at 100% while the file is still going up is a worse lie than one that stops at 90%.

## The gauge only ever moves forward

Two sources feed it now and they measure different things: the CDN download (minutes) and the loopback read of the finished file (instant), which restarts from near zero. Without the monotonic guard the bar would climb, drop, and climb again.

Keeping the loopback source rather than deleting it is deliberate: `client/api/` is reinstalled independently of this app, and on a server that has never heard of `media-download-progress` it is the only signal there is.

## One real defect found on the way

A parametrised test caught it on real code: **NaN survived the clamp as 1.0**. `min(1.0, nan)` is `1.0`, because every comparison with NaN is False — so a malformed progress event would have shown a completed transfer over a download that had not started. Guarded in both gauges, with `inf` still merely clamped since an ordering exists for it.

## Verification

The Node-side seams were checked live: `onDownloadProgress` really does fire in Node with axios 1.20 (tested against a real HTTP request), and `makeOptions`/`magix`/`useragentOverride` all import from the paths used here. What has **not** been exercised is a real large transfer end to end — that needs a big file on a real session, so treat the percentages as unconfirmed until the next alpha.

26 tests cover the stage-driven advance and its bounds, that the server no longer gates emission on a number, the throttle and fallback on the Node side, the monotonic gauge, and NaN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)