### PR TITLE
Repair the profile when the QR arrives, not three status polls later

### DIFF
--- a/client/core/profile_recovery.py
+++ b/client/core/profile_recovery.py
@@ -88,6 +88,28 @@ def snapshot_dir(global_dir, session_name):
     return os.path.join(global_dir, "api", SNAPSHOT_DIR_NAME, session_name)
 
 
+def previous_snapshot_dir(global_dir, session_name):
+    """The snapshot the last refresh replaced.
+
+    Kept because a clean close is not proof that the profile it wrote will
+    still authenticate. Measured across one day on a real install: four clean
+    shutdowns, each with close-session acknowledged, the session observed
+    CLOSED and Chrome confirmed to have released the profile — and two of the
+    four were followed by a launch where WhatsApp Web logged itself out seven
+    seconds into the page load. The two hard-killed runs that day both came
+    back fine, which is the opposite of what the module docstring above
+    predicts.
+
+    So `capture_snapshot()`'s conditions can all hold and still write a
+    restore point that does not work, and on that install the good one was
+    22.7 h old against a 24 h refresh window: one more hour and the refresh
+    would have overwritten the only profile that still authenticated. Keeping
+    the generation it replaces costs one extra copy on disk and is the
+    difference between a recoverable session and a re-pairing.
+    """
+    return snapshot_dir(global_dir, session_name) + ".prev"
+
+
 def snapshot_age_seconds(global_dir, session_name, now=None):
     """Seconds since this session's snapshot was completed, or None if there
     is none. Read off the directory itself, which `capture_snapshot()` renames
@@ -184,6 +206,22 @@ def capture_snapshot(global_dir, session_name, budget=SNAPSHOT_BUDGET_SECONDS,
         shutil.rmtree(staged, ignore_errors=True)
         os.makedirs(staged, exist_ok=True)
         _copy_tree_bounded(source, staged, deadline)
+        # Demote the snapshot being replaced rather than dropping it. See
+        # previous_snapshot_dir(): a clean close is not proof that what it
+        # wrote will authenticate on the next load, and the generation being
+        # overwritten is the one already known to have worked. Everything above
+        # happened in `staged`, so a failure before this point still leaves
+        # both generations untouched.
+        previous = previous_snapshot_dir(global_dir, session_name)
+        if os.path.isdir(final):
+            shutil.rmtree(previous, ignore_errors=True)
+            try:
+                os.replace(final, previous)
+            except OSError as exc:
+                # Not fatal: losing the older generation costs a fallback,
+                # while refusing to refresh at all costs the restore point.
+                logging.warning("[profile-snapshot] could not keep the previous "
+                                "generation for %s: %s", session_name[:12], exc)
         _replace_directory(staged, final)
         logging.info("[profile-snapshot] restore point written for session %s",
                      session_name[:12])
@@ -197,8 +235,13 @@ def capture_snapshot(global_dir, session_name, budget=SNAPSHOT_BUDGET_SECONDS,
         return False
 
 
-def restore_snapshot(global_dir, session_name):
+def restore_snapshot(global_dir, session_name, prefer_previous=False):
     """Put the saved profile back. Returns True if the live profile was replaced.
+
+    `prefer_previous` restores the generation before the newest one — the
+    ladder for the case the newest snapshot is itself a profile that no longer
+    authenticates. See previous_snapshot_dir() for why that is reachable from
+    a shutdown that did everything right.
 
     The caller must have stopped Chrome first — restoring under a running
     browser would be overwriting a LevelDB while its owner holds it open, i.e.
@@ -208,7 +251,8 @@ def restore_snapshot(global_dir, session_name):
     is the only evidence of what went wrong, and deleting the one copy of a
     failure nobody has reproduced is how a bug survives another release.
     """
-    source = snapshot_dir(global_dir, session_name)
+    source = (previous_snapshot_dir(global_dir, session_name) if prefer_previous
+              else snapshot_dir(global_dir, session_name))
     if not os.path.isdir(source):
         return False
     live = profile_dir(global_dir, session_name)
@@ -238,8 +282,10 @@ def restore_snapshot(global_dir, session_name):
         return False
 
 
-def has_snapshot(global_dir, session_name):
-    return os.path.isdir(snapshot_dir(global_dir, session_name))
+def has_snapshot(global_dir, session_name, prefer_previous=False):
+    return os.path.isdir(previous_snapshot_dir(global_dir, session_name)
+                         if prefer_previous
+                         else snapshot_dir(global_dir, session_name))
 
 
 class ProfileHealthTracker:

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -833,6 +833,35 @@ class WebSocketClient:
             mw.settings.get("privateinfo", {}).get("paired")
             and not getattr(mw, "_auto_repair_dialog_shown", False)
         ):
+            # Try to repair the profile before sending the user off to pair by
+            # hand. This event is the *earliest and strongest* evidence that
+            # the Chrome profile lost its login: as this method's own docstring
+            # says, WPPConnect only mints a code once it has decided the stored
+            # session cannot be restored — which is exactly the condition
+            # ProfileHealthTracker spends minutes trying to infer from
+            # status-session strings.
+            #
+            # Measured on a real install on 2026-09-08: a clean Ctrl+Shift+Q
+            # shutdown, and the next launch logged itself out 7 s into the page
+            # load. The tracker counted INITIALIZING/CLOSED cycles at ~60 s
+            # each and had reached 2 of 3 when the code arrived at t+2.4 min —
+            # and _show_repair_dialog() then froze it there for good, because
+            # check_wa_connection_http() returns immediately while a pairing
+            # dialog is up, so the poll that feeds the tracker never ran again.
+            # The restore was reachable by hand and never by the app; doing it
+            # here removes the race instead of retuning it.
+            #
+            # A user who genuinely unlinked from their phone lands here too and
+            # gets a snapshot whose credentials the server has already revoked.
+            # That costs one cycle before the dialog appears after all —
+            # _recover_suspect_profile() runs at most once per launch and calls
+            # back when it gives up — against a re-pairing saved every time the
+            # profile was the actual fault.
+            if mw._recover_suspect_profile(
+                    reason="WPPConnect minted a pairing code for a paired "
+                           "install — the stored session could not be restored",
+                    on_give_up=self._show_repair_dialog):
+                return
             self._show_repair_dialog()
             return
         if seen == self._UNATTENDED_QR_LIMIT:

--- a/client/main.py
+++ b/client/main.py
@@ -8473,6 +8473,11 @@ class MainWindow(wx.Frame):
                 from core.profile_recovery import ProfileHealthTracker
                 tracker = self._profile_health = ProfileHealthTracker()
             paired = bool(self.settings.get("privateinfo", {}).get("paired"))
+            if ((status or "").upper() == "CONNECTED"
+                    and self._profile_recovery_generation()):
+                # Whatever was put back is working. The ladder starts over, so
+                # a future break restores the newest snapshot first again.
+                self._set_profile_recovery_generation(0)
             if tracker.note_status(status, paired=paired):
                 self._recover_suspect_profile()
         except Exception:
@@ -8494,8 +8499,19 @@ class MainWindow(wx.Frame):
         except Exception:
             logging.exception("[profile-health] start note failed (non-fatal)")
 
-    def _recover_suspect_profile(self):
+    def _recover_suspect_profile(self, reason="session started and died 3x "
+                                              "without connecting",
+                                 on_give_up=None):
         """Put the last clean-shutdown profile back, or say why we cannot.
+
+        Returns True when a restore was actually started, and `on_give_up` is
+        called — on the UI thread — if that restore then fails. A False return
+        means nothing was started and the caller should handle it inline;
+        `on_give_up` is deliberately *not* called in that case, so a caller
+        that both passes it and falls through on False cannot act twice. The
+        QR caller is exactly that shape: it is choosing between repairing the
+        profile and sending the user off to re-pair by hand, and only one of
+        those may happen.
 
         Runs at most once per launch. The retry it triggers is the ordinary
         health-checker /start-session on the next poll, so if the restore did
@@ -8510,19 +8526,36 @@ class MainWindow(wx.Frame):
         its fallback — the same helper _stop_wpp_server() relies on.
         """
         if getattr(self, "_profile_recovery_attempted", False):
-            return
+            return False
         self._profile_recovery_attempted = True
 
         session_name = (getattr(self, "token", "") or "").split(":")[0]
         global_dir = getattr(self, "global_dir", None)
         if not session_name or not global_dir:
-            return
+            return False
 
         from core import profile_recovery
-        self._shutdown_audit("profile suspect — session started and died 3x "
-                             "without connecting")
+        self._shutdown_audit("profile suspect — %s" % reason)
 
-        if not profile_recovery.has_snapshot(global_dir, session_name):
+        # Which generation to put back. A restore that did not hold means the
+        # newest snapshot is itself a profile that no longer authenticates —
+        # reachable from a shutdown that did everything right, see
+        # previous_snapshot_dir() — so the next launch climbs to the one
+        # before it rather than restoring the same failure again. Persisted,
+        # because one launch cannot observe its own outcome; cleared the
+        # moment a session reports CONNECTED.
+        generation = self._profile_recovery_generation()
+        prefer_previous = generation >= 1
+        if prefer_previous and not profile_recovery.has_snapshot(
+                global_dir, session_name, prefer_previous=True):
+            prefer_previous = False
+        self._set_profile_recovery_generation(generation + 1)
+        if prefer_previous:
+            logging.warning("[profile-recovery] the newest snapshot did not hold "
+                            "— restoring the generation before it.")
+
+        if not profile_recovery.has_snapshot(global_dir, session_name,
+                                             prefer_previous=prefer_previous):
             # Nothing to restore. Say so plainly rather than leaving the user
             # staring at "offline": this is the one outcome where the only fix
             # is a human deciding to pair again, and a blind user has no way to
@@ -8530,7 +8563,7 @@ class MainWindow(wx.Frame):
             logging.error("[profile-recovery] session %s looks broken and there "
                           "is no snapshot to restore.", session_name[:12])
             wx.CallAfter(self._announce_profile_beyond_repair)
-            return
+            return False
 
         def _restore():
             try:
@@ -8545,16 +8578,48 @@ class MainWindow(wx.Frame):
                         logging.warning("[profile-recovery] close-session failed: %s: %s",
                                         type(e).__name__, redact_credentials(str(e)))
                 self.wait_for_profile_release(session_name, timeout=20.0)
-                if profile_recovery.restore_snapshot(global_dir, session_name):
+                if profile_recovery.restore_snapshot(
+                        global_dir, session_name, prefer_previous=prefer_previous):
                     self._shutdown_audit("profile restored from snapshot")
+                    # The QR burst that triggered this was produced by the
+                    # profile now moved aside; counting it against the flood
+                    # ceiling would halt a session that is about to be fine.
+                    self._unattended_qr_events = 0
                     wx.CallAfter(self._announce_profile_restored)
                 else:
                     wx.CallAfter(self._announce_profile_beyond_repair)
+                    if on_give_up is not None:
+                        wx.CallAfter(on_give_up)
             except Exception:
                 logging.exception("[profile-recovery] restore failed")
                 wx.CallAfter(self._announce_profile_beyond_repair)
+                if on_give_up is not None:
+                    wx.CallAfter(on_give_up)
 
         threading.Thread(target=_restore, daemon=True).start()
+        return True
+
+    _PROFILE_RECOVERY_GENERATION_KEY = "profile_recovery_generation"
+
+    def _profile_recovery_generation(self) -> int:
+        """How many recoveries have been attempted since the last CONNECTED."""
+        try:
+            if getattr(self, "db", None) is None:
+                return 0
+            return max(0, int(self.db.get_metadata_json(
+                self._PROFILE_RECOVERY_GENERATION_KEY, 0) or 0))
+        except Exception:
+            return 0
+
+    def _set_profile_recovery_generation(self, value: int) -> None:
+        """Best effort, like every other persist on this path: losing it costs
+        a repeated restore attempt, never the profile."""
+        try:
+            if getattr(self, "db", None) is not None:
+                self.db.set_metadata_json(
+                    self._PROFILE_RECOVERY_GENERATION_KEY, max(0, int(value)))
+        except Exception as exc:
+            logging.warning("[profile-recovery] could not persist the generation: %s", exc)
 
     def _announce_profile_restored(self):
         try:

--- a/tests/test_profile_recovery.py
+++ b/tests/test_profile_recovery.py
@@ -342,3 +342,78 @@ class TestEverConnected:
         for s in ("INITIALIZING", "disconnectedMobile", "CLOSED", "QRCODE"):
             t.note_status(s)
         assert t.ever_connected() is False
+
+
+class TestKeepingTheGenerationARefreshReplaces:
+    """A clean close is not proof the profile it wrote will authenticate.
+
+    Measured across one day on a real install: four clean shutdowns, each with
+    close-session acknowledged, the session observed CLOSED and Chrome
+    confirmed to have released the profile — and two of the four were followed
+    by a launch where WhatsApp Web logged itself out seven seconds into the
+    page load. Both hard-killed runs that day came back fine, which is the
+    opposite of what this module's docstring predicts.
+
+    So capture_snapshot()'s conditions can all hold and still write a restore
+    point that does not work. On that install the one that *did* work was
+    22.7 h old against a 24 h refresh window — one hour from being overwritten
+    by the profile that fails to load.
+    """
+
+    def _profile(self, tmp_path, marker):
+        live = pr.profile_dir(str(tmp_path), "sess")
+        os.makedirs(live, exist_ok=True)
+        with open(os.path.join(live, "who.txt"), "w") as fh:
+            fh.write(marker)
+        return live
+
+    def _read(self, path):
+        with open(os.path.join(path, "who.txt")) as fh:
+            return fh.read()
+
+    def test_the_first_snapshot_leaves_no_previous_generation(self, tmp_path):
+        self._profile(tmp_path, "first")
+        assert pr.capture_snapshot(str(tmp_path), "sess") is True
+        assert pr.has_snapshot(str(tmp_path), "sess") is True
+        assert pr.has_snapshot(str(tmp_path), "sess", prefer_previous=True) is False
+
+    def test_a_refresh_demotes_the_snapshot_it_replaces(self, tmp_path):
+        self._profile(tmp_path, "good")
+        pr.capture_snapshot(str(tmp_path), "sess")
+        self._profile(tmp_path, "doomed")
+        pr.capture_snapshot(str(tmp_path), "sess", max_age=0)
+
+        assert self._read(pr.snapshot_dir(str(tmp_path), "sess")) == "doomed"
+        assert self._read(pr.previous_snapshot_dir(str(tmp_path), "sess")) == "good"
+
+    def test_the_previous_generation_can_be_restored(self, tmp_path):
+        self._profile(tmp_path, "good")
+        pr.capture_snapshot(str(tmp_path), "sess")
+        self._profile(tmp_path, "doomed")
+        pr.capture_snapshot(str(tmp_path), "sess", max_age=0)
+        self._profile(tmp_path, "broken-live")
+
+        assert pr.restore_snapshot(str(tmp_path), "sess", prefer_previous=True) is True
+        assert self._read(pr.profile_dir(str(tmp_path), "sess")) == "good"
+
+    def test_restoring_the_newest_is_still_the_default(self, tmp_path):
+        self._profile(tmp_path, "good")
+        pr.capture_snapshot(str(tmp_path), "sess")
+        self._profile(tmp_path, "doomed")
+        pr.capture_snapshot(str(tmp_path), "sess", max_age=0)
+        self._profile(tmp_path, "broken-live")
+
+        assert pr.restore_snapshot(str(tmp_path), "sess") is True
+        assert self._read(pr.profile_dir(str(tmp_path), "sess")) == "doomed"
+
+    def test_asking_for_a_previous_generation_that_does_not_exist_is_refused(self, tmp_path):
+        self._profile(tmp_path, "only")
+        pr.capture_snapshot(str(tmp_path), "sess")
+        assert pr.restore_snapshot(str(tmp_path), "sess", prefer_previous=True) is False
+
+    def test_a_third_refresh_keeps_only_two_generations(self, tmp_path):
+        for marker in ("oldest", "middle", "newest"):
+            self._profile(tmp_path, marker)
+            pr.capture_snapshot(str(tmp_path), "sess", max_age=0)
+        assert self._read(pr.snapshot_dir(str(tmp_path), "sess")) == "newest"
+        assert self._read(pr.previous_snapshot_dir(str(tmp_path), "sess")) == "middle"

--- a/tests/test_profile_recovery_wiring.py
+++ b/tests/test_profile_recovery_wiring.py
@@ -24,6 +24,19 @@ from core.profile_recovery import ProfileHealthTracker
 from main import MainWindow
 
 
+class _MetadataDB:
+    """Just the metadata pair the recovery generation is persisted through."""
+
+    def __init__(self):
+        self.values = {}
+
+    def get_metadata_json(self, key, default=None):
+        return self.values.get(key, default)
+
+    def set_metadata_json(self, key, value):
+        self.values[key] = value
+
+
 class _Stub:
     """Carries only what the methods under test actually touch."""
 
@@ -39,6 +52,14 @@ class _Stub:
         self.recovered = 0
         self.error_sound = types.SimpleNamespace(play=lambda: None)
         self.i18n = types.SimpleNamespace(t=lambda key: key)
+        self.db = _MetadataDB()
+
+    # Bound from the real class: the generation ladder decides *which*
+    # snapshot goes back, so a stub that faked it would let the wiring drift
+    # from the module its own tests cover.
+    _PROFILE_RECOVERY_GENERATION_KEY = MainWindow._PROFILE_RECOVERY_GENERATION_KEY
+    _profile_recovery_generation = MainWindow._profile_recovery_generation
+    _set_profile_recovery_generation = MainWindow._set_profile_recovery_generation
 
     def _shutdown_audit(self, msg):
         self.audits.append(msg)
@@ -110,7 +131,7 @@ class TestRecoveryRunsAtMostOncePerLaunch:
         calls = []
         monkeypatch.setattr(
             "core.profile_recovery.has_snapshot",
-            lambda *a: calls.append(a) or False)
+            lambda *a, **kw: calls.append(a) or False)
         monkeypatch.setattr("main.wx.CallAfter", lambda fn, *a, **kw: None)
         MainWindow._recover_suspect_profile(stub)
         MainWindow._recover_suspect_profile(stub)
@@ -120,7 +141,7 @@ class TestRecoveryRunsAtMostOncePerLaunch:
         stub = _Stub(token="")
         monkeypatch.setattr(
             "core.profile_recovery.has_snapshot",
-            lambda *a: pytest.fail("should not have looked for a snapshot"))
+            lambda *a, **kw: pytest.fail("should not have looked for a snapshot"))
         MainWindow._recover_suspect_profile(stub)
 
 
@@ -131,7 +152,7 @@ class TestWithNoSnapshotTheUserIsTold:
 
     def test_the_message_is_announced(self, monkeypatch):
         stub = _Stub()
-        monkeypatch.setattr("core.profile_recovery.has_snapshot", lambda *a: False)
+        monkeypatch.setattr("core.profile_recovery.has_snapshot", lambda *a, **kw: False)
         monkeypatch.setattr("main.wx.CallAfter",
                             lambda fn, *a, **kw: fn(*a, **kw))
         MainWindow._recover_suspect_profile(stub)
@@ -141,7 +162,7 @@ class TestWithNoSnapshotTheUserIsTold:
         """shutdown_audit.log is the only file that survives the next launch,
         and this is exactly the diagnosis a user's next report needs."""
         stub = _Stub()
-        monkeypatch.setattr("core.profile_recovery.has_snapshot", lambda *a: False)
+        monkeypatch.setattr("core.profile_recovery.has_snapshot", lambda *a, **kw: False)
         monkeypatch.setattr("main.wx.CallAfter", lambda fn, *a, **kw: None)
         MainWindow._recover_suspect_profile(stub)
         assert any("profile suspect" in line for line in stub.audits)

--- a/tests/test_qrcode_auto_repair_dialog.py
+++ b/tests/test_qrcode_auto_repair_dialog.py
@@ -72,6 +72,18 @@ class _FakeMainWindow:
         self._qr_flood_halted = False
         self._pairing_in_progress = False
         self.halt_calls = 0
+        # Whether a snapshot exists to put back. False keeps every test
+        # written before the profile-repair step behaving exactly as it did:
+        # nothing to restore, so the pairing dialog is the outcome.
+        self.profile_restore_available = False
+        self.recover_calls = []
+
+    def _recover_suspect_profile(self, reason=None, on_give_up=None):
+        self.recover_calls.append(reason)
+        # Mirrors the real contract: on_give_up fires only when a restore was
+        # started and then failed. A False return means nothing was started,
+        # and the caller handles it inline — see _recover_suspect_profile().
+        return bool(self.profile_restore_available)
 
     def _is_pairing_dialog_active(self):
         return self._pairing_dialog_active
@@ -189,3 +201,77 @@ class TestProactivePairingDialog:
         mw._auto_repair_dialog_shown = False  # what a real reconnect does
         s.on_qrcode_update(QR_EVENT)
         assert connect.show_connection_dial_calls == 2
+
+
+class TestTheProfileIsRepairedBeforeAskingTheUserToPair:
+    """A code minted for a *paired* install means the stored session could not
+    be restored — which is exactly the condition the profile recovery exists
+    for, and this is the earliest and cleanest evidence of it available.
+
+    Measured on a real install on 2026-09-08. A clean Ctrl+Shift+Q shutdown
+    (close-session acknowledged, session observed CLOSED, Chrome confirmed to
+    have released the profile), and the next launch logged itself out seven
+    seconds into the page load. ProfileHealthTracker counted
+    INITIALIZING/CLOSED cycles at ~60 s each and stood at 2 of 3 when the code
+    arrived at t+2.4 min — and opening the pairing dialog then froze it there
+    for good, because check_wa_connection_http() returns immediately while a
+    pairing dialog is up, so the poll that feeds the tracker never ran again.
+    The snapshot was restorable by hand the whole time; the app could never
+    reach it.
+    """
+
+    def test_a_restorable_profile_is_repaired_instead_of_re_paired(self):
+        mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
+        mw.profile_restore_available = True
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        s.on_qrcode_update(QR_EVENT)
+
+        assert len(mw.recover_calls) == 1
+        assert connect.show_connection_dial_calls == 0
+
+    def test_the_reason_says_what_was_observed(self):
+        # It lands in shutdown_audit.log, which survives the launch — the one
+        # place the next diagnosis can read why a restore was attempted.
+        mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
+        mw.profile_restore_available = True
+        s = _Stub(mw, _FakeConnect(mw))
+
+        s.on_qrcode_update(QR_EVENT)
+
+        assert "pairing code" in (mw.recover_calls[0] or "")
+
+    def test_with_nothing_to_restore_the_user_is_still_sent_to_pair(self):
+        mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
+        mw.profile_restore_available = False
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        s.on_qrcode_update(QR_EVENT)
+
+        assert len(mw.recover_calls) == 1
+        assert connect.show_connection_dial_calls == 1
+
+    def test_an_install_that_never_paired_is_not_a_broken_profile(self):
+        # Nothing to restore and nothing lost: this is an ordinary first
+        # pairing, and the recovery must not run at all.
+        mw = _FakeMainWindow(paired=False, pairing_dialog_active=False)
+        s = _Stub(mw, _FakeConnect(mw))
+
+        s.on_qrcode_update(QR_EVENT)
+
+        assert mw.recover_calls == []
+
+    def test_a_qr_refresh_during_the_restore_does_not_retry_it(self):
+        # Codes rotate every ~20-30 s. _recover_suspect_profile() latches on
+        # its own, but the caller must not be the thing relying on that.
+        mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
+        mw.profile_restore_available = True
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        s.on_qrcode_update(QR_EVENT)
+        s.on_qrcode_update(QR_EVENT)
+
+        assert connect.show_connection_dial_calls == 0

--- a/tests/test_qrcode_unattended_session.py
+++ b/tests/test_qrcode_unattended_session.py
@@ -100,6 +100,18 @@ class _FakeMainWindow:
         self._pairing_in_progress = False
         self._auto_repair_dialog_shown = False
         self.halt_calls = 0
+        # Whether a snapshot exists to put back before the user is asked to
+        # pair by hand. False everywhere in this module: these tests are about
+        # what happens when nothing can be repaired, which is the path that
+        # still has to reach the dialog and the flood ceiling.
+        self.profile_restore_available = False
+        self.recover_calls = []
+
+    def _recover_suspect_profile(self, reason=None, on_give_up=None):
+        # on_give_up fires only when a restore was started and then failed;
+        # a False return means nothing was started. See the real method.
+        self.recover_calls.append(reason)
+        return bool(self.profile_restore_available)
 
     def _is_pairing_dialog_active(self):
         return self._pairing_dialog_active


### PR DESCRIPTION
Second live session loss on 2026-09-08, same signature as the first. Recovered by hand again; the app never reached the restore, for a **different** reason than the one #180 fixed.

## Why the recovery could not fire

`ProfileHealthTracker` counts through `check_wa_connection_http()`, which [returns immediately while a pairing dialog is up](client/main.py:11561). The measured run:

```
17:43:54  start-session  → armed
17:44:53  CLOSED         → cycle 1
17:44:54  start-session
17:45:54  CLOSED         → cycle 2
17:46:08  QR → _show_repair_dialog() → the poll never ran again
```

Frozen at 2 of 3 for the life of the process. The race is unwinnable by tuning: three cycles at ~60 s each cannot beat a code that arrives at t+2.4 min.

## The QR is the trigger

`_handle_unattended_qr()`'s own docstring already said it: a code minted for a paired install is a reliable "the stored session cannot be restored" signal, and *better* than the status-session string the tracker watches. It then sent the user off to re-pair with it. It now attempts the restore first and falls through to the pairing dialog only when there is no snapshot or the restore fails.

`_recover_suspect_profile()` returns whether it started one. `on_give_up` fires only for an async failure, so a caller that both passes it and falls through on False cannot act twice.

## The snapshot nearly destroyed itself

From that day's `shutdown_audit.log`:

| shutdown | type | next launch |
|---|---|---|
| 00:35:42 | clean | ok |
| *(killed, no stop line)* | **dirty** | **ok** |
| 11:29:28 | clean | **broken** |
| *(killed)* | **dirty** | **ok** |
| 15:15:53 | clean | ok |
| 15:59:42 | clean | ok |
| 17:37:28 | clean | **broken** |

Four clean shutdowns: two broke, two did not. Both hard-killed runs came back fine — the opposite of what `profile_recovery.py`'s docstring predicts.

So `capture_snapshot()`'s conditions can all hold and still write a restore point that does not authenticate, and #180's `ever_connected` guard cannot see that either. The snapshot that actually worked was **22.7 h old against a 24 h refresh window** — one more hour and the refresh would have destroyed the only profile that still authenticated.

The replaced generation is now demoted to `.prev`, and a restore that does not hold escalates to it on the next launch (persisted counter, cleared the moment a session reports CONNECTED).

## Still open

Why the profile loses its login. It is not the dirty shutdown this module was written for, and on this evidence it is not the clean one either. Both broken profiles are preserved on the reporting install for the next round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)