### PR TITLE
Do not store the ciphertext placeholder as a message

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -5638,6 +5638,16 @@ class MainWindow(wx.Frame):
         self._schedule_set_chats()
         return True
 
+    #: WhatsApp Web's "arrived, not decrypted yet" placeholder. It is followed
+    #: by the real message under the same key.id.
+    _UNDECRYPTED_PLACEHOLDER_TYPES = frozenset({"ciphertext"})
+
+    @staticmethod
+    def _is_undecrypted_placeholder(msg: dict) -> bool:
+        """Whether this event is a placeholder rather than a message."""
+        return (((msg or {}).get("messageType") or "")
+                in MainWindow._UNDECRYPTED_PLACEHOLDER_TYPES)
+
     def _apply_possible_edit(self, existing: dict, incoming: dict, remote_jid: str):
         """Detect and apply a text-message edit re-delivered under the same key.id.
 
@@ -5895,6 +5905,41 @@ class MainWindow(wx.Frame):
 
         # Extract mapping and mentions from incoming messages
         self._extract_lid_mapping(msg)
+
+        # A `ciphertext` is not a message — it is WhatsApp Web saying "something
+        # arrived and I have not decrypted it yet". The real one follows under
+        # the SAME key.id (2.5 s and 4.2 s in the two occurrences measured on a
+        # live install), and storing the placeholder is what makes that second
+        # delivery look like a duplicate.
+        #
+        # The damage is the whole notification, not a cosmetic one. Measured:
+        #
+        #   18:30:49 on_messages_upsert id=ACBF…B49F type=ciphertext
+        #   18:30:49 [unread] chats-update in: …936700@g.us unread=1 previous=0
+        #   18:30:49 [unread] …936700@g.us: no change after discounting
+        #                     non-countable messages (already 0, previous=0)
+        #   18:30:51 on_messages_upsert id=ACBF…B49F type=audioMessage
+        #
+        # WhatsApp said unread=1; the placeholder is not countable (correctly —
+        # it has no content), so the badge was discounted back to zero, and the
+        # real message 2.5 s later hit the same-id dedup and was routed to
+        # _apply_possible_edit(), which never announces anything. The user got
+        # a voice message with no sound, no badge and no screen-reader
+        # announcement, and the row read "Mensagem incompatível" until a later
+        # poll rewrote it.
+        #
+        # Dropping it costs nothing that is not already lost: the placeholder
+        # renders as "Mensagem incompatível", and on the path where the
+        # decrypted copy never arrives at all the 60 s poll is what recovers
+        # the message today either way. _extract_lid_mapping() above still runs
+        # first, since the envelope's addressing is real even when its content
+        # is not.
+        if MainWindow._is_undecrypted_placeholder(msg):
+            logging.info(
+                "[on_new_message] %s: ignoring the ciphertext placeholder for %s "
+                "— waiting for the decrypted copy under the same id.",
+                remote_jid, (key or {}).get("id", "")[:22])
+            return
 
         # Statuses (stories) arrive as messages on status@broadcast; they are
         # stored in _status_updates for the Status tab, not in a conversation.

--- a/tests/test_ciphertext_placeholder.py
+++ b/tests/test_ciphertext_placeholder.py
@@ -1,0 +1,86 @@
+"""The placeholder WhatsApp Web sends before it has decrypted a message.
+
+Reported live on 2026-09-08: a voice message arrived in a group and WinZapp
+announced nothing at all — no sound, no unread badge, no screen-reader
+announcement — and the chat row read "Mensagem incompatível" until a later
+poll rewrote it. The log holds the whole mechanism in four lines:
+
+    18:30:49  on_messages_upsert id=ACBF…B49F type=ciphertext
+    18:30:49  [unread] chats-update in: …936700@g.us unread=1 previous=0
+    18:30:49  [unread] …936700@g.us: no change after discounting
+                       non-countable messages (already 0, previous=0)
+    18:30:51  on_messages_upsert id=ACBF…B49F type=audioMessage
+
+WhatsApp delivers the message twice: a `ciphertext` envelope first, then the
+decrypted copy under the *same* key.id, 2.5 s later (4.2 s in the other
+occurrence that day). WinZapp stored the placeholder, correctly refused to
+count it — it carries no content — and so discounted WhatsApp's own unread=1
+back to zero. The real message then hit on_new_message()'s same-id dedup and
+was routed into _apply_possible_edit(), which never announces anything.
+
+So the placeholder must not be stored. Then the decrypted copy is what it
+actually is: a new message, arriving through the full notify/count path.
+"""
+
+from main import MainWindow, is_countable_message
+
+
+def _msg(message_type, message=None, mid="ACBF379ADE20FB1E6C64A2F72037B49F"):
+    return {
+        "key": {"remoteJid": "120363409931936700@g.us", "fromMe": False, "id": mid},
+        "message": message if message is not None else {},
+        "messageType": message_type,
+        "messageTimestamp": 1788899448,
+    }
+
+
+class TestRecognisingThePlaceholder:
+    def test_a_ciphertext_is_a_placeholder(self):
+        assert MainWindow._is_undecrypted_placeholder(_msg("ciphertext")) is True
+
+    def test_the_decrypted_copy_is_not(self):
+        assert MainWindow._is_undecrypted_placeholder(
+            _msg("audioMessage", {"audioMessage": {"seconds": 3}})) is False
+
+    def test_an_ordinary_text_message_is_not(self):
+        assert MainWindow._is_undecrypted_placeholder(
+            _msg("conversation", {"conversation": "oi"})) is False
+
+    def test_a_missing_type_is_not_a_placeholder(self):
+        # Only the types WhatsApp Web actually uses for this may be dropped;
+        # anything else must keep flowing, however odd it looks.
+        assert MainWindow._is_undecrypted_placeholder({"key": {}}) is False
+        assert MainWindow._is_undecrypted_placeholder({}) is False
+        assert MainWindow._is_undecrypted_placeholder(None) is False
+
+    def test_it_is_not_a_blocklist_of_system_types(self):
+        # e2e_notification and friends are already excluded by
+        # is_countable_message(); they are stored, this one is not, and
+        # conflating the two lists is how a real type gets dropped.
+        for other in ("e2e_notification", "groupNotification", "protocolMessage"):
+            assert MainWindow._is_undecrypted_placeholder(_msg(other)) is False
+
+
+class TestWhyTheBadgeVanished:
+    def test_the_placeholder_could_never_have_counted(self):
+        """Not a bug on its own — it carries no content, so refusing to count
+        it is right. Storing it is what turned that into a silent message."""
+        assert is_countable_message(_msg("ciphertext")) is False
+
+    def test_the_decrypted_copy_does_count(self):
+        assert is_countable_message(
+            _msg("audioMessage", {"audioMessage": {"seconds": 3}})) is True
+
+
+class TestTheDropIsWiredIntoTheLiveFunnel:
+    def test_on_new_message_returns_before_storing_a_placeholder(self):
+        import inspect
+        src = inspect.getsource(MainWindow.on_new_message)
+        assert "_is_undecrypted_placeholder" in src
+
+    def test_the_lid_mapping_is_learned_before_the_drop(self):
+        """The envelope's addressing is real even when its content is not, and
+        _extract_lid_mapping() is the one thing that must still see it."""
+        import inspect
+        src = inspect.getsource(MainWindow.on_new_message)
+        assert src.index("_extract_lid_mapping") < src.index("_is_undecrypted_placeholder")


### PR DESCRIPTION
Reported live: a voice message arrived in a group and WinZapp announced **nothing** — no sound, no unread badge, no screen-reader announcement — and the chat row read "Mensagem incompatível" until a later poll rewrote it.

The log holds the whole mechanism in four lines:

```
18:30:49  on_messages_upsert id=ACBF…B49F type=ciphertext
18:30:49  [unread] chats-update in: …936700@g.us unread=1 previous=0
18:30:49  [unread] …936700@g.us: no change after discounting
                   non-countable messages (already 0, previous=0)
18:30:51  on_messages_upsert id=ACBF…B49F type=audioMessage
```

WhatsApp Web delivers the message **twice**: a `ciphertext` envelope first, then the decrypted copy under the *same* `key.id` — 2.5 s later here, 4.2 s in the other occurrence that day.

WinZapp stored the placeholder and then, correctly, refused to count it: it carries no content, so `is_countable_message()` excludes it, and WhatsApp's own `unread=1` was discounted back to zero. The real message then hit `on_new_message()`'s same-id dedup and was routed into `_apply_possible_edit()`, which never announces anything.

The word `ciphertext` did not appear anywhere in the codebase — this was not a rule being misapplied, the type had simply never been seen.

## The fix

Drop the placeholder instead of storing it. That costs nothing already lost: it renders as "Mensagem incompatível", and on the path where the decrypted copy never arrives the 60 s poll is what recovers the message today either way. Not storing it makes the decrypted copy what it actually is — a new message, through the full notify/count path.

`_extract_lid_mapping()` still runs before the drop: the envelope's addressing is real even when its content is not. The predicate is a frozenset of placeholder types, deliberately separate from `is_countable_message()`'s allowlist — `e2e_notification` and friends are *stored* and merely uncounted, and conflating the two lists is how a real type gets dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)