### PR TITLE
Retire a chat the phone answers with nothing, durably

### DIFF
--- a/client/core/profile_recovery.py
+++ b/client/core/profile_recovery.py
@@ -84,6 +84,55 @@ def profile_dir(global_dir, session_name):
     return os.path.join(global_dir, "api", "userDataDir", session_name)
 
 
+#: The subtree WhatsApp Web keeps its login in. Fingerprinted rather than
+#: read: the point is only whether it changed, and its contents are the user's
+#: message history.
+_LOGIN_STORE_RELPATH = os.path.join(
+    "Default", "IndexedDB", "https_web.whatsapp.com_0.indexeddb.leveldb")
+
+
+def login_store_fingerprint(global_dir, session_name):
+    """A cheap "is this the same bytes as last time" reading of the profile.
+
+    Exists to settle one question the logs cannot currently answer. Across one
+    day on a real install, four clean shutdowns — close-session acknowledged,
+    the session observed CLOSED, Chrome confirmed to have released the profile,
+    5-6 s of genuine waiting in every one of them — produced two launches where
+    WhatsApp Web logged itself out seven seconds into the page load, and two
+    that were fine. Nothing in `shutdown_audit.log` distinguishes them, and
+    `log.log` is truncated on the launch that would report it.
+
+    Recorded at the end of a shutdown and again at the start of the next
+    launch, this separates the two remaining explanations: a fingerprint that
+    moved in between means something wrote to the profile after WinZapp let go
+    of it, and one that is identical means the profile WinZapp left is exactly
+    the one WhatsApp Web then rejected — which is a stale credential, not a
+    lost write, and would rule out the whole shutdown path.
+
+    Never raises: this is a diagnostic, and a shutdown must not die in one.
+    """
+    try:
+        path = os.path.join(profile_dir(global_dir, session_name),
+                            _LOGIN_STORE_RELPATH)
+        newest = 0.0
+        total = 0
+        count = 0
+        for entry in os.scandir(path):
+            try:
+                st = entry.stat()
+            except OSError:
+                continue
+            if entry.is_file():
+                count += 1
+                total += st.st_size
+                newest = max(newest, st.st_mtime)
+        if not count:
+            return None
+        return "files=%d bytes=%d newest=%.0f" % (count, total, newest)
+    except Exception:
+        return None
+
+
 def snapshot_dir(global_dir, session_name):
     return os.path.join(global_dir, "api", SNAPSHOT_DIR_NAME, session_name)
 

--- a/client/main.py
+++ b/client/main.py
@@ -3851,7 +3851,12 @@ class MainWindow(wx.Frame):
             logging.info("[_raw_session_status] probe failed: %s", e)
         return ""
 
-    def _chrome_pids_owning_session(self, session_name: str) -> list:
+    def _chrome_pids_owning_session(self, session_name: str):
+        """PIDs of chrome.exe processes holding this session's profile.
+
+        A list — possibly empty, which is an answer — or None when the
+        process list could not be read at all, which is not.
+        """
         import sys
         if sys.platform != "win32" or not session_name:
             return []
@@ -3865,8 +3870,21 @@ class MainWindow(wx.Frame):
                 creationflags=no_window, text=True, stderr=subprocess.DEVNULL, timeout=15,
             )
         except Exception as e:
-            logging.info("[profile-lock] could not list chrome processes: %s", e)
-            return []
+            # None, not []. An empty list is an *answer* — "nothing holds this
+            # profile" — and wait_for_profile_release() acts on it by letting
+            # the taskkill proceed. A failed query knows nothing, and reading
+            # it as the answer turns a slow or refused PowerShell spawn into
+            # "Chrome released the profile", audited as such, immediately
+            # before the tree kill that then hits a browser still writing.
+            #
+            # Measured on the reporting machine this query runs in 0.21 s idle
+            # and 0.31 s under six competing PowerShell processes, with no
+            # failures in 65 runs — so this is a latent fault, not the cause of
+            # the losses that prompted the review. It is still the wrong
+            # default, and its only trace today is a logging.info into log.log,
+            # which the next launch truncates.
+            logging.warning("[profile-lock] could not list chrome processes: %s", e)
+            return None
         pids = []
         for line in out.splitlines():
             pid, _, cmdline = line.partition("\t")
@@ -3874,16 +3892,59 @@ class MainWindow(wx.Frame):
                 pids.append(pid.strip())
         return pids
 
+    def _login_store_fingerprint(self, session_name: str = None) -> str:
+        """Fingerprint of the store WhatsApp Web keeps its login in.
+
+        Written into shutdown_audit.log at the end of a shutdown and again at
+        the start of the next launch, because that file survives and log.log
+        does not. Two clean shutdowns on the reporting install were followed by
+        a launch that had already logged itself out, and two identical ones
+        were fine — with nothing in the audit telling them apart. This does:
+        a fingerprint that moved between the two lines means something wrote to
+        the profile after WinZapp let go of it, and one that is identical means
+        the profile WinZapp left is exactly the one WhatsApp Web rejected,
+        which clears the shutdown path entirely.
+
+        Never raises and never blocks — a diagnostic must not be able to cost
+        a teardown.
+        """
+        try:
+            from core import profile_recovery
+            global_dir = getattr(self, "global_dir", None)
+            name = session_name or (getattr(self, "token", "") or "").split(":")[0]
+            if not global_dir or not name:
+                return "unknown"
+            return profile_recovery.login_store_fingerprint(global_dir, name) or "absent"
+        except Exception:
+            return "unknown"
+
     def wait_for_profile_release(self, session_name: str, timeout: float = 20.0) -> bool:
         import sys
         if sys.platform != "win32" or not session_name:
             return True
         deadline = time.monotonic() + timeout
+        started = time.monotonic()
         polls = 0
+        unreadable = 0
         while time.monotonic() < deadline:
             polls += 1
             holders = self._chrome_pids_owning_session(session_name)
+            if holders is None:
+                # Could not tell. Keep waiting rather than assuming the best:
+                # the only thing after this gate is a /T kill of the process
+                # tree Chrome is in.
+                unreadable += 1
+                time.sleep(0.5)
+                continue
             if not holders:
+                # Into the audit, not just log.log: log.log is truncated by the
+                # launch that would report the damage, so "Chrome exited after
+                # 6 s of real waiting" and "the very first poll said nothing
+                # was there" are indistinguishable the morning after. They are
+                # opposite diagnoses.
+                self._shutdown_audit(
+                    "profile released after %d poll(s) in %.1fs "
+                    "(%d unreadable)" % (polls, time.monotonic() - started, unreadable))
                 if polls > 1:
                     logging.info(
                         "[profile-lock] %s released after %d poll(s)",
@@ -3898,7 +3959,7 @@ class MainWindow(wx.Frame):
         self._kill_orphaned_chrome_for_session(session_name)
         grace_deadline = time.monotonic() + 5.0
         for _ in range(10):
-            if not self._chrome_pids_owning_session(session_name):
+            if self._chrome_pids_owning_session(session_name) == []:
                 return True
             if time.monotonic() >= grace_deadline:
                 break
@@ -8896,7 +8957,13 @@ class MainWindow(wx.Frame):
                 if self.wait_for_profile_release(
                     session_name, timeout=_phase_timeout(15.0)
                 ):
-                    self._shutdown_audit("Chrome released the profile before the kill")
+                    try:
+                        released_fp = self._login_store_fingerprint(session_name)
+                    except Exception:
+                        released_fp = "unknown"
+                    self._shutdown_audit(
+                        "Chrome released the profile before the kill "
+                        f"login_store={released_fp}")
                     self._capture_profile_snapshot(session_name,
                                                    browser_closed_cleanly, budget)
                 else:
@@ -10421,6 +10488,13 @@ class MainWindow(wx.Frame):
         # store think of it + every sibling. If a working session silently turned
         # 'abandoned' and a fresh (unpaired) one took over between quit and this
         # launch, THIS line proves it across the log truncation.
+        # Computed before the audit block, and separately, so a diagnostic can
+        # never take the STARTUP line down with it. That line is the anchor of
+        # every cross-launch diagnosis this file exists for.
+        try:
+            login_store = self._login_store_fingerprint()
+        except Exception:
+            login_store = "unknown"
         try:
             store = self._get_session_store()
             listing = []
@@ -10431,7 +10505,8 @@ class MainWindow(wx.Frame):
                 f"STARTUP account={getattr(self,'account_id','?')} "
                 f"active_session={self.token.split(':')[0]!r} "
                 f"paired={self.settings.get('privateinfo',{}).get('paired')} "
-                f"store=[{', '.join(listing)}]")
+                f"store=[{', '.join(listing)}] "
+                f"login_store={login_store}")
         except Exception:
             pass
 
@@ -17959,6 +18034,48 @@ class MainWindow(wx.Frame):
             self._chats_awaiting_messages.add(canonical)
             self._partial_history_counts[canonical] = count
 
+    def _retire_chat_without_older_history(self, jid: str) -> None:
+        """Record, durably, that the phone has no older history for this chat.
+
+        The backfill asked, spent its budget, and nothing came back. Until
+        this existed that verdict lived only in `_older_request_attempts`,
+        which is in memory — so every launch handed the same chat a fresh
+        budget and asked again. Each of those asks is a notification on the
+        user's phone, and the phone answers a request it cannot satisfy with
+        "Sync paused. Open WhatsApp to resume." — an *error*, on an account
+        that has been fully synced for weeks, for a conversation the user
+        never opened. Reported exactly that way.
+
+        Measured on a real install: two groups holding 1 and 2 messages, each
+        asked twice, `oldestMsgKey` byte-identical across both asks, twelve
+        get-messages rounds in between, nothing ever delivered. Their
+        `endOfHistoryTransferType` was 4 and null, where every ask that *did*
+        deliver came back as 0 — worth knowing, but the verdict here is taken
+        from the outcome rather than from an undocumented enum value, so it
+        stays right if WhatsApp renumbers them.
+
+        `_exhausted_chats` is the same set fetch_older_messages() writes and
+        the deep walk reads, so this also stops the chat being re-queried from
+        the other direction. The user scrolling up clears it — see
+        _forget_history_exhaustion() and the F5 resync.
+        """
+        if not hasattr(self, "_exhausted_chats"):
+            self._exhausted_chats = set()
+        if jid in self._exhausted_chats:
+            return
+        self._exhausted_chats.add(jid)
+        self._persist_exhausted_chats()
+        self._remove_backfill_pending(jid)
+        with self._backfill_state_guard():
+            gap_forms = set(self._jid_address_forms(jid))
+            gap_forms.update(
+                self._jid_address_forms(self._canonical_backfill_jid(jid)))
+            self._history_gap_jids.difference_update(gap_forms)
+        logging.info(
+            "[history-sync] The phone answered nothing for %s after %d request(s) "
+            "— retiring it for good so it is never asked again.",
+            jid, self._MAX_PHONE_HISTORY_REQUESTS)
+
     def _is_backfill_pending(self, jid: str) -> bool:
         """Whether a conversation is queued under either known address."""
         with self._backfill_state_guard():
@@ -18344,8 +18461,20 @@ class MainWindow(wx.Frame):
                         older_arrived.add(jid)
                     if now >= self.history_page_target() or now > was:
                         continue
-                    self._keep_backfill_pending(jid, now)
+                    if jid in getattr(self, "_exhausted_chats", set()):
+                        # Already answered, durably: the phone was asked and
+                        # had nothing older. Re-queuing it here is what made
+                        # that answer worthless — see the retirement below.
+                        self._remove_backfill_pending(jid)
+                        continue
                     asked_at = getattr(self, "_older_requested_chats", {}).get(jid)
+                    if MainWindow._older_history_is_exhausted(
+                            asked_at, attempts.get(jid, 0), time.time(),
+                            self._OLDER_REQUEST_GRACE,
+                            self._MAX_PHONE_HISTORY_REQUESTS):
+                        self._retire_chat_without_older_history(jid)
+                        continue
+                    self._keep_backfill_pending(jid, now)
                     if not MainWindow._phone_history_request_due(
                             asked_at, attempts.get(jid, 0), time.time(),
                             self._OLDER_REQUEST_GRACE,
@@ -22675,6 +22804,29 @@ class MainWindow(wx.Frame):
     # that request is attended, and a notification the user just caused is not
     # the problem being fixed here.
     _MAX_PHONE_HISTORY_REQUESTS = 2
+
+    @staticmethod
+    def _older_history_is_exhausted(asked_at, attempts, now_ts,
+                                    grace, max_attempts) -> bool:
+        """Whether the phone has answered, by silence, that it has no more.
+
+        True once a chat has spent its whole request budget and the reply
+        window has closed on the last of those asks with no older history
+        having arrived — because gaining any would have cleared the budget
+        (see the caller). That is the phone's answer; it just arrives as
+        nothing rather than as a refusal.
+
+        The grace is the same one fetch_older_messages() writes its own
+        write-off behind, and for the same reason: the request is
+        fire-and-forget and the reply is a history-sync chunk minutes later,
+        so a verdict reached inside that window is a guess. Here it makes the
+        verdict *durable*, which is the whole point — without it the in-memory
+        budget resets on every launch and the chat is asked twice again,
+        forever.
+        """
+        if attempts < max_attempts or asked_at is None:
+            return False
+        return (now_ts - asked_at) >= grace
 
     @staticmethod
     def _phone_history_request_due(asked_at, attempts, now_ts,

--- a/tests/test_history_sync_on_demand.py
+++ b/tests/test_history_sync_on_demand.py
@@ -1091,3 +1091,113 @@ class TestPhoneRequestsAreSpacedNotBunched:
         # time (16 requests in 20 minutes on the measured install), long
         # enough that two notifications never stack.
         assert 60 <= MainWindow._PHONE_REQUEST_MIN_GAP <= 300
+
+
+class TestAChatThePhoneCannotHelpIsRetiredForGood:
+    """The phone answers "I have nothing older" two ways, and only one of them
+    used to be durable.
+
+    An explicit `primaryHasMore=false` is a refusal, costs no notification and
+    retires the chat. The other answer is *silence*: the request goes out, the
+    phone tells its owner it is synchronising, delivers nothing, and follows up
+    with "Sync paused. Open WhatsApp to resume." — an error notification, on an
+    account synced for weeks, for a conversation the user never opened.
+
+    Measured on a real install on 2026-09-08: two groups holding 1 and 2
+    messages, each asked twice, `oldestMsgKey` byte-identical across both asks
+    and twelve get-messages rounds in between. `_older_request_attempts` is in
+    memory, so every launch handed them a fresh budget and asked again.
+    """
+
+    GRACE = MainWindow._OLDER_REQUEST_GRACE
+    MAX = MainWindow._MAX_PHONE_HISTORY_REQUESTS
+
+    def test_a_budget_still_unspent_is_not_a_verdict(self):
+        assert MainWindow._older_history_is_exhausted(
+            1000.0, self.MAX - 1, 1000.0 + self.GRACE * 10,
+            self.GRACE, self.MAX) is False
+
+    def test_a_chat_never_asked_is_not_a_verdict(self):
+        assert MainWindow._older_history_is_exhausted(
+            None, self.MAX, 10_000.0, self.GRACE, self.MAX) is False
+
+    def test_the_reply_window_must_close_first(self):
+        # The request is fire-and-forget and the chunk lands minutes later;
+        # a verdict inside that window is a guess, and this one is permanent.
+        assert MainWindow._older_history_is_exhausted(
+            1000.0, self.MAX, 1000.0 + self.GRACE - 1,
+            self.GRACE, self.MAX) is False
+
+    def test_budget_spent_and_window_closed_is_the_verdict(self):
+        assert MainWindow._older_history_is_exhausted(
+            1000.0, self.MAX, 1000.0 + self.GRACE,
+            self.GRACE, self.MAX) is True
+
+    def test_the_verdict_only_follows_a_full_budget(self):
+        # Gaining older history clears the budget (see the caller), so
+        # reaching the cap already means every ask came back with nothing.
+        assert self.MAX >= 2
+        for spent in range(self.MAX):
+            assert MainWindow._older_history_is_exhausted(
+                1000.0, spent, 1000.0 + self.GRACE * 5,
+                self.GRACE, self.MAX) is False
+
+
+class TestRetirementIsWrittenDownAndRespected:
+    class _Stub:
+        _retire_chat_without_older_history = MainWindow._retire_chat_without_older_history
+        _jid_address_forms = MainWindow._jid_address_forms
+        _canonical_backfill_jid = MainWindow._canonical_backfill_jid
+        _MAX_PHONE_HISTORY_REQUESTS = MainWindow._MAX_PHONE_HISTORY_REQUESTS
+
+        def __init__(self):
+            self._exhausted_chats = set()
+            self._history_gap_jids = set()
+            self._lid_to_phone = {}
+            self._phone_to_lid = {}
+            self._chats_awaiting_messages = set()
+            self._partial_history_counts = {}
+            self.persisted = 0
+            self.removed = []
+
+        def _persist_exhausted_chats(self):
+            self.persisted += 1
+
+        def _remove_backfill_pending(self, jid):
+            self.removed.append(jid)
+
+        class _Guard:
+            def __enter__(self):
+                return None
+
+            def __exit__(self, *a):
+                return False
+
+        def _backfill_state_guard(self):
+            return self._Guard()
+
+    JID = "120363166461067873@g.us"
+
+    def test_the_verdict_is_persisted_not_just_remembered(self):
+        stub = self._Stub()
+        stub._retire_chat_without_older_history(self.JID)
+        assert self.JID in stub._exhausted_chats
+        assert stub.persisted == 1
+
+    def test_it_leaves_the_backfill_queue(self):
+        stub = self._Stub()
+        stub._retire_chat_without_older_history(self.JID)
+        assert stub.removed == [self.JID]
+
+    def test_the_history_gap_is_cleared_under_every_address(self):
+        stub = self._Stub()
+        stub._lid_to_phone = {self.JID: "5511@s.whatsapp.net"}
+        stub._history_gap_jids = {self.JID, "5511@s.whatsapp.net"}
+        stub._retire_chat_without_older_history(self.JID)
+        assert stub._history_gap_jids == set()
+
+    def test_retiring_twice_writes_once(self):
+        stub = self._Stub()
+        stub._retire_chat_without_older_history(self.JID)
+        stub._retire_chat_without_older_history(self.JID)
+        assert stub.persisted == 1

--- a/tests/test_pairing_waits_for_profile_release.py
+++ b/tests/test_pairing_waits_for_profile_release.py
@@ -115,6 +115,12 @@ class TestWaitForProfileRelease:
             # One entry per poll: the PIDs still holding the profile.
             self._sequence = list(holder_sequence)
             self.kills = []
+            # How long the wait really took now goes to shutdown_audit.log,
+            # which survives the log truncation that hides it today.
+            self.audits = []
+
+        def _shutdown_audit(self, msg):
+            self.audits.append(msg)
 
         def _chrome_pids_owning_session(self, session_name):
             return self._sequence.pop(0) if self._sequence else []

--- a/tests/test_profile_recovery.py
+++ b/tests/test_profile_recovery.py
@@ -417,3 +417,57 @@ class TestKeepingTheGenerationARefreshReplaces:
             pr.capture_snapshot(str(tmp_path), "sess", max_age=0)
         assert self._read(pr.snapshot_dir(str(tmp_path), "sess")) == "newest"
         assert self._read(pr.previous_snapshot_dir(str(tmp_path), "sess")) == "middle"
+
+
+class TestFingerprintingTheLoginStore:
+    """Written to shutdown_audit.log at both ends of a restart, to settle a
+    question the existing logs cannot answer.
+
+    Four clean shutdowns on a real install — close-session acknowledged, the
+    session observed CLOSED, Chrome confirmed released after 5-6 s of genuine
+    waiting in every one — produced two launches where WhatsApp Web had already
+    logged itself out and two that were fine. Nothing in the audit told them
+    apart, and log.log is truncated by the launch that would report it.
+
+    A fingerprint that moved between the shutdown line and the next STARTUP
+    line means something wrote to the profile after WinZapp let go; an
+    identical pair means the profile WinZapp left is the one WhatsApp Web
+    rejected, which clears the shutdown path.
+    """
+
+    def _store(self, tmp_path, contents):
+        path = os.path.join(pr.profile_dir(str(tmp_path), "sess"),
+                            pr._LOGIN_STORE_RELPATH)
+        os.makedirs(path, exist_ok=True)
+        for name, body in contents.items():
+            with open(os.path.join(path, name), "w") as fh:
+                fh.write(body)
+        return path
+
+    def test_a_missing_profile_fingerprints_as_nothing(self, tmp_path):
+        assert pr.login_store_fingerprint(str(tmp_path), "sess") is None
+
+    def test_an_empty_store_fingerprints_as_nothing(self, tmp_path):
+        self._store(tmp_path, {})
+        assert pr.login_store_fingerprint(str(tmp_path), "sess") is None
+
+    def test_the_same_bytes_fingerprint_the_same(self, tmp_path):
+        self._store(tmp_path, {"000001.ldb": "aaa", "CURRENT": "x"})
+        first = pr.login_store_fingerprint(str(tmp_path), "sess")
+        assert first == pr.login_store_fingerprint(str(tmp_path), "sess")
+
+    def test_a_changed_file_changes_the_fingerprint(self, tmp_path):
+        self._store(tmp_path, {"000001.ldb": "aaa"})
+        before = pr.login_store_fingerprint(str(tmp_path), "sess")
+        self._store(tmp_path, {"000001.ldb": "aaaa"})
+        assert pr.login_store_fingerprint(str(tmp_path), "sess") != before
+
+    def test_a_new_file_changes_the_fingerprint(self, tmp_path):
+        self._store(tmp_path, {"000001.ldb": "aaa"})
+        before = pr.login_store_fingerprint(str(tmp_path), "sess")
+        self._store(tmp_path, {"000002.ldb": "b"})
+        assert pr.login_store_fingerprint(str(tmp_path), "sess") != before
+
+    def test_it_never_raises_on_a_path_it_cannot_read(self, tmp_path):
+        # A diagnostic must not be able to cost a teardown.
+        assert pr.login_store_fingerprint(None, "sess") is None

--- a/tests/test_shutdown_flushes_profile.py
+++ b/tests/test_shutdown_flushes_profile.py
@@ -115,3 +115,62 @@ class TestWppconnectLogKeepsOneGeneration:
         following = source[rotate : rotate + 400]
         assert "except Exception" in following
         assert "could not rotate wppconnect.log" in following
+
+
+class TestAnUnreadableProcessListIsNotAnAnswer:
+    """"I could not tell" must never reach the caller as "nothing holds it".
+
+    The only thing after wait_for_profile_release() is `taskkill /F /T` on the
+    process tree Chrome is in, so reading a failed query as a release turns a
+    slow or refused PowerShell spawn into a hard kill of a browser that is
+    still writing its LevelDB — and audits it as "Chrome released the profile
+    before the kill". Its only trace today is a logging.info into log.log,
+    which the launch that would report the damage truncates.
+
+    Measured on the reporting machine before changing this: 0.21 s idle, 0.31 s
+    under six competing PowerShell processes, zero failures in 65 runs. So this
+    is a latent fault rather than the cause of the losses that prompted the
+    review — and still the wrong default.
+    """
+
+    class _Stub:
+        wait_for_profile_release = MainWindow.wait_for_profile_release
+
+        def __init__(self, answers):
+            self._answers = list(answers)
+            self.audits = []
+            self.killed = 0
+
+        def _chrome_pids_owning_session(self, session_name):
+            return self._answers.pop(0) if self._answers else []
+
+        def _shutdown_audit(self, msg):
+            self.audits.append(msg)
+
+        def _kill_orphaned_chrome_for_session(self, session_name):
+            self.killed += 1
+
+    def test_an_empty_list_still_means_released(self):
+        stub = self._Stub([[]])
+        assert stub.wait_for_profile_release("sess", timeout=2.0) is True
+        assert stub.killed == 0
+
+    def test_an_unreadable_answer_keeps_waiting(self):
+        # None first, then a real empty answer: it must not have concluded on
+        # the None.
+        stub = self._Stub([None, []])
+        assert stub.wait_for_profile_release("sess", timeout=5.0) is True
+        assert any("unreadable" in a for a in stub.audits)
+
+    def test_a_held_profile_is_still_reported_as_held(self):
+        stub = self._Stub([["1234"]] * 50)
+        assert stub.wait_for_profile_release("sess", timeout=1.0) is False
+        assert stub.killed == 1
+
+    def test_the_audit_records_how_long_the_wait_actually_took(self):
+        """"Chrome exited after 6 s of real waiting" and "the first poll said
+        nothing was there" are opposite diagnoses and looked identical."""
+        stub = self._Stub([["1234"], []])
+        stub.wait_for_profile_release("sess", timeout=5.0)
+        released = [a for a in stub.audits if "profile released" in a]
+        assert released and "poll(s)" in released[0]


### PR DESCRIPTION
## Correcting what I told the reporting user

I said his phone-history requests were all productive. For these chats that was wrong, and his logs say so:

```
20:57:08  120363166461067873@g.us  oldestMsgKey: A5003D73AD21822979AD20861CC6C7EC_…
21:13:43  120363166461067873@g.us  oldestMsgKey: A5003D73AD21822979AD20861CC6C7EC_…   ← identical
```

Byte-identical anchor across both asks, twelve `get-messages` rounds apart, chat still holding **one** message. Two more behaved the same. The requests that *did* deliver carried `endOfHistoryTransferType: 0`; these carry **4** and **null**.

That is what produces "Sync paused. Open WhatsApp to resume." instead of a completion — the phone answering, correctly, that it could not satisfy a request WinZapp should not have repeated, on an account synced for weeks, for conversations the user never opened.

## Why it repeated

The verdict was never written down. `_older_request_attempts` is in memory, so every launch handed the same chat a fresh budget.

A chat that has spent its budget and let the reply window close with no older history arriving now goes into `_exhausted_chats`, which is persisted — the same set `fetch_older_messages()` writes and the deep walk reads, so **scrolling up in that conversation still clears it and asks again**. The automatic asking stops; what the user explicitly requests does not. The verdict comes from the outcome, not from `endOfHistoryTransferType`, so it stays right if WhatsApp renumbers those.

## From the shutdown review this prompted

`_chrome_pids_owning_session()` returned `[]` when the query *failed*, and `[]` is an answer — "nothing holds this profile" — which `wait_for_profile_release()` acts on by letting `taskkill /F /T` proceed against the tree Chrome is in. It now returns `None`, and the wait continues.

**Measured on the reporting machine before changing it**: 0.21 s idle, 0.31 s under six competing PowerShell processes, **zero failures in 65 runs**, and all four of that day's shutdowns spent a genuine 5–6 s waiting. So this is a latent fault and **not** the cause of the two profile losses. The two that broke look identical in the audit to the two that were fine, which is the real problem:

- how long the release wait actually took now goes to `shutdown_audit.log`, because `log.log` is truncated by the launch that would report the damage, and "Chrome exited after 6 s" and "the first poll saw nothing" currently read the same;
- a fingerprint of WhatsApp Web's IndexedDB is recorded at the end of a shutdown and again at the next STARTUP. A pair that **differs** means something wrote to the profile after WinZapp let go; an **identical** pair means the profile WinZapp left is the one WhatsApp Web rejected — clearing the shutdown path and moving the search to a stale credential.

Both diagnostics are computed outside the audit's own `try`, so neither can take the STARTUP line down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)