### PR TITLE
Compare the unread snapshot's timestamps in the same unit

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -1322,6 +1322,46 @@ def reconcile_open_chat_unread(
     return min(server_unread, local_new), False
 
 
+def _log_refused_read_receipt(jid: str, server_unread: int, local_unread: int,
+                             incoming_timestamp, local_timestamp,
+                             merged: int) -> None:
+    """Say so when a snapshot reporting "read" was not allowed to clear a badge.
+
+    The only symptom of this from outside is a conversation that stays unread
+    forever and comes back only after F5, and until this line existed the logs
+    could not tell whether WPPConnect had reported a stale count or WinZapp had
+    refused a good one (issue #173 says exactly that: "the available
+    diagnostics do not establish" which).
+
+    Both timestamps go in raw, because the units are the thing under
+    suspicion — see _unread_seconds().
+    """
+    if server_unread != 0 or local_unread <= 0 or merged == 0:
+        return
+    logging.info(
+        "[unread] %s: snapshot says read (0) but kept %d — "
+        "snapshot t=%s local t=%s",
+        jid, merged, incoming_timestamp, local_timestamp,
+    )
+
+
+def _unread_seconds(value) -> int:
+    """A timestamp in seconds, whatever unit it arrived in.
+
+    Deliberately the same rule as core/incremental_sync.py's _seconds(), and
+    deliberately a second copy rather than an import: main.py is the module
+    incremental_sync is imported INTO, and reaching back the other way for four
+    lines would make the dependency circular. The threshold is the one that
+    cannot be ambiguous — 1e12 seconds is the year 33658, so anything above it
+    is milliseconds.
+    """
+    try:
+        ts = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    return ts // 1000 if ts > 1_000_000_000_000 else ts
+
+
 def reconcile_snapshot_unread(
     server_unread: int,
     local_unread: int,
@@ -1329,12 +1369,33 @@ def reconcile_snapshot_unread(
     local_timestamp: int,
     unsynced: bool = False,
 ) -> int:
-    """Merge an authoritative chat snapshot without losing newer live arrivals."""
+    """Merge an authoritative chat snapshot without losing newer live arrivals.
+
+    The timestamp guard below is what let a conversation read on the phone sit
+    at 8 unread forever, curable only with F5 (issue #173) — and the reason is
+    not the rule, it is that the two sides were being compared in different
+    units. `t` arrives from WhatsApp Web in seconds, while several local paths
+    write a millisecond value into the very same field (on_historical_message()
+    is the one CLAUDE.md names). A millisecond local timestamp is a thousand
+    times any second-based snapshot, so `incoming < local` became permanently
+    true and NO later snapshot could ever lower the count again. F5 "fixed" it
+    only by wiping self.chats, leaving nothing to preserve.
+
+    core/incremental_sync.py learned this on its own side and its _seconds()
+    docstring says it outright: comparing the two raw "makes the local side
+    look impossibly newer, which is the direction that silently skips a chat".
+    The same normalisation belongs here, on the comparison that decides whether
+    a read is allowed to reach the badge.
+
+    The guard itself stays exactly as it was, because it protects a real case:
+    a snapshot a second older than a live arrival must not clear the count that
+    arrival just raised.
+    """
     server_unread = max(0, int(server_unread or 0))
     local_unread = max(0, int(local_unread or 0))
     if server_unread >= local_unread:
         return server_unread
-    if unsynced or int(incoming_timestamp or 0) < int(local_timestamp or 0):
+    if unsynced or _unread_seconds(incoming_timestamp) < _unread_seconds(local_timestamp):
         return local_unread
     return server_unread
 
@@ -13716,6 +13777,11 @@ class MainWindow(wx.Frame):
                                 chat.get("t", 0),
                                 self.chats[jid].get("t", 0),
                                 bool(self.chats[jid].get("_unread_count_unsynced")),
+                            )
+                            _log_refused_read_receipt(
+                                jid, server_unread, local_unread,
+                                chat.get("t", 0), self.chats[jid].get("t", 0),
+                                chat["unreadCount"],
                             )
                         chats[jid] = chat
                     else:

--- a/tests/test_unread_snapshot_units.py
+++ b/tests/test_unread_snapshot_units.py
@@ -1,0 +1,131 @@
+"""A chat read on the phone that stays unread forever (issue #173).
+
+`reconcile_snapshot_unread()` refuses to let a snapshot lower a count when the
+local activity is newer than the snapshot. That rule is right and protects a
+real case — a snapshot one second older than a live arrival must not clear the
+badge that arrival just raised.
+
+What was wrong is that it compared the two **in different units**. `t` arrives
+from WhatsApp Web in seconds, while several local paths write a millisecond
+value into the same field (`on_historical_message()` is the one CLAUDE.md
+names). A millisecond timestamp is a thousand times any second-based snapshot,
+so `incoming < local` became permanently true for that chat and no later
+snapshot could ever lower its count again — including a snapshot saying the
+conversation had been read.
+
+That also explains the shape of the report: *one* conversation stuck while the
+others updated correctly. Only a chat whose `t` went through the millisecond
+path is affected, which is why this is occasional rather than universal.
+
+F5 "fixed" it by wiping `self.chats` entirely, leaving nothing to preserve —
+not by reconciling anything.
+
+`core/incremental_sync.py` had already learned this on its own side; its
+`_seconds()` docstring says comparing the two raw "makes the local side look
+impossibly newer, which is the direction that silently skips a chat".
+"""
+
+import logging
+
+import pytest
+
+from main import _unread_seconds, reconcile_snapshot_unread
+
+
+SECONDS = 1_700_000_000
+#: The same instant, written the way on_historical_message() writes it.
+MILLIS = 1_700_000_000_000
+
+
+class TestTheUnitsAreNormalisedBeforeComparing:
+    def test_a_millisecond_local_timestamp_no_longer_blocks_a_read(self):
+        """The bug, in one line: the same instant in two units read as a
+        thousand-year gap, so the badge could never be cleared."""
+        assert reconcile_snapshot_unread(0, 8, SECONDS, MILLIS) == 0
+
+    def test_it_did_not_matter_which_way_the_count_moved(self):
+        """A merely lagging count was refused for the same wrong reason."""
+        assert reconcile_snapshot_unread(3, 8, SECONDS, MILLIS) == 3
+
+    @pytest.mark.parametrize("value, expected", [
+        (SECONDS, SECONDS),
+        (MILLIS, SECONDS),
+        (0, 0),
+        (None, 0),
+        ("", 0),
+        ("nonsense", 0),
+        (1_000_000_000_000, 1_000_000_000_000),   # exactly the threshold: seconds
+        (1_000_000_000_001, 1_000_000_000),       # just above it: milliseconds
+    ])
+    def test_the_conversion(self, value, expected):
+        assert _unread_seconds(value) == expected
+
+
+class TestTheGuardItselfIsUnchanged:
+    """It protects a real case and this must not have weakened it."""
+
+    def test_a_snapshot_older_than_a_live_arrival_still_cannot_clear_it(self):
+        assert reconcile_snapshot_unread(0, 1, 1000, 1001) == 1
+
+    def test_the_same_in_realistic_units(self):
+        assert reconcile_snapshot_unread(0, 4, SECONDS, SECONDS + 1) == 4
+
+    def test_a_read_at_the_same_instant_is_still_accepted(self):
+        assert reconcile_snapshot_unread(0, 4, SECONDS, SECONDS) == 0
+
+    def test_a_higher_remote_count_is_still_always_accepted(self):
+        assert reconcile_snapshot_unread(5, 2, 2000, 1000) == 5
+
+    def test_a_chat_first_seen_live_still_keeps_its_own_count(self):
+        """Its local count is built on an assumed zero, so there is nothing
+        here to believe yet — including a zero."""
+        assert reconcile_snapshot_unread(0, 2, SECONDS, MILLIS, unsynced=True) == 2
+
+    def test_a_lagging_count_is_still_refused_when_local_is_genuinely_newer(self):
+        assert reconcile_snapshot_unread(3, 8, SECONDS, SECONDS + 5) == 8
+
+
+class TestTheRefusalIsNowVisibleInTheLog:
+    """Issue #173 said the available diagnostics could not establish whether
+    the server reported a stale count or WinZapp refused a good one. Now they
+    can."""
+
+    def _emit(self, caplog, **kwargs):
+        from main import _log_refused_read_receipt
+        with caplog.at_level(logging.INFO):
+            _log_refused_read_receipt(**kwargs)
+        return [r.message for r in caplog.records]
+
+    def test_a_refused_read_receipt_is_logged(self, caplog):
+        messages = self._emit(
+            caplog, jid="5511@s.whatsapp.net", server_unread=0, local_unread=8,
+            incoming_timestamp=SECONDS, local_timestamp=MILLIS, merged=8)
+        assert any("snapshot says read" in m for m in messages)
+
+    def test_both_timestamps_are_reported_raw(self, caplog):
+        """The units are the thing under suspicion; normalising them for the
+        log would hide the evidence."""
+        messages = self._emit(
+            caplog, jid="5511@s.whatsapp.net", server_unread=0, local_unread=8,
+            incoming_timestamp=SECONDS, local_timestamp=MILLIS, merged=8)
+        assert any(str(MILLIS) in m and str(SECONDS) in m for m in messages)
+
+    def test_an_accepted_read_is_not_logged(self, caplog):
+        messages = self._emit(
+            caplog, jid="5511@s.whatsapp.net", server_unread=0, local_unread=8,
+            incoming_timestamp=SECONDS, local_timestamp=SECONDS, merged=0)
+        assert messages == []
+
+    def test_a_merely_lagging_count_is_not_logged(self, caplog):
+        """Only a refused *read receipt* is interesting — a count that dropped
+        from 8 to 3 says nothing about whether the chat was read."""
+        messages = self._emit(
+            caplog, jid="5511@s.whatsapp.net", server_unread=3, local_unread=8,
+            incoming_timestamp=SECONDS, local_timestamp=MILLIS, merged=8)
+        assert messages == []
+
+    def test_nothing_is_logged_when_there_was_no_badge_to_keep(self, caplog):
+        messages = self._emit(
+            caplog, jid="5511@s.whatsapp.net", server_unread=0, local_unread=0,
+            incoming_timestamp=SECONDS, local_timestamp=MILLIS, merged=0)
+        assert messages == []


### PR DESCRIPTION
Issue #173: one conversation keeps its unread count after being read on the phone; restarting and completing an incremental sync does not help; only F5 corrects it.

## The rule was right, the comparison wasn't

`reconcile_snapshot_unread()` refuses to let a snapshot lower a count while the local activity is newer than the snapshot. That rule protects a real case — a snapshot one second older than a live arrival must not clear the badge that arrival just raised — and two existing tests pin it.

What was wrong is that it compared the two **in different units**:

```python
if unsynced or int(incoming_timestamp or 0) < int(local_timestamp or 0):
    return local_unread
```

`t` arrives from WhatsApp Web in **seconds**, while several local paths write a **millisecond** value into the same field (`on_historical_message()` is the one CLAUDE.md names). For such a chat `incoming < local` is permanently true by a factor of a thousand, so no later snapshot could ever lower its count again — including one saying the conversation had been read.

`core/incremental_sync.py` had already learned this on its own side. Its `_seconds()` docstring says it outright: comparing the two raw *"makes the local side look impossibly newer, which is the direction that silently skips a chat"*. The same normalisation belongs on the comparison that decides whether a read reaches the badge.

## Why this fits the report

- **"Occasionally, one conversation"** — only a chat whose `t` went through the millisecond path is affected. A guard that was merely too strict would hit every chat, not one.
- **"Restarting did not help"** — the corrupted `t` is persisted, so it comes back corrupted.
- **"F5 corrected it"** — F5 wipes `self.chats` entirely (`self.chats = {}`, "exactly as if pairing for the first time"), so there is no local count left to preserve. It never reconciled anything.

## On the reporter's hypothesis

@karolasty83 suggested `chat_sync_change_reason()` skips a fall to zero because it requires `current_unread > 0`. That is a fair reading of a genuinely odd-looking condition, and I tried it first — but it is not the cause, and I have left the condition alone.

That function decides whether a chat needs a **get-messages**, and a chat that was merely read has no new messages to fetch. Two things confirm it would not have helped: `unread_after_history_sync()` returns `max(baseline, …)` and so can never lower a count even when the chat *is* synced; and the badge is set by the snapshot merge in `get_remote_chats()`, which runs for every chat regardless of the sync plan.

## Diagnostics

The issue notes that "the available diagnostics do not establish whether WPPConnect returned a stale count or WinZapp retained the local one". A refused read receipt is now logged, with **both timestamps raw** — the units are the thing under suspicion, so normalising them for the log would hide the evidence.

## Tests

`tests/test_unread_snapshot_units.py` (21): the millisecond case in both directions, the conversion including its exact threshold, and — deliberately — that every branch of the guard still behaves as before, since the risk here is weakening a rule that exists for a reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)