### PR TITLE
Don't let Cancel/Escape destroy a session that isn't confirmed logged out

### DIFF
--- a/client/ui/dialogs/connect.py
+++ b/client/ui/dialogs/connect.py
@@ -1732,6 +1732,45 @@ class Connect:
                          name="winzapp-pairing-grace").start()
         return True
 
+    def _dialog_dismiss_should_preserve_session(self) -> bool:
+        """True when Cancel/Escape/Quit from this dialog must not touch the
+        saved session — either because WhatsApp is confirmed connected right
+        now, or because nothing has actually confirmed it is NOT, which is
+        just as important and easy to miss.
+
+        Reported live: status-session read 'disconnectedMobile', which
+        _act_on_unlink_decision() (main.py) classifies as RESUMING — its
+        own docstring calls this a transient, recoverable state and
+        deliberately does not wipe anything for it. Ten seconds later,
+        WPPConnect minted a fresh QR with no dialog open, and
+        _show_repair_dialog() (websocket_client.py) opened this dialog on
+        the strength of that QR alone — its own docstring reasons that an
+        unattended QR means the stored session "can't be restored" and
+        therefore Cancel/close/Quit have "nothing left to lose". That
+        premise was false here: main.py's own, more careful classifier had
+        independently looked at the very same disconnect and judged it
+        recoverable. The user dismissed the unexpected dialog (its Cancel
+        button carries wx.ID_CANCEL, so a plain Escape reaches it too) and
+        the session was destroyed anyway, on a signal main.py itself was
+        not yet willing to act on.
+        _logout_handled (main.py) is the one place that distinction already
+        lives: _act_on_unlink_decision() sets it only for a decision that
+        actually authorizes a wipe (LOGOUT confirmed by the host-device
+        probe, or RESUME_FAILED after repeated strikes) — never for
+        RESUMING, and never merely because a QR arrived. Folding it in here
+        means Cancel/Escape/Quit are only ever destructive once main.py's
+        own, much more careful machinery has independently reached the same
+        conclusion — not on the say-so of a lone QR event.
+        """
+        if self._started_new_session_token:
+            # Narrower than "nothing confirmed yet" on purpose — see the
+            # class-level tests for why: a session this dialog itself
+            # started must still be torn down on Cancel, or it is left
+            # registered as the account's active session while orphaned.
+            return False
+        return (getattr(self.main_window, "_wa_connected", False)
+                or not getattr(self.main_window, "_logout_handled", False))
+
     def on_dialog_close(self, event):
         logging.info("[on_dialog_close] Dialog close event triggered.")
         if event.CanVeto() and self._defer_close_for_pairing_startup(
@@ -1745,37 +1784,17 @@ class Connect:
         # Invalidate any in-flight _bg_pairing_flow() — see on_continue().
         self._pairing_attempt_id += 1
         self.main_window._pairing_in_progress = False
-        if (getattr(self.main_window, "_wa_connected", False)
-                and not self._started_new_session_token):
-            # This dialog can now open on its own while already paired (the
-            # proactive re-pair dialog — websocket_client.py's
-            # _show_repair_dialog()), and WhatsApp can genuinely reconnect
-            # in the background — via the normal health check, independent
-            # of this dialog — before the user ever reacts to it. Below,
-            # every close path assumes the opposite: that a dialog on
-            # screen means nothing usable exists yet, so it always
-            # disconnects the live socket and clears the saved token.
-            # Reported live: an account that was working the entire session
-            # showed the pairing dialog again on the very next launch, with
-            # its WPPConnect session and Chrome profile completely intact —
-            # only the stored token reference had been wiped, by exactly
-            # this path, closing a dialog that should never have treated a
-            # live connection as disposable.
-            #
-            # The second half of the condition is what keeps this from
-            # becoming a worse bug than the one it fixes. If the user
-            # actually started a NEW session from this dialog, minting it
-            # already overwrote the settings token and abandoned the live
-            # session's store entry — so skipping the teardown here would
-            # leave a half-paired session registered as the account's active
-            # one AND leave its Chrome alive, minting QR codes that
-            # on_qrcode_update() ignores while _wa_connected is True, which
-            # is exactly the unattended code stream that gets accounts
-            # banned. In that case we fall through to the normal teardown:
-            # no better than before this fix, but no worse either.
+        if self._dialog_dismiss_should_preserve_session():
+            # See _dialog_dismiss_should_preserve_session()'s docstring —
+            # either WhatsApp is genuinely connected right now, or nothing
+            # has actually confirmed it isn't, and either way a dialog that
+            # can now open on its own (websocket_client.py's proactive
+            # _show_repair_dialog()) closing here is not evidence the
+            # session is disposable.
             logging.info(
-                "[on_dialog_close] WhatsApp is connected — closing without "
-                "disconnecting the socket or clearing the saved session."
+                "[on_dialog_close] WhatsApp is connected, or nothing has "
+                "confirmed it is logged out — closing without disconnecting "
+                "the socket or clearing the saved session."
             )
             event.Skip()
             return
@@ -1798,18 +1817,17 @@ class Connect:
             return
         self._pairing_attempt_id += 1
         self.main_window._pairing_in_progress = False
-        if (getattr(self.main_window, "_wa_connected", False)
-                and not self._started_new_session_token):
-            # Same reasoning as on_dialog_close() above, including why a
-            # session this dialog started itself is excluded: WhatsApp is
-            # genuinely connected right now, so "Quit" here means exactly
-            # what it means from the main window — close the app through
-            # the normal graceful teardown, and do not disconnect the live
-            # socket or wipe the saved session first.
+        if self._dialog_dismiss_should_preserve_session():
+            # Same reasoning as on_dialog_close() above: "Quit" here means
+            # exactly what it means from the main window — close the app
+            # through the normal graceful teardown, and do not disconnect
+            # the live socket or wipe the saved session first, unless
+            # main.py's own classifier has actually confirmed there is
+            # nothing left to preserve.
             logging.info(
-                "[on_quit_from_connect] WhatsApp is connected — quitting "
-                "via the normal graceful shutdown instead of tearing down "
-                "the active session."
+                "[on_quit_from_connect] WhatsApp is connected, or nothing "
+                "has confirmed it is logged out — quitting via the normal "
+                "graceful shutdown instead of tearing down the session."
             )
             # real_exit() hides the main frame so quitting looks instant, but
             # this modal dialog is not the frame: without hiding it too, it

--- a/tests/test_dialog_close_preserves_live_session.py
+++ b/tests/test_dialog_close_preserves_live_session.py
@@ -63,10 +63,17 @@ class _FakeCloseEvent:
 
 
 class _FakeMainWindow:
-    def __init__(self, wa_connected, pairing_in_progress=False):
+    def __init__(self, wa_connected, pairing_in_progress=False, logout_handled=True):
         self.settings = {"general": {"language": "pt-BR"}}
         self._wa_connected = wa_connected
         self._pairing_in_progress = pairing_in_progress
+        # Defaults to True (a confirmed logout already happened) so every
+        # pre-existing "not connected" test below keeps meaning what its own
+        # docstring says: a confirmed-dead session, not merely a currently
+        # unconnected one. See TestDismissWhileNeitherConnectedNorConfirmed
+        # for the actual new gap (_logout_handled defaults to False on a
+        # real MainWindow — see main.py — until something confirms a wipe).
+        self._logout_handled = logout_handled
         self.ws = _FakeWs()
         self.token = "sess1:hash1"
         self.wpp_server = "http://127.0.0.1"
@@ -127,9 +134,12 @@ class TestOnDialogCloseWhileConnected:
 
 class TestOnDialogCloseWhileNotConnected:
     def test_disconnects_and_clears_as_before(self):
-        """Unchanged behaviour: nothing usable is connected, so closing the
-        dialog still tears the attempt down."""
-        mw = _FakeMainWindow(wa_connected=False)
+        """Unchanged behaviour: not connected AND main.py has already
+        independently confirmed the account is logged out (logout_handled),
+        so closing the dialog still tears the attempt down. See
+        TestDismissWhileNeitherConnectedNorConfirmedLoggedOut for the case
+        this class used to also (incorrectly) cover."""
+        mw = _FakeMainWindow(wa_connected=False, logout_handled=True)
         c, close_calls = _make_connect(mw)
         event = _FakeCloseEvent()
 
@@ -155,7 +165,9 @@ class TestOnQuitFromConnectWhileConnected:
 
 class TestOnQuitFromConnectWhileNotConnected:
     def test_disconnects_clears_and_exits_as_before(self):
-        mw = _FakeMainWindow(wa_connected=False)
+        """Unchanged behaviour: not connected AND already confirmed logged
+        out — see TestOnDialogCloseWhileNotConnected above."""
+        mw = _FakeMainWindow(wa_connected=False, logout_handled=True)
         c, close_calls = _make_connect(mw)
 
         with pytest.raises(SystemExit):
@@ -202,6 +214,63 @@ class TestADialogThatStartedItsOwnSessionIsStillTornDown:
 
         assert len(close_calls) == 1
         assert mw.real_exit_calls == 0
+
+
+class TestDismissWhileNeitherConnectedNorConfirmedLoggedOut:
+    """The actual gap this fix closes, reported live: status-session read
+    'disconnectedMobile', which _act_on_unlink_decision() (main.py)
+    classifies as RESUMING and explicitly does not wipe anything for.
+    Ten seconds later WPPConnect minted a fresh QR with no dialog open,
+    and _show_repair_dialog() opened this dialog on the strength of that
+    QR alone, reasoning (in its own docstring) that an unattended QR means
+    "nothing left to lose". The dialog's Cancel button carries
+    wx.ID_CANCEL, so a plain Escape reaches it too — and either dismissal
+    reached this handler with _wa_connected already False (offline had
+    already been announced) and _logout_handled never set (RESUMING never
+    sets it), destroying a session main.py's own, more careful classifier
+    was not yet willing to give up on.
+
+    A real MainWindow never initializes _logout_handled at all — every
+    read goes through getattr(..., False) — so logout_handled=False here
+    is the actual default a fresh process starts in, not a contrived edge
+    case.
+    """
+
+    def test_close_preserves_the_session(self):
+        mw = _FakeMainWindow(wa_connected=False, logout_handled=False)
+        c, close_calls = _make_connect(mw)
+        event = _FakeCloseEvent()
+
+        c.on_dialog_close(event)
+
+        assert close_calls == []
+        assert mw.ws is not None
+        assert mw.ws.sio.disconnect_calls == 0
+        assert event.skip_calls == 1
+
+    def test_quit_preserves_the_session_and_exits_gracefully(self):
+        mw = _FakeMainWindow(wa_connected=False, logout_handled=False)
+        c, close_calls = _make_connect(mw)
+
+        c.on_quit_from_connect(None)
+
+        assert close_calls == []
+        assert mw.ws is not None
+        assert mw.ws.sio.disconnect_calls == 0
+        assert mw.real_exit_calls == 1
+
+    def test_a_session_this_dialog_itself_started_is_still_torn_down(self):
+        """_started_new_session_token still wins even when nothing has
+        confirmed a logout — same reasoning as
+        TestADialogThatStartedItsOwnSessionIsStillTornDown above."""
+        mw = _FakeMainWindow(wa_connected=False, logout_handled=False)
+        c, close_calls = _make_connect(mw, started_new_session="sess2:hash2")
+        event = _FakeCloseEvent()
+
+        c.on_dialog_close(event)
+
+        assert len(close_calls) == 1
+        assert mw.ws is None
 
 
 class TestTheGuardsLeaveThePairingStateConsistent:


### PR DESCRIPTION
Reported live: status-session read disconnectedMobile, which _act_on_unlink_decision() (`main.py`) classifies as RESUMING and explicitly does not wipe anything for — its own log line says "resuming — data preserved". Ten seconds later WPPConnect minted a fresh QR with no dialog open, and _show_repair_dialog() opened the connection dialog on the strength of that QR alone, reasoning in its own docstring that an unattended QR means the stored session has "nothing left to lose". That premise was false here: `main.py`'s own, more careful classifier had independently looked at the same disconnect and judged it recoverable. The dialog's "Cancel" button carries `wx.ID_CANCEL`, so a plain Escape reaches it too (standard wx/dialog behavior), and two seconds after the dialog appeared, the session was torn down anyway, on a signal `main.py` itself was not yet willing to act on. PR #159's _wa_connected guard doesn't cover this case either, since WhatsApp had already been announced offline by that point. This folds in _logout_handled — the one place that already distinguishes "`main.py` positively confirmed a logout" from "merely not currently connected" — so Cancel/`Escape`/Quit are destructive only once `main.py`'s own careful machinery has independently reached the same conclusion, not on the say-so of a lone QR event.