### PR TITLE
Space out the phone-history requests instead of firing them in bursts

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -17365,7 +17365,27 @@ class MainWindow(wx.Frame):
     # burst of automation traffic on top of the media phase.
     _BACKFILL_WORKERS     = 3
     _BACKFILL_CHUNK       = 60     # chats re-queried per pass
-    _OLDER_REQUESTS_PER_PASS = 10  # bounded phone-history requests per pass
+    # Phone-history requests per pass. **One**, not a batch, and the reason is
+    # not load: every one of these lights up the user's phone with a sync
+    # notification (see request_older_messages()). Ten per pass meant four of
+    # them inside 900 ms on a real install — the phone stacks four
+    # notifications, which reads as WinZapp spamming even though each request
+    # was productive. One per pass is the same throughput spread over the pass
+    # loop, and the user sees one notification resolve before the next starts.
+    _OLDER_REQUESTS_PER_PASS = 1
+
+    #: Floor between any two phone-history requests, whatever the pass loop is
+    #: doing. The backoff below is not a substitute: it collapses back to
+    #: _BACKFILL_FIRST_DELAY the moment a pass makes progress, and a chunk
+    #: landing *is* progress — so a productive request guarantees the next pass
+    #: 30 s later, which is precisely the burst being removed. Measured on a
+    #: real install: passes settled at the 5-minute ceiling, then ran at 32 s
+    #: intervals for three passes as soon as chunks started landing.
+    #:
+    #: Two minutes keeps the total unchanged (16 requests in 20 minutes on that
+    #: install) while never bunching them. Nothing here is urgent — this is
+    #: history the user is not looking at yet.
+    _PHONE_REQUEST_MIN_GAP = 120
 
     @classmethod
     def _initial_backfill_delay(cls, short_chats_pending: bool) -> int:
@@ -17377,6 +17397,20 @@ class MainWindow(wx.Frame):
                                           continuing_short_sweep: bool) -> bool:
         """Names and deep history must not block short-page recovery."""
         return not short_chats_pending and not continuing_short_sweep
+
+    @staticmethod
+    def _phone_request_gap_elapsed(last_at, now_monotonic, min_gap) -> bool:
+        """Whether enough time has passed since the last phone-history request.
+
+        A floor that the pass loop cannot talk its way out of. Every request
+        this gates is a notification on the user's phone, and the pass cadence
+        is driven by whether the *queue* is advancing — which a successful
+        request makes true, so the requests kept pulling their own next round
+        forward. Monotonic on purpose: a clock change must not open the gate.
+        """
+        if last_at is None:
+            return True
+        return (now_monotonic - last_at) >= min_gap
 
     @classmethod
     def _backfill_short_queue_delays(cls, retry_delay: int, sweep_finished: bool,
@@ -18185,6 +18219,21 @@ class MainWindow(wx.Frame):
                 # from 15 to 90 messages made real progress and must not read as
                 # a wasted pass — that is what backs the delay off.
                 counts_before = {j: self._local_record_count(j) for j in window}
+                # ...and which message is the oldest one on disk, which is the
+                # only signal that separates "the phone sent us older history"
+                # from "someone wrote in this chat". See the phone-request
+                # block below for why that distinction is load-bearing.
+                #
+                # Only for the chats that could possibly ask the phone this
+                # pass: this is a SQLite read each, and a window is up to
+                # _BACKFILL_CHUNK chats while the short queue is typically a
+                # handful. A chat already holding a full page is not a
+                # candidate and is not read.
+                _target = self.history_page_target()
+                oldest_before = {
+                    j: self._anchor_identity(self._oldest_stored_message(j))
+                    for j, c in counts_before.items() if c < _target
+                }
                 if targets:
                     with ThreadPoolExecutor(max_workers=self._BACKFILL_WORKERS) as pool:
                         futs = [pool.submit(
@@ -18209,13 +18258,25 @@ class MainWindow(wx.Frame):
                 attempts = getattr(self, "_older_request_attempts", None)
                 if attempts is None:
                     attempts = self._older_request_attempts = {}
+                older_arrived = set()
                 for jid, was in counts_before.items():
                     now = self._local_record_count(jid)
-                    if now > was:
-                        # The chat gained messages, so whatever was asked for
-                        # arrived: the attempt budget below starts over. Only a
-                        # chat that asks and gains nothing ever spends it.
+                    if jid in oldest_before and (
+                            self._anchor_identity(self._oldest_stored_message(jid))
+                            != oldest_before[jid]):
+                        # *Older* history arrived, so the ask this chat spent
+                        # its budget on worked and the budget starts over.
+                        #
+                        # Deliberately not "the record count grew". A chat also
+                        # grows when a message is sent or received in it, and
+                        # reading that as backfill progress hands the chat two
+                        # more phone requests — so every message the user sends
+                        # into a short chat buys itself a round of sync
+                        # notifications. The oldest stored message can only stay
+                        # put or move further back (see _anchor_identity), which
+                        # is exactly the question being asked here.
                         attempts.pop(jid, None)
+                        older_arrived.add(jid)
                     if now >= self.history_page_target() or now > was:
                         continue
                     self._keep_backfill_pending(jid, now)
@@ -18227,7 +18288,12 @@ class MainWindow(wx.Frame):
                         continue
                     if phone_requests_left <= 0:
                         continue
+                    if not MainWindow._phone_request_gap_elapsed(
+                            getattr(self, "_last_phone_request_at", None),
+                            time.monotonic(), self._PHONE_REQUEST_MIN_GAP):
+                        continue
                     phone_requests_left -= 1
+                    self._last_phone_request_at = time.monotonic()
                     attempts[jid] = attempts.get(jid, 0) + 1
                     requested = self.request_older_messages(jid)
                     if requested is True:
@@ -18265,11 +18331,20 @@ class MainWindow(wx.Frame):
                 grew = sum(1 for j, was in counts_before.items()
                            if self._local_record_count(j) > was)
                 logging.info(
-                    "[backfill] Pass %d: %d chat(s) gained messages, %d no longer pending "
-                    "(of %d).", attempt, grew, completed, before)
+                    "[backfill] Pass %d: %d chat(s) gained messages (%d of them older "
+                    "history), %d no longer pending (of %d).",
+                    attempt, grew, len(older_arrived), completed, before)
                 made_progress = (grew > 0 or completed > 0 or named > 0
                                  or deep_stored > 0)
-                sweep_made_progress = sweep_made_progress or made_progress
+                # What may pull the *next* pass forward is narrower than what
+                # justifies a repaint. A live message arriving in a short chat
+                # is real progress for the UI and no evidence at all that the
+                # phone has more history to give — resetting the backoff on it
+                # is how an ordinary conversation drags the whole queue back to
+                # a 30 s cadence, and with it the sync notifications.
+                queue_advanced = (len(older_arrived) > 0 or completed > 0
+                                  or named > 0 or deep_stored > 0)
+                sweep_made_progress = sweep_made_progress or queue_advanced
                 if made_progress:
                     # Unread badges, the "is this chat worth showing" decision and
                     # the displayed name all depend on this, so rebuild the list.

--- a/tests/load/test_message_backfill_load.py
+++ b/tests/load/test_message_backfill_load.py
@@ -132,6 +132,13 @@ class _SweepLoadStub:
     _backfill_short_queue_delays = MainWindow._backfill_short_queue_delays
     _keep_backfill_pending = MainWindow._keep_backfill_pending
     history_page_target = MainWindow.history_page_target
+    # The backfill reads the oldest stored message per short chat to tell
+    # "the phone sent older history" apart from "someone wrote in this chat".
+    # Bound from the real class, against a db that answers nothing, so this
+    # load test keeps measuring the per-pass cost of that read.
+    _oldest_stored_message = MainWindow._oldest_stored_message
+    _anchor_identity = staticmethod(MainWindow._anchor_identity)
+    _phone_request_gap_elapsed = staticmethod(MainWindow._phone_request_gap_elapsed)
 
     _BACKFILL_BUDGET = MainWindow._BACKFILL_BUDGET
     _BACKFILL_LANDING_BUDGET = MainWindow._BACKFILL_LANDING_BUDGET
@@ -143,6 +150,8 @@ class _SweepLoadStub:
     _DEEP_CHATS_PER_PASS = MainWindow._DEEP_CHATS_PER_PASS
     _OLDER_REQUESTS_PER_PASS = MainWindow._OLDER_REQUESTS_PER_PASS
     _OLDER_REQUEST_GRACE = getattr(MainWindow, "_OLDER_REQUEST_GRACE", 300)
+    _MAX_PHONE_HISTORY_REQUESTS = MainWindow._MAX_PHONE_HISTORY_REQUESTS
+    _PHONE_REQUEST_MIN_GAP = MainWindow._PHONE_REQUEST_MIN_GAP
 
     def __init__(self, chat_count: int):
         self._backfill_state_lock = threading.RLock()

--- a/tests/test_deep_history_backfill.py
+++ b/tests/test_deep_history_backfill.py
@@ -539,3 +539,51 @@ class TestBackgroundNeverFloodsThePhone:
         stub.deep_backfill_chat("chat@g.us")
 
         assert stub.requested == []
+
+
+class TestOlderHistoryIsToldApartFromANewMessage:
+    """The signal the backfill's phone requests are budgeted on.
+
+    `_backfill_empty_chats()` used to read "the record count grew" as "the ask
+    we spent this chat's budget on worked", which handed the chat a fresh
+    budget — and two more sync notifications on the user's phone — every time
+    anyone wrote in it. Reported on 2026-09-08 as notifications firing while
+    sending a message. The oldest stored message can only stay put or move
+    further back (see `_anchor_identity`), so it answers the narrower question
+    the budget actually meant to ask.
+    """
+
+    OLD = {"key": {"id": "OLD"}, "messageTimestamp": 1000}
+    OLDER = {"key": {"id": "OLDER"}, "messageTimestamp": 500}
+
+    def _stub(self, oldest):
+        stub = _Stub(pages=[])
+        stub.db = _DB({"5511@s.whatsapp.net": oldest})
+        return stub
+
+    def _anchor(self, stub):
+        return MainWindow._anchor_identity(
+            MainWindow._oldest_stored_message(stub, "5511@s.whatsapp.net"))
+
+    def test_a_newer_message_leaves_the_anchor_untouched(self):
+        # Sending or receiving adds at the top; the oldest row does not move.
+        stub = self._stub(self.OLD)
+        before = self._anchor(stub)
+        stub.db.oldest["5511@s.whatsapp.net"] = self.OLD   # unchanged
+        assert self._anchor(stub) == before
+
+    def test_older_history_landing_moves_the_anchor(self):
+        stub = self._stub(self.OLD)
+        before = self._anchor(stub)
+        stub.db.oldest["5511@s.whatsapp.net"] = self.OLDER
+        assert self._anchor(stub) != before
+
+    def test_two_messages_sharing_a_timestamp_are_still_told_apart(self):
+        # Why identity and not order: get_messages_asc() breaks a tie on id.
+        a = MainWindow._anchor_identity({"key": {"id": "A"}, "messageTimestamp": 1000})
+        b = MainWindow._anchor_identity({"key": {"id": "B"}, "messageTimestamp": 1000})
+        assert a != b
+
+    def test_an_empty_chat_has_a_stable_anchor(self):
+        stub = self._stub(None)
+        assert self._anchor(stub) == self._anchor(stub)

--- a/tests/test_history_sync_on_demand.py
+++ b/tests/test_history_sync_on_demand.py
@@ -1038,3 +1038,56 @@ class TestBackfillPhoneRequestBudget:
         stub._persist_older_requested = lambda: None
         MainWindow._forget_history_exhaustion(stub)
         assert stub._older_request_attempts == {}
+
+
+class TestPhoneRequestsAreSpacedNotBunched:
+    """Every phone-history request is a notification on the user's phone.
+
+    Read off a real install on 2026-09-08, running the bounded-attempts fix:
+    the requests were *productive* (one chat walked 50 -> 63 -> 113 -> 163
+    messages, another 2 -> 52 -> 102), so the answer is not to stop asking.
+    What the user actually reported was the bunching — four requests inside
+    900 ms, and bursts that kept arriving while he was using the app.
+
+    Two things caused that, and both are gone:
+
+      * ten requests per pass, fired back to back;
+      * a backoff that collapsed to _BACKFILL_FIRST_DELAY whenever a pass made
+        progress — and a chunk landing *is* progress, so every productive
+        request bought itself another pass 30 s later. On that install the
+        passes had settled at the 5-minute ceiling and then ran at 32 s
+        intervals for three passes as soon as chunks began landing.
+    """
+
+    GAP = MainWindow._PHONE_REQUEST_MIN_GAP
+
+    def test_only_one_request_leaves_per_pass(self):
+        assert MainWindow._OLDER_REQUESTS_PER_PASS == 1
+
+    def test_the_first_request_of_a_run_is_never_held_back(self):
+        assert MainWindow._phone_request_gap_elapsed(None, 10_000.0, self.GAP) is True
+
+    def test_a_second_request_inside_the_gap_is_refused(self):
+        assert MainWindow._phone_request_gap_elapsed(
+            1000.0, 1000.0 + self.GAP - 1, self.GAP) is False
+
+    def test_the_gap_elapsing_lets_the_next_one_through(self):
+        assert MainWindow._phone_request_gap_elapsed(
+            1000.0, 1000.0 + self.GAP, self.GAP) is True
+
+    def test_the_measured_burst_would_now_be_one_request(self):
+        # The four requests the install actually sent, in monotonic seconds
+        # relative to the first: 0.000, 0.045, 0.249, 0.448.
+        last = None
+        sent = 0
+        for offset in (0.0, 0.045, 0.249, 0.448):
+            if MainWindow._phone_request_gap_elapsed(last, offset, self.GAP):
+                sent += 1
+                last = offset
+        assert sent == 1
+
+    def test_the_gap_is_long_enough_to_separate_two_notifications(self):
+        # Short enough that the backfill still finishes in the same order of
+        # time (16 requests in 20 minutes on the measured install), long
+        # enough that two notifications never stack.
+        assert 60 <= MainWindow._PHONE_REQUEST_MIN_GAP <= 300


### PR DESCRIPTION
Follow-up to #179, diagnosed from a real install already running that fix.

## The requests are productive — that changes the fix

```
232022857539711@lid :  50 → 63 → 113 → 163 messages
9045234692316@lid   :   2 → 52 → 102
78615182094571@lid  :   1 → 10
```

~50 messages arrive per request. Every notification on the user's phone is the phone actually shipping a chunk of his history, which is why it appears and then clears. So the answer is not to stop asking — it is to stop asking *in bursts*.

## Three causes

**Ten requests per pass, back to back.** Four went out inside 900 ms; the phone stacks four notifications. Now one per pass.

**The backoff defeated itself.** `_backfill_short_queue_delays()` resets to `_BACKFILL_FIRST_DELAY` whenever a pass made progress — and a chunk landing *is* progress, so every productive request bought itself another pass 30 s later:

```
pass 6  15:24:24
pass 7  15:29:25   (+5 min — the ceiling)
pass 8  15:34:25   (+5 min)
pass 9  15:34:57   (+32 s)  ← collapsed as chunks landed
pass 10 15:35:29   (+32 s)
pass 11 15:36:29   (+60 s)
```

`_PHONE_REQUEST_MIN_GAP` (120 s) is a floor the pass loop cannot talk its way out of, monotonic so a clock change cannot open it either. The total is unchanged — 16 requests in 20 minutes on that install — they just stop arriving together.

**"Progress" meant "the record count grew".** A chat also grows when a message is sent or received in it. #179 hung the attempt budget on that signal, so writing in a short chat handed it two fresh phone requests — which is the user's own report: notifications firing while he sent a message. Both the budget and the backoff now key on the oldest stored message, which can only stay put or move further back (see `_anchor_identity`). The repaint still keys on any growth: a live message is real progress for the UI and no evidence at all about the phone.

The anchor is read only for chats under `history_page_target()` — one SQLite read each, and a window is up to `_BACKFILL_CHUNK` chats while the short queue is typically a handful. `tests/load`'s stub binds both helpers from the real class so that per-pass cost stays measured.

## Not fixed, because the logs refute it

The user attributed the notifications to a slow send (12.4 s, `242558294872167@lid`, 15:25:44→15:25:56). There were **no** phone requests within seven minutes either side of it, and the log is silent between 15:25:45.9 and 15:25:55.3 — those seconds were spent inside WhatsApp Web. The burst he saw was the one at 15:34:58, 13 s after a different send.

## Tests

`tests/test_history_sync_on_demand.py` (the measured 4-in-900 ms burst, replayed, now yields one request), `tests/test_deep_history_backfill.py` (older history vs. a new message, including the shared-timestamp tie-break), `tests/load/test_message_backfill_load.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)