### PR TITLE
Stop rebuilding the page when its chat store is the empty side

### DIFF
--- a/client/api_patches/src/util/createSessionUtil.ts
+++ b/client/api_patches/src/util/createSessionUtil.ts
@@ -1229,10 +1229,43 @@ export default class CreateSessionUtil {
           // like the MsgKey._serialized and status sender shims. See this
           // method's own doc comment for why a single attempt was never
           // enough here.
+          // One timer per page, and it settles exactly once — neither of which
+          // clearInterval() can be trusted to deliver here.
+          //
+          // Measured on a user's session: a SINGLE scheduled installer logged
+          // "installed after 0 retries" every 500ms for three minutes and ten
+          // seconds, stopping only when the session was torn down. One timer,
+          // 364 lines. So the `if` body ran 364 times, which means
+          // clearInterval(timer) ran 364 times and did not stop it. The likely
+          // reason is that WhatsApp Web wraps setInterval for its own
+          // scheduler and returns a handle the native clearInterval does not
+          // recognise — but the fix must not depend on knowing that, because
+          // whatever the cause, a page.evaluate'd loop running at 2 Hz inside
+          // WhatsApp Web is not something to leave to a call that has already
+          // been observed to fail.
+          //
+          // `settled` closes over this one timer, so the callback becomes a
+          // bare return the moment its work is done. The interval may keep
+          // ticking; it can no longer do anything or say anything.
+          const w = window as any;
+          if (w.__winzappUnreadListenerScheduled) {
+            // A second installer would stack a second uncancellable timer on
+            // top of the first. page.on('load') can fire this repeatedly.
+            return 'already scheduled';
+          }
+          w.__winzappUnreadListenerScheduled = true;
           let tries = 0;
+          let settled = false;
           const timer = setInterval(() => {
+            if (settled) return;
             if (install() || ++tries > 60) {
-              clearInterval(timer);
+              settled = true;
+              w.__winzappUnreadListenerScheduled = false;
+              try {
+                clearInterval(timer);
+              } catch (e) {
+                /* see above — the timer is disarmed by `settled` regardless */
+              }
               // The evaluate below can only ever log 'scheduled' — it returns
               // long before this loop resolves — so without this line the log
               // cannot tell "installed three seconds later" apart from "gave

--- a/client/main.py
+++ b/client/main.py
@@ -1810,8 +1810,9 @@ class MainWindow(wx.Frame):
         # that is merely cold. Never reset while the process lives; a chat
         # count that was real once does not stop having been real.
         self._chat_list_high_water = 0
-        # Consecutive sync rounds that found the store not answering, counted
-        # towards recreating the session. See _BROKEN_STORE_REPAIR_ROUNDS.
+        # Consecutive sync rounds that found the store not answering. Purely a
+        # diagnostic since the session-rebuild escalation was removed — see the
+        # store_broken branch in start_sync() for the field log that killed it.
         self._broken_store_rounds = 0
         # Message-sync workers discover incomplete chats concurrently. Keep the
         # queue and its growth counters behind one lock so a LID and its phone
@@ -11973,11 +11974,11 @@ class MainWindow(wx.Frame):
     # legitimately sit at zero for a moment while the in-memory store hydrates
     # behind the IndexedDB side that storeCounts reads.
     _BROKEN_STORE_CONFIRM = 3
-    # Rounds that must detect a broken store before the session is recreated.
-    # One round backs off and re-checks; the second repairs. _restart_wpp_session()
-    # carries its own re-entrancy guard, its own 120 s cooldown and the
-    # _auto_restart_grace_active() window that keeps a restart from being
-    # mistaken for a phone-side unlink.
+    # Kept, unused by the sync path, and deliberately not deleted: it is the
+    # number this codebase used to rebuild the page on, and a reader who finds
+    # the round counter needs to be able to find out what it used to mean.
+    # Nothing schedules a rebuild from a broken store any more — see the
+    # store_broken branch in start_sync().
     _BROKEN_STORE_REPAIR_ROUNDS = 2
 
     # A list-chats snapshot does not have to equal storeCounts.chat exactly:
@@ -12414,10 +12415,10 @@ class MainWindow(wx.Frame):
                     and self.store_looks_broken(server_count, wa_web_count, evidence_count)):
                 broken_readings += 1
                 logging.warning(
-                    "[start_sync] list-chats answered %d chat(s) while WhatsApp Web "
-                    "reports %s in its own store and we have evidence for %d "
-                    "(reading %d/%d) — the page's in-memory chat store looks broken, "
-                    "not cold.",
+                    "[start_sync] list-chats answered %d chat(s) (the page's "
+                    "in-memory ChatStore) while %s chat(s) sit in WhatsApp Web's "
+                    "IndexedDB and we have evidence for %d (reading %d/%d) — two "
+                    "different stores, and the in-memory one is the empty side.",
                     server_count, wa_web_count, evidence_count,
                     broken_readings, self._BROKEN_STORE_CONFIRM,
                 )
@@ -12535,34 +12536,46 @@ class MainWindow(wx.Frame):
             # its one pruning pass is keyed on JIDs present in the response,
             # which is empty here.
             self._broken_store_rounds = getattr(self, "_broken_store_rounds", 0) + 1
+            # This used to recreate the WPPConnect session after two such
+            # rounds, on the reasoning that "nothing short of rebuilding the
+            # page recovers a store in this state". A field log falsified it
+            # directly, and the escalation is gone rather than retuned.
+            #
+            # Measured: the rebuild ran exactly as designed — browserClose, a
+            # fresh browser, the pinned document served again, a new session
+            # reaching inChat, all inside seven seconds — and list-chats
+            # answered 0 again THREE SECONDS LATER, against the same 938 chats
+            # in IndexedDB it had been answering 0 against before. Four more
+            # rounds followed, each detecting the same thing.
+            #
+            # And rebuilding is not merely useless here, it is destructive:
+            # WPP.chat.list() reads the page's in-memory ChatStore, which a new
+            # document starts empty and fills from IndexedDB. Tearing the page
+            # down throws away whatever progress it had made and starts that
+            # over — which is the most plausible reading of why the ONE
+            # non-zero answer in the whole session (37 chats, five seconds
+            # after the session came up) was never built on.
+            #
+            # What is left is what the rest of this branch already did: refuse
+            # the known-wrong snapshot, keep the sync incomplete, and let the
+            # health checker come back. That is strictly better than a rebuild
+            # for the case above, and no worse for the case the escalation was
+            # written for — where re-asking did not help either, over 37
+            # minutes, WITHOUT anyone having rebuilt anything.
             logging.error(
-                "[start_sync] WhatsApp Web's in-memory chat store is not answering "
-                "(round %d of %d before recreating the session). Messages are "
-                "unaffected — get-messages reads IndexedDB and keeps working — so "
-                "this sync continues with the chats already known locally.",
-                self._broken_store_rounds, self._BROKEN_STORE_REPAIR_ROUNDS,
+                "[start_sync] WhatsApp Web's in-memory chat store answered %d "
+                "while IndexedDB holds far more (round %d). Not rebuilding the "
+                "page: a rebuild empties that store and restarts the load from "
+                "scratch, which is measurably what this state does not need. "
+                "Messages are unaffected — get-messages reads IndexedDB — so "
+                "this sync continues with the chats already known locally and "
+                "the health checker retries.",
+                server_count, self._broken_store_rounds,
             )
-            if self._broken_store_rounds >= self._BROKEN_STORE_REPAIR_ROUNDS:
-                self._broken_store_rounds = 0
-                # Nothing short of rebuilding the page recovers a store in
-                # this state: it stayed broken for 37 minutes and four full
-                # sync rounds in the captured session, and no amount of
-                # re-asking changed it. Stop here rather than running the
-                # message and media phases into a session about to be torn
-                # down; the health checker starts a fresh sync once the new
-                # session is up.
-                logging.error(
-                    "[start_sync] Recreating the WPPConnect session to rebuild the "
-                    "store — this restores the existing WhatsApp session from its "
-                    "saved token, it does not ask for a new QR code."
-                )
-                self._sync_completed = False
-                self._sync_retry_count = getattr(self, "_sync_retry_count", 0) + 1
-                threading.Thread(target=self._restart_wpp_session, daemon=True).start()
-                return
         else:
-            # A plausible answer clears the tally: only *consecutive* rounds
-            # count towards recreating the session.
+            # A plausible answer clears the tally, which is now purely a
+            # diagnostic: it says how many consecutive rounds saw the store
+            # empty, and nothing acts on it.
             self._broken_store_rounds = 0
         if not chat_list_ok:
             # Report once, after every attempt is exhausted, instead of one

--- a/tests/test_run_sync_broken_store.py
+++ b/tests/test_run_sync_broken_store.py
@@ -262,13 +262,39 @@ class TestTheCapturedSessions:
         stub._run_sync()
         assert stub.media_sync_ran == 0
 
-    def test_the_second_such_round_recreates_the_session(self):
+    def test_no_number_of_such_rounds_recreates_the_session(self):
+        """This asserted the opposite until a field log falsified the premise.
+
+        The rebuild ran exactly as designed on a user's machine — browserClose,
+        a fresh browser, the pinned document served again, a new session
+        reaching inChat, all inside seven seconds — and list-chats answered 0
+        again THREE SECONDS LATER, against the same 938 chats in IndexedDB.
+        Four more rounds followed.
+
+        It is not merely useless: WPP.chat.list() reads the page's in-memory
+        ChatStore, which a new document starts empty and fills from IndexedDB,
+        so tearing the page down throws away whatever progress it had made and
+        starts that over.
+        """
         stub = _make([0] * 60, wa_web=937, local_chats=931, high_water=935)
         stub._broken_store_rounds = MainWindow._BROKEN_STORE_REPAIR_ROUNDS - 1
         stub._run_sync()
-        assert stub.restarted is True
+        assert stub.restarted is False
         assert stub._sync_completed is False
-        assert stub.message_sync_ran == 0, "ran the message phase into a dying session"
+
+    def test_it_keeps_counting_rounds_so_the_log_still_says_how_many(self):
+        stub = _make([0] * 60, wa_web=937, local_chats=931, high_water=935)
+        stub._broken_store_rounds = 4
+        stub._run_sync()
+        assert stub._broken_store_rounds == 5
+        assert stub.restarted is False
+
+    def test_a_far_higher_round_count_still_does_not_rebuild(self):
+        """No threshold anywhere: the escalation is gone, not raised."""
+        stub = _make([0] * 60, wa_web=937, local_chats=931, high_water=935)
+        stub._broken_store_rounds = 500
+        stub._run_sync()
+        assert stub.restarted is False
 
     def test_the_amputated_account_is_refused(self):
         """Session two: fresh install, no cache, 36 seen once, then 0. The old

--- a/tests/test_unread_listener_timer_disarms.py
+++ b/tests/test_unread_listener_timer_disarms.py
@@ -1,0 +1,100 @@
+"""The unread-listener retry timer has to stop, and clearInterval does not.
+
+Measured on a user's session: a **single** scheduled installer logged
+"onUnreadCountChanged listener: installed after 0 retries" every 500 ms for
+three minutes and ten seconds, stopping only when the session was torn down.
+One `setInterval`, 364 log lines, all at exactly 500 ms, all reporting 0
+retries — so the `if` body ran 364 times, which means `clearInterval(timer)`
+ran 364 times and did not stop it.
+
+The likely reason is that WhatsApp Web wraps `setInterval` for its own
+scheduler and returns a handle the native `clearInterval` does not recognise.
+But the fix must not depend on knowing that: whatever the cause, a
+`page.evaluate`'d loop running at 2 Hz inside WhatsApp Web — while it is
+loading a 900-chat account — is not something to leave to a call already
+observed to fail.
+
+The code's own comment had anticipated exactly this shape ("leaving a timer
+firing every 500ms for the life of the page") for a different reason, which is
+what makes it worth pinning rather than trusting.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "client" / "api_patches" / "src" / "util" / "createSessionUtil.ts"
+).read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def installer():
+    """The unread listener's page.evaluate body, up to its `.then()`."""
+    start = SOURCE.index("async onUnreadCountChanged(")
+    return SOURCE[start:SOURCE.index(".then((result: string)", start)]
+
+
+class TestTheCallbackDisarmsItself:
+    def test_it_returns_early_once_settled(self, installer):
+        """The interval may keep ticking; it must stop being able to do
+        anything."""
+        assert "if (settled) return;" in installer
+
+    def test_settled_is_set_before_anything_else_in_the_branch(self, installer):
+        body = installer[installer.index("if (install() || ++tries > 60)"):]
+        settled = body.index("settled = true;")
+        clear = body.index("clearInterval(timer)")
+        log = body.index("console.log(")
+        assert settled < clear < log, (
+            "the flag has to be set before the call that has been observed to "
+            "fail, or a failing clearInterval still leaves the callback armed"
+        )
+
+    def test_clearinterval_is_still_attempted_but_cannot_throw(self, installer):
+        """Keep asking politely — just never depend on the answer."""
+        block = installer[installer.index("settled = true;"):]
+        block = block[:block.index("console.log(")]
+        assert "try {" in block and "clearInterval(timer)" in block
+        assert "catch" in block
+
+
+class TestOnlyOneTimerPerPage:
+    def test_a_second_installer_does_not_stack_another_timer(self, installer):
+        """installListener is registered on page.on('load'), so it can be
+        invoked repeatedly — and an uncancellable timer per invocation is how
+        one becomes many."""
+        assert "__winzappUnreadListenerScheduled" in installer
+        assert "return 'already scheduled';" in installer
+
+    def test_the_guard_is_checked_before_the_timer_is_created(self, installer):
+        guard = installer.index("if (w.__winzappUnreadListenerScheduled)")
+        create = installer.index("setInterval(")
+        assert guard < create
+
+    def test_the_slot_is_released_when_the_timer_settles(self, installer):
+        """Otherwise a page that reloads never gets a listener again: the flag
+        would still say one is scheduled, and the timer it named is gone."""
+        block = installer[installer.index("settled = true;"):]
+        assert "__winzappUnreadListenerScheduled = false;" in block[:400]
+
+    def test_the_immediate_success_path_never_sets_the_guard(self, installer):
+        """`if (install()) return 'installed'` happens first and schedules
+        nothing, so it must not leave a flag behind claiming otherwise."""
+        head = installer[:installer.index("if (install()) return 'installed';")]
+        assert "__winzappUnreadListenerScheduled" not in head
+
+
+class TestTheRetryBoundSurvives:
+    def test_it_still_gives_up_after_60_tries(self, installer):
+        assert "++tries > 60" in installer
+
+    def test_it_still_reports_which_outcome_it_reached(self, installer):
+        assert "installed after ${tries} retries" in installer
+        assert "GAVE UP after 60 retries" in installer
+
+    def test_the_interval_is_still_500ms(self, installer):
+        assert re.search(r"\}, 500\);", installer)


### PR DESCRIPTION
A user reports that opening WinZapp often syncs only some conversations, and that the only cure is quitting completely and reopening. His logs answer that, and rule out both of the suspected causes.

## Not the updater, and not a stale pin

That install is fully current, and everything from the recent work reached it and self-corrected:

| | |
| --- | --- |
| WinZapp | `1.1.0.2570alpha` |
| wppconnect | **2.3.3** — the homologated pin, every patch applied |
| wppconnect-server | **2.10.18** |
| WhatsApp Web pin | `2.3000.1046969912-alpha`, expires 2026-11-08 |

The log even carries the two lines added yesterday — `checkQrCode: no patch needed — wppconnect 2.3.3 carries the auth-probe fix upstream`, and `wa-js supports >=2.3000.1038792969-alpha` on the pin line.

*(One unrelated observation for the record: he runs an alpha with the alpha channel **off**, so he receives no alpha updates automatically.)*

## The real fault: two stores, and the empty one is the one being asked

```
09:07:35  list-chats -> 0
09:07:40  list-chats -> 37
09:07:46  list-chats -> 0     IndexedDB: 899
09:07:52  list-chats -> 0     IndexedDB: 900
...
09:16:24  list-chats -> 0     IndexedDB: 938
```

`WPP.chat.list()` reads the page's **in-memory** ChatStore. `storeCounts.chat` is read **straight out of IndexedDB** (`deviceController.ts`: *"Counts straight out of WhatsApp Web's own IndexedDB"*). The detection message said "reports N in its own store", which invited exactly the wrong reading — that a fresh page holding 0 in memory and 938 on disk is broken. It now names both stores.

## Why the escalation is removed, not retuned

The branch used to recreate the WPPConnect session after two such rounds, on the stated reasoning that *"nothing short of rebuilding the page recovers a store in this state"*. The log falsifies that directly.

The rebuild ran **exactly as designed** — `browserClose`, `Initializing browser`, `Loading WhatsApp WEB`, `pinned document served (#1)` with the counter reset, a new session reaching `inChat` — all inside **seven seconds**. `list-chats` answered 0 again **three seconds later**, against the same 938 chats. Four more rounds followed.

And it is destructive rather than merely useless: a new document starts that in-memory store empty and fills it from IndexedDB, so tearing the page down throws away whatever progress it had made. That is the most plausible reading of why the single non-zero answer in the whole session — 37 chats, five seconds after the session came up — was never built on.

What remains is what the branch already did: refuse the known-wrong snapshot, keep the sync incomplete, and let the health checker come back. Strictly better for this case, and no worse for the case the escalation was written for — where re-asking did not help either, over 37 minutes, *without anyone having rebuilt anything*.

`_BROKEN_STORE_REPAIR_ROUNDS` is kept and unused: it is the number this codebase used to rebuild on, and a reader finding the round counter needs to be able to find out what it meant.

## A second, unrelated defect in the same logs

A **single** scheduled unread-listener installer logged `installed after 0 retries` every 500 ms for **three minutes and ten seconds**, stopping only when the session was torn down. One `setInterval`, 364 lines, all reporting 0 retries — so the `if` body ran 364 times, which means `clearInterval(timer)` ran 364 times and did not stop it. The likeliest reason is that WhatsApp Web wraps `setInterval` for its own scheduler and returns a handle the native `clearInterval` does not recognise.

The fix does not depend on knowing that. The callback now sets a closure flag **before** touching `clearInterval`, and returns immediately on every later tick; a page-level guard stops `page.on('load')` stacking a second uncancellable timer on the first.

This is not the cause of the sync problem — the timer starts at 12:12 and `list-chats` was already 0 at 12:07 — but a `page.evaluate`'d loop running at 2 Hz inside WhatsApp Web while it loads a 900-chat account is not something to leave running.

## What this does not do

It does not make the in-memory store fill. The root cause is in the page/wa-js, as the 2026-08-20 commit that introduced this detection already concluded. This stops WinZapp making it worse and stops it destroying the evidence; whether the user still needs a manual restart is the next thing to measure, ideally against a log of an opening that *worked*.

## Tests

`tests/test_run_sync_broken_store.py` — one test inverted (it asserted the rebuild) with the field evidence in its docstring, plus two new ones pinning that no round count, however high, rebuilds.
`tests/test_unread_listener_timer_disarms.py` (10) — the flag is set before `clearInterval`, the callback returns early once settled, only one timer per page, the slot is released so a reload can install again, and the retry bound and both outcome messages survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)