### PR TITLE
Make the profile recovery reachable, and stop it eating its own snapshot

### DIFF
--- a/client/core/profile_recovery.py
+++ b/client/core/profile_recovery.py
@@ -245,32 +245,70 @@ def has_snapshot(global_dir, session_name):
 class ProfileHealthTracker:
     """Decides when a paired session's failure to start means a broken profile.
 
-    The signature is specific, and being specific is what keeps this from
-    firing on an ordinary offline spell: a session that is **paired** (there is
-    a token, so no pairing is pending), that WPPConnect reports as
-    INITIALIZING, and that then reaches CLOSED without ever having reported
-    CONNECTED. That is the browser starting, failing to bring WhatsApp Web up,
-    and being torn down — repeatedly.
+    The signature is: a **paired** session that has been observed trying to
+    start, that has reached CLOSED that many times, and that has never once
+    reported CONNECTED in between. That is the browser starting, failing to
+    bring WhatsApp Web up, and being torn down — repeatedly.
 
     A plain network outage does not look like this: an established session
-    reports CONNECTED first, and a session that never gets that far still
-    passes through CONNECTED at some point in the account's life. The tracker
-    resets on any CONNECTED, so a single good connection clears whatever came
-    before it.
+    reports CONNECTED, and any CONNECTED resets everything, so a single good
+    connection clears whatever came before it.
+
+    **What "observed trying to start" must not mean is "we caught a status
+    reading that said INITIALIZING".** That was the original rule and it made
+    the whole recovery unreachable in the field. Measured on a real broken
+    install: `check_wa_connection_http()` polls every 30 s while one failed
+    cycle takes ~60 s (start-session, browser up, wa-js never ready,
+    `injectApi()` times out at 30 s, CLOSED), and the poll only ever landed on
+    `disconnectedMobile` and `CLOSED`. INITIALIZING was seen exactly once, at
+    launch, and the old code cleared its arming flag on every CLOSED — so the
+    counter reached 1 and stayed there for the entire life of the process. The
+    log carried twelve minutes of that loop and not one `[profile-health]`
+    line, with a perfectly good snapshot sitting on disk. WhatsApp Web then
+    logged *itself* out of the unusable profile (`post_logout=1`,
+    `logout_reason=0`), and the user was left re-pairing an account whose
+    phone still listed the device as linked — restoring that snapshot by hand
+    brought the same login straight back, connected and syncing.
+
+    So arming is latched until CONNECTED, and `note_session_start_requested()`
+    arms it too: the health checker POSTing /start-session is direct evidence
+    that a start is being attempted, and it does not depend on a poll landing
+    inside a window narrower than the poll interval.
 
     Three cycles rather than one, because the first can be a slow machine and
-    the second can be the wake-from-hibernate path that already has its own
-    recovery; a profile that is genuinely unreadable fails every time.
+    the second the wake-from-hibernate path that has its own recovery; a
+    profile that is genuinely unreadable fails every time. At roughly a minute
+    per cycle that fires about three minutes in — comfortably before the
+    logged-out page starts pushing QR codes at the user, which on the measured
+    install took seven.
+
+    One case is deliberately accepted rather than excluded: a user who unlinks
+    the device from their phone produces the same readings, and this will
+    restore a snapshot whose credentials the server has already revoked. That
+    costs one cycle — WhatsApp Web rejects it and asks to pair again, which is
+    where they were going anyway — and `_recover_suspect_profile()` runs at
+    most once per launch, so it cannot loop. Being wrong in that direction
+    costs a minute; being wrong in the other direction is what this class was
+    written for, and it cost a re-pairing.
     """
 
-    #: Consecutive INITIALIZING->CLOSED cycles before the profile is suspect.
+    #: Consecutive failed start cycles before the profile is suspect.
     FAILED_CYCLES_BEFORE_SUSPECT = 3
 
     def __init__(self, threshold=None):
         self.threshold = threshold or self.FAILED_CYCLES_BEFORE_SUSPECT
         self.failed_cycles = 0
-        self._saw_initializing = False
+        self._armed = False
         self._ever_connected = False
+
+    def note_session_start_requested(self, paired=True):
+        """The health checker just POSTed /start-session for this session.
+
+        Arms the tracker without waiting for a poll to catch INITIALIZING —
+        see the class docstring for why that catch cannot be relied on.
+        """
+        if paired:
+            self._armed = True
 
     def note_status(self, status, paired=True):
         """Feed one status-session reading. Returns True the moment the profile
@@ -279,26 +317,37 @@ class ProfileHealthTracker:
         normalized = (status or "").upper()
         if normalized == "CONNECTED":
             self._ever_connected = True
-            self._saw_initializing = False
+            self._armed = False
             self.failed_cycles = 0
             return False
         if not paired:
             # Mid-pairing there is no profile worth preserving and no login to
             # lose, and the QR/code flow drives the session through these very
             # states on purpose.
-            self._saw_initializing = False
+            self._armed = False
             self.failed_cycles = 0
             return False
         if normalized == "INITIALIZING":
-            self._saw_initializing = True
+            self._armed = True
             return False
-        if normalized == "CLOSED" and self._saw_initializing:
-            self._saw_initializing = False
+        if normalized == "CLOSED" and self._armed:
+            # Deliberately stays armed. Clearing it here is the original bug:
+            # the next cycle's INITIALIZING falls between two polls and the
+            # count never advances again.
             self.failed_cycles += 1
             if self.failed_cycles == self.threshold:
                 return True
         return False
 
+    def ever_connected(self):
+        """Whether this session reported CONNECTED at least once this run.
+
+        Read by the snapshot side, not by the recovery side: a run that never
+        connected must not be allowed to overwrite the restore point that
+        would have rescued it. See _capture_profile_snapshot().
+        """
+        return self._ever_connected
+
     def reset(self):
         self.failed_cycles = 0
-        self._saw_initializing = False
+        self._armed = False

--- a/client/main.py
+++ b/client/main.py
@@ -8478,6 +8478,22 @@ class MainWindow(wx.Frame):
         except Exception:
             logging.exception("[profile-health] check failed (non-fatal)")
 
+    def _note_session_start_for_profile_health(self):
+        """Arm the profile-health tracker when we ask for a session start.
+
+        Wrapped like its sibling: profile health observes the connection poll
+        and must never be able to change that poll's verdict.
+        """
+        try:
+            tracker = getattr(self, "_profile_health", None)
+            if tracker is None:
+                from core.profile_recovery import ProfileHealthTracker
+                tracker = self._profile_health = ProfileHealthTracker()
+            paired = bool(self.settings.get("privateinfo", {}).get("paired"))
+            tracker.note_session_start_requested(paired=paired)
+        except Exception:
+            logging.exception("[profile-health] start note failed (non-fatal)")
+
     def _recover_suspect_profile(self):
         """Put the last clean-shutdown profile back, or say why we cannot.
 
@@ -8579,7 +8595,7 @@ class MainWindow(wx.Frame):
         core/profile_recovery.py for why a snapshot of a live profile is worse
         than no snapshot at all.
 
-        Two refusals, both deliberate:
+        Three refusals, all deliberate:
 
         * `browser_closed_cleanly` False means the graceful close-session never
           confirmed, so the leveldb may be mid-write. That is precisely the
@@ -8589,11 +8605,32 @@ class MainWindow(wx.Frame):
           megabytes would take the time away from the flush that prevents the
           corruption in the first place — and the run that most needs a
           snapshot is the one before, not this one.
+        * The session never reported CONNECTED in this run. A profile can be
+          quiescent, completely written, closed in perfect order — and hold no
+          login at all, because WhatsApp Web logged itself out of a profile it
+          could not use (`post_logout=1`) hours earlier. Snapshotting that
+          overwrites the one restore point that would have rescued the account
+          with a copy of the failure. It came within hours of happening on a
+          real install: the profile broke, the good snapshot was 16.5 h old,
+          and the 24 h refresh window was the only thing standing between a
+          successful hand-restore and a permanently lost session. Closing
+          cleanly is evidence about *how* the profile was written, never about
+          whether what was written is worth keeping.
 
         Never raises: a missing restore point is a nicety lost, while a
         teardown that dies here is the corruption itself.
         """
         if not session_name or not browser_closed_cleanly or budget is not None:
+            return
+        tracker = getattr(self, "_profile_health", None)
+        if tracker is not None and not tracker.ever_connected():
+            # Absent tracker means no connection poll ever ran, which is not
+            # evidence of anything — fall through and behave as before.
+            logging.info(
+                "[profile-snapshot] Not refreshing the restore point: this run "
+                "never reached CONNECTED, so the profile on disk may be the "
+                "broken one.")
+            self._shutdown_audit("profile snapshot skipped — never connected this run")
             return
         global_dir = getattr(self, "global_dir", None)
         if not global_dir:
@@ -11691,6 +11728,12 @@ class MainWindow(wx.Frame):
                             start_url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/start-session"
                             api_post(start_url, json={"waitQrCode": False}, headers=headers, timeout=10)
                             logging.info("[check_wa_connection_http] Sent auto-start session command")
+                            # Direct evidence that a start is being attempted.
+                            # The tracker used to depend on a 30 s poll landing
+                            # on INITIALIZING inside a ~60 s cycle, which in
+                            # the field it never did after launch — see
+                            # ProfileHealthTracker's own docstring.
+                            self._note_session_start_for_profile_health()
                         except Exception as e:
                             logging.error("[check_wa_connection_http] Failed to auto-start session: %s", e)
                 else:
@@ -15981,6 +16024,11 @@ class MainWindow(wx.Frame):
     # costs a single no-op CallAfter per second while everything is healthy.
     _UI_WATCHDOG_INTERVAL = 1.0
     _UI_WATCHDOG_STALL_SECONDS = 2.0
+    #: Longest gap between two reports of the *same* unchanging stack. The
+    #: sampling rate does not change, only how often an identical sample is
+    #: written, so a genuine freeze still leaves periodic evidence while an
+    #: open modal dialog costs one line a minute instead of thirty.
+    _UI_WATCHDOG_MAX_REPORT_GAP = 60.0
 
     def start_ui_watchdog(self):
         """Detect a frozen wx main loop and log *where* it is frozen.
@@ -16015,6 +16063,9 @@ class MainWindow(wx.Frame):
                 except Exception:
                     return          # app is going away
                 stalled = False
+                last_stack = None
+                next_report = 0.0
+                report_gap = self._UI_WATCHDOG_STALL_SECONDS
                 while not pong.wait(self._UI_WATCHDOG_STALL_SECONDS):
                     if getattr(self, "_shutting_down", False):
                         return
@@ -16022,9 +16073,25 @@ class MainWindow(wx.Frame):
                     frame = _sys._current_frames().get(main_id)
                     stack = ("".join(_traceback.format_stack(frame)) if frame
                              else "<main thread frame unavailable>")
-                    logging.warning(
-                        "[ui-watchdog] UI thread unresponsive for %.1fs — main thread stack:\n%s",
-                        time.monotonic() - t0, stack)
+                    elapsed = time.monotonic() - t0
+                    # A stack that keeps changing is the interesting case, so
+                    # it is always logged. An unchanging one is reported on a
+                    # doubling backoff instead of every couple of seconds,
+                    # because the longest "stall" this ever sees is not a bug
+                    # at all: a modal dialog runs its own event loop and never
+                    # answers the ping, so a re-pairing prompt left on screen
+                    # produced 1,400 lines of identical stack in four minutes
+                    # and buried the session failure that had opened it. The
+                    # log is truncated every launch and is the only record of
+                    # that failure; drowning it costs the diagnosis.
+                    if stack != last_stack or elapsed >= next_report:
+                        logging.warning(
+                            "[ui-watchdog] UI thread unresponsive for %.1fs — main thread stack:\n%s",
+                            elapsed, stack)
+                        last_stack = stack
+                        next_report = elapsed + report_gap
+                        report_gap = min(report_gap * 2,
+                                         self._UI_WATCHDOG_MAX_REPORT_GAP)
                 if stalled:
                     logging.warning(
                         "[ui-watchdog] UI thread responsive again after %.1fs.",

--- a/tests/test_profile_recovery.py
+++ b/tests/test_profile_recovery.py
@@ -254,3 +254,91 @@ class TestDecidingAProfileIsBroken:
             t.note_status("initializing")
             fired = t.note_status("closed")
         assert fired is True
+
+
+class TestTheRealBrokenInstallSequence:
+    """The sequence that shipped with the detector unreachable.
+
+    Read off log.log + wppconnect.log from a real install on 2026-09-08. The
+    health checker polls every 30 s; one failed cycle takes about 60 s
+    (/start-session, browser up, wa-js never ready, injectApi times out at
+    30 s, CLOSED). So the poll landed on INITIALIZING exactly once, at launch,
+    and thereafter only ever saw disconnectedMobile and CLOSED alternating.
+
+    The old rule cleared its arming flag on every CLOSED, so the counter
+    reached 1 and stayed there for the life of the process: twelve minutes of
+    that loop, zero [profile-health] lines, and a good snapshot on disk the
+    whole time. WhatsApp Web then logged itself out of the profile it could
+    not use (post_logout=1, logout_reason=0) and the user was asked to pair
+    again for an account whose phone still listed the device as linked —
+    restoring that snapshot by hand brought the same login straight back.
+    """
+
+    #: The statuses in the order the poll actually observed them.
+    OBSERVED = [
+        "INITIALIZING", "INITIALIZING",
+        "disconnectedMobile", "CLOSED",
+        "disconnectedMobile", "CLOSED",
+        "disconnectedMobile", "CLOSED",
+        "disconnectedMobile", "CLOSED",
+    ]
+
+    def test_the_recorded_sequence_now_fires(self):
+        t = pr.ProfileHealthTracker()
+        assert any(t.note_status(s) for s in self.OBSERVED)
+
+    def test_it_fires_before_the_logged_out_page_starts_pushing_qr_codes(self):
+        # On the measured install the break began at 11:29:55 and the QR
+        # reached the user at 11:37:10 — seven minutes. Each CLOSED here is
+        # about one minute apart, so firing on the third keeps a wide margin.
+        t = pr.ProfileHealthTracker()
+        fired_at = next(i for i, s in enumerate(self.OBSERVED)
+                        if t.note_status(s))
+        assert self.OBSERVED[fired_at] == "CLOSED"
+        assert self.OBSERVED[:fired_at + 1].count("CLOSED") == 3
+
+    def test_a_start_request_arms_it_without_any_initializing_reading(self):
+        """The poll may never catch INITIALIZING at all — the window is
+        narrower than the polling interval. Asking for a start is the
+        evidence that does not depend on timing."""
+        t = pr.ProfileHealthTracker()
+        fired = False
+        for _ in range(3):
+            t.note_session_start_requested()
+            fired = t.note_status("CLOSED") or fired
+        assert fired is True
+
+    def test_a_start_request_on_an_unpaired_account_arms_nothing(self):
+        t = pr.ProfileHealthTracker()
+        for _ in range(5):
+            t.note_session_start_requested(paired=False)
+            assert t.note_status("CLOSED", paired=False) is False
+
+    def test_a_connection_still_clears_a_latched_arming(self):
+        t = pr.ProfileHealthTracker()
+        t.note_status("INITIALIZING")
+        t.note_status("CLOSED")
+        t.note_status("CONNECTED")
+        for _ in range(5):
+            assert t.note_status("CLOSED") is False
+
+
+class TestEverConnected:
+    """Read by the snapshot side so a run that never worked cannot overwrite
+    the restore point that would have rescued it."""
+
+    def test_a_fresh_tracker_has_not_connected(self):
+        assert pr.ProfileHealthTracker().ever_connected() is False
+
+    def test_one_connection_is_remembered_through_later_failures(self):
+        t = pr.ProfileHealthTracker()
+        t.note_status("CONNECTED")
+        t.note_status("INITIALIZING")
+        t.note_status("CLOSED")
+        assert t.ever_connected() is True
+
+    def test_a_run_that_only_ever_failed_reports_false(self):
+        t = pr.ProfileHealthTracker()
+        for s in ("INITIALIZING", "disconnectedMobile", "CLOSED", "QRCODE"):
+            t.note_status(s)
+        assert t.ever_connected() is False

--- a/tests/test_profile_recovery_wiring.py
+++ b/tests/test_profile_recovery_wiring.py
@@ -199,3 +199,87 @@ class TestTheTrackerItselfIsTheOneUsed:
         stub = _Stub()
         _note(stub, "INITIALIZING")
         assert isinstance(stub._profile_health, ProfileHealthTracker)
+
+
+class TestTheStartRequestArmsTheDetector:
+    """/start-session is the timing-independent evidence that a start is being
+    attempted; the INITIALIZING window is narrower than the polling interval,
+    so the poll cannot be relied on to catch it. See the tracker's docstring."""
+
+    def _start(self, stub):
+        return MainWindow._note_session_start_for_profile_health(stub)
+
+    def test_start_requests_alone_reach_the_threshold(self):
+        stub = _Stub()
+        for _ in range(3):
+            self._start(stub)
+            _note(stub, "CLOSED")
+        assert stub.recovered == 1
+
+    def test_the_real_broken_installs_poll_sequence_recovers(self):
+        # The readings log.log actually recorded on 2026-09-08, with the
+        # start-session POSTs the health checker made between them.
+        stub = _Stub()
+        _note(stub, "INITIALIZING")
+        for _ in range(3):
+            _note(stub, "disconnectedMobile")
+            _note(stub, "CLOSED")
+            self._start(stub)
+        assert stub.recovered == 1
+
+    def test_an_unpaired_account_is_still_never_touched(self):
+        stub = _Stub(paired=False)
+        for _ in range(6):
+            self._start(stub)
+            _note(stub, "CLOSED")
+        assert stub.recovered == 0
+
+    def test_a_broken_tracker_never_breaks_the_health_poll(self, monkeypatch):
+        """Same rule as its sibling: profile health observes the connection
+        poll and must never be able to change that poll's verdict."""
+        stub = _Stub()
+        stub.settings = None          # any access raises
+        self._start(stub)             # must not propagate
+
+
+class TestARunThatNeverConnectedMayNotOverwriteTheRestorePoint:
+    """The trap that came within hours of costing a real session.
+
+    Closing cleanly is evidence about *how* the profile was written, never
+    about whether what was written is worth keeping. On 2026-09-08 the profile
+    stopped carrying a login, WhatsApp Web logged itself out of it, and the
+    good snapshot was 16.5 h old — the only thing standing between a
+    successful hand-restore and a permanently lost session was the 24 h
+    refresh window not having elapsed yet.
+    """
+
+    @pytest.fixture
+    def captured(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr("core.profile_recovery.capture_snapshot",
+                            lambda *a, **kw: calls.append(a) or True)
+        return calls
+
+    def test_a_clean_close_after_a_run_that_never_connected_is_refused(self, captured):
+        stub = _Stub()
+        _note(stub, "INITIALIZING")
+        _note(stub, "CLOSED")
+        MainWindow._capture_profile_snapshot(stub, "sess123", True, None)
+        assert captured == []
+        assert any("never connected" in line for line in stub.audits)
+
+    def test_a_run_that_connected_at_some_point_still_snapshots(self, captured):
+        stub = _Stub()
+        _note(stub, "CONNECTED")
+        _note(stub, "CLOSED")        # ordinary quit after a healthy session
+        MainWindow._capture_profile_snapshot(stub, "sess123", True, None)
+        assert len(captured) == 1
+
+    def test_no_tracker_at_all_behaves_as_before(self, captured):
+        """Absent tracker means no connection poll ever ran, which is not
+        evidence of anything — refusing there would silently stop snapshotting
+        on installs this was never meant to touch."""
+        stub = _Stub()
+        assert not hasattr(stub, "_profile_health")
+        MainWindow._capture_profile_snapshot(stub, "sess123", True, None)
+        assert len(captured) == 1

--- a/tests/test_ui_watchdog.py
+++ b/tests/test_ui_watchdog.py
@@ -32,6 +32,7 @@ class _Stub:
     # seconds (asserted separately below).
     _UI_WATCHDOG_INTERVAL = 0.02
     _UI_WATCHDOG_STALL_SECONDS = 0.05
+    _UI_WATCHDOG_MAX_REPORT_GAP = 0.2
 
     def __init__(self):
         self._shutting_down = False
@@ -137,3 +138,35 @@ class TestUiWatchdog:
         real load on the very loop it is measuring."""
         assert MainWindow._UI_WATCHDOG_INTERVAL >= 1.0
         assert MainWindow._UI_WATCHDOG_STALL_SECONDS >= 2.0
+
+
+class TestAnUnchangingStackIsNotRepeatedForever:
+    """A modal dialog is indistinguishable from a freeze, from out here.
+
+    `_show_repair_dialog()` runs its own event loop and never answers the
+    ping, so on a real install a re-pairing prompt left on screen produced
+    1,400 lines of identical stack in four minutes. log.log is truncated every
+    launch and was the only record of the session failure that had opened that
+    dialog, so the noise cost the diagnosis. Sampling still happens at the
+    stall interval; only the *writing* of an unchanged sample backs off.
+    """
+
+    def test_reports_of_an_identical_stack_thin_out(self, fake_main_loop, caplog):
+        caplog.set_level(logging.WARNING)
+        s = _Stub()
+        s.start_ui_watchdog()
+        time.sleep(0.6)
+        stalls = [r for r in caplog.records if "unresponsive" in r.getMessage()]
+        _stop(s)
+
+        # Un-backed-off, a 0.05s sampling interval over 0.6s would be ~12
+        # lines. The cap is 0.2s, so it cannot exceed roughly a third of that.
+        assert 2 <= len(stalls) <= 6, len(stalls)
+
+    def test_a_changing_stack_is_always_reported(self):
+        # The interesting freeze moves between calls, and must never be
+        # thinned: only an identical sample waits for the backoff.
+        assert MainWindow._UI_WATCHDOG_MAX_REPORT_GAP > MainWindow._UI_WATCHDOG_STALL_SECONDS
+
+    def test_the_shipped_cap_is_a_minute(self):
+        assert MainWindow._UI_WATCHDOG_MAX_REPORT_GAP == 60.0


### PR DESCRIPTION
Diagnosed and **recovered live** on a real install on 2026-09-08. Every piece of the recovery already existed; only the trigger was unreachable.

## What happened

The account went offline after an update, looped `/start-session` for twelve minutes, and was then asked to pair again — for a device the phone still listed as linked. Restoring the 16.5-hour-old snapshot by hand (through the shipped `restore_snapshot()`) brought the same login back, `CONNECTED` and syncing in twenty seconds, and it has stayed connected since.

Two things that narrow the cause and are worth recording:

- **The LevelDB was not corrupt.** `LOG`/`LOG.old` from the broken profile show a clean `Reusing MANIFEST` / `Recovering log` / `Compacted 1@0 + 5@1 files` with no errors. So this is not the half-written-leveldb family; the file was fine and the *login inside it* was gone.
- **It was not an updater race.** The generated `.bat` waits on the WinZapp PID (`:WAIT` / `tasklist /FI "PID eq <pid>"`) before touching port 6300, and `shutdown_audit.log` shows the graceful close completing first: `close-session POSTed` → `FLUSH OK` → `Chrome released the profile before the kill` → `taskkill node`.

## Why the recovery never fired

`ProfileHealthTracker` required INITIALIZING and CLOSED as *consecutive* readings and cleared its arming flag on every CLOSED. `check_wa_connection_http()` polls every 30 s while one failed cycle takes ~60 s (start-session, browser up, wa-js never ready, `injectApi` times out at 30 s, CLOSED). So the poll caught INITIALIZING once, at launch, and after that only `disconnectedMobile` and `CLOSED` alternating:

```
11:29:55 INITIALIZING    → armed
11:30:55 CLOSED          → failed_cycles = 1
11:31:55 CLOSED          → not counted (no INITIALIZING seen since)
...                        stuck at 1 of 3, forever
```

Twelve minutes of that, zero `[profile-health]` lines, snapshot on disk the whole time.

## Changes

- Arming is **latched until CONNECTED**, and `note_session_start_requested()` arms it from the health checker's own `/start-session` POST — evidence that does not depend on a poll landing inside a window narrower than the poll interval. On the recorded sequence this fires on the third CLOSED, ~3 min in; the logged-out page took 7 min to start pushing QR codes at the user.
- `_capture_profile_snapshot()` gains a third refusal: **a run that never reported CONNECTED**. Closing cleanly is evidence about *how* the profile was written, never about whether what was written is worth keeping. Here the good snapshot was 16.5 h old against a 24 h refresh window — that margin was the only thing between a successful restore and a session lost for good.
- The UI watchdog backs off on an *unchanging* stack, capped at a minute. The longest stall it ever sees is not a bug: a modal dialog runs its own event loop and never answers the ping, so the re-pairing prompt this failure opens produced 1,400 lines of identical stack in four minutes, burying the session failure in a log that is truncated every launch. A changing stack is still always logged.

One case is accepted deliberately: a user who unlinks from their phone produces the same readings and will get a revoked snapshot restored. That costs one cycle before WhatsApp Web asks to pair again — where they were going anyway — and `_recover_suspect_profile()` runs at most once per launch.

## Tests

`tests/test_profile_recovery.py`, `tests/test_profile_recovery_wiring.py`, `tests/test_ui_watchdog.py` — including the literal status sequence read off the broken install's `log.log`, which the old rule does not fire on and the new one does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)