### PR TITLE
Re-check chats the sync plan has stopped looking at

### DIFF
--- a/client/core/incremental_sync.py
+++ b/client/core/incremental_sync.py
@@ -234,6 +234,46 @@ def classify_chat_sync(
     return "skip", "unchanged"
 
 
+def select_stale_rechecks(candidates, verified_at, now, per_round, after):
+    """Which skipped chats have gone too long without an actual get-messages.
+
+    Every signal classify_chat_sync() reads — `t`, `unreadCount`,
+    `lastReceivedKey`, `lastMessage` — is chat-list *metadata*. When that
+    metadata is stale for one chat, every signal agrees nothing changed and the
+    chat is skipped on every round, forever, while get-messages for it would
+    have returned newer messages the whole time. Nothing in the plan can break
+    out of that, which is why the only cure users found was F5 — a forced full
+    rebuild of every chat in the account (issue #181: two chats stuck at 200
+    messages, ending at 08:35 and 07:34, that F5 advanced to 17:12 and 17:11
+    by fetching 34 and 7 messages *newer* than anything stored).
+
+    The history-repair queue does not cover it either: that asks the phone for
+    history *older* than what is held, and these messages were newer.
+
+    So staleness is bounded by time rather than trusted to the markers. The
+    chats that have gone longest without a successful fetch are re-checked, a
+    few per round, whatever the markers say. Returned oldest-first and capped,
+    so the cost per round is fixed no matter how large the account is; a chat
+    with no recorded verification at all sorts first, because it is the one
+    nothing is known about.
+    """
+    if per_round <= 0 or after < 0:
+        return []
+    verified_at = verified_at if isinstance(verified_at, dict) else {}
+    due = []
+    for jid in candidates or ():
+        if not jid:
+            continue
+        try:
+            last = int(verified_at.get(jid, 0) or 0)
+        except (TypeError, ValueError):
+            last = 0
+        if now - last >= after:
+            due.append((last, jid))
+    due.sort()
+    return [jid for _, jid in due[:per_round]]
+
+
 def next_incremental_limit(
     current_limit: int,
     page_size: int,

--- a/client/main.py
+++ b/client/main.py
@@ -52,6 +52,7 @@ from core.incremental_sync import (
     chat_message_records as _chat_message_records,
     chat_sync_marker as _chat_sync_marker,
     classify_chat_sync as _classify_chat_sync,
+    select_stale_rechecks as _select_stale_rechecks,
     messages_overlap as _messages_overlap,
     next_incremental_limit as _next_incremental_limit,
 )
@@ -10804,6 +10805,17 @@ class MainWindow(wx.Frame):
         else:
             self._older_requested_chats = {}
 
+        # When get-messages last actually ran for each chat, for the staleness
+        # net in _plan_message_sync(). Persisted on purpose: a chat last
+        # fetched before a restart is exactly as stale afterwards, and starting
+        # empty would re-check the whole account on every launch.
+        _verified_at = self.db.get_metadata_json("chat_verified_at_v1", {})
+        self._chat_verified_at = {
+            str(jid): int(ts) for jid, ts in _verified_at.items()
+            if isinstance(ts, (int, float))
+        } if isinstance(_verified_at, dict) else {}
+        self._chat_verified_at_dirty = False
+
         # How many times the backfill has asked the phone about each chat this
         # session. Deliberately in memory and not persisted, for the same reason
         # _note_verified_activity() is: the bound exists to stop one run asking
@@ -17287,6 +17299,58 @@ class MainWindow(wx.Frame):
         if jid and activity > int(synced.get(jid, 0) or 0):
             synced[jid] = activity
 
+    #: How long a chat may go without an actual get-messages before it is
+    #: re-checked whatever the chat-list markers say, and how many such
+    #: re-checks one planning round may add.
+    #:
+    #: Every signal classify_chat_sync() reads is chat-list metadata, so a
+    #: chat whose metadata goes stale is skipped on every round forever while
+    #: get-messages for it would have returned newer messages the whole time.
+    #: Issue #181 is exactly that: two chats stuck at 200 messages ending at
+    #: 08:35 and 07:34, which F5 advanced to 17:12 and 17:11 — 34 and 7
+    #: messages *newer* than anything stored. Nothing but a forced full
+    #: rebuild of all 295 chats could reach them.
+    #:
+    #: Five per round against a 60 s poll is 300 chats an hour, so an account
+    #: the size of that report is fully re-verified in about the hour this
+    #: bounds staleness to — at a fixed cost per round however large the
+    #: account grows, which is the property a full sweep does not have.
+    _STALE_RECHECK_AFTER = 60 * 60
+    _STALE_RECHECK_PER_ROUND = 5
+
+    def _note_chat_verified_now(self, remote_jid: str) -> None:
+        """Record that get-messages actually ran for this chat, just now.
+
+        Separate from _note_verified_activity(), which records *which activity
+        value* was covered and is deliberately per-session. This one answers
+        "when did we last really look?", which is what the staleness net needs,
+        and it is persisted: a chat last fetched before a restart is exactly as
+        stale afterwards, and forgetting that on every launch would re-check
+        the whole account each time WinZapp opens.
+        """
+        seen = getattr(self, "_chat_verified_at", None)
+        if not isinstance(seen, dict):
+            seen = self._chat_verified_at = {}
+        jid = self._normalize_jid(remote_jid or "")
+        if not jid:
+            return
+        seen[jid] = int(time.time())
+        self._chat_verified_at_dirty = True
+
+    def _persist_chat_verified_at(self) -> None:
+        """Best effort, like every other sync-state persist: losing it costs
+        one extra round of re-checks, never a message."""
+        if not getattr(self, "_chat_verified_at_dirty", False):
+            return
+        try:
+            if getattr(self, "db", None) is not None:
+                self.db.set_metadata_json(
+                    "chat_verified_at_v1",
+                    dict(getattr(self, "_chat_verified_at", {})))
+                self._chat_verified_at_dirty = False
+        except Exception as exc:
+            logging.warning("[sync] failed to persist chat_verified_at: %s", exc)
+
     def _plan_message_sync(self, baseline: dict, force_full: bool = False,
                            include_repairs: bool = True):
         """Return (full_targets, incremental_targets, skipped_count, reasons).
@@ -17298,7 +17362,7 @@ class MainWindow(wx.Frame):
         """
         full_targets = []
         incremental_targets = []
-        skipped = 0
+        skipped_chats = []
         reasons = {}
         gap_jids = set(getattr(self, "_history_gap_jids", set()) or set())
         pending_jids = set(getattr(self, "_chats_awaiting_messages", set()) or set())
@@ -17358,7 +17422,31 @@ class MainWindow(wx.Frame):
                 incremental_targets.append(chat)
                 reasons[jid] = reason
             else:
-                skipped += 1
+                skipped_chats.append((jid, chat))
+
+        # The staleness net. Everything above reads chat-list metadata, so a
+        # chat whose metadata stops moving is skipped on every round forever —
+        # see _STALE_RECHECK_AFTER and issue #181. Never on a forced full
+        # sync, where every chat is already a target.
+        skipped = len(skipped_chats)
+        if not force_full and skipped_chats:
+            verified_at = getattr(self, "_chat_verified_at", None)
+            due = set(_select_stale_rechecks(
+                [jid for jid, _ in skipped_chats],
+                verified_at if isinstance(verified_at, dict) else {},
+                int(time.time()),
+                # Off the class, not the instance: these are constants, and
+                # the test stubs that bind this method answer any unknown
+                # attribute with a lambda — see the _verified_activity guard
+                # above for the same hazard.
+                MainWindow._STALE_RECHECK_PER_ROUND,
+                MainWindow._STALE_RECHECK_AFTER,
+            ))
+            for jid, chat in skipped_chats:
+                if jid in due:
+                    incremental_targets.append(chat)
+                    reasons[jid] = "stale-recheck"
+                    skipped -= 1
 
         return full_targets, incremental_targets, skipped, reasons
 
@@ -17391,6 +17479,13 @@ class MainWindow(wx.Frame):
                 self.db.set_metadata_json("sync_state_v1", state)
         except Exception as exc:
             logging.warning("[sync] failed to persist sync_state_v1: %s", exc)
+        # Guarded on its own: sync_state_v1 is the latch that decides whether
+        # the next round is another full sync, and a fault in the staleness
+        # net's bookkeeping must not be able to leave it unwritten.
+        try:
+            self._persist_chat_verified_at()
+        except Exception as exc:
+            logging.warning("[sync] failed to persist chat_verified_at: %s", exc)
 
     def sync_remote_chats(self, target_chats=None, incremental: bool = False):
         chats = list(target_chats) if target_chats is not None else list(self.chats.values())
@@ -19808,6 +19903,18 @@ class MainWindow(wx.Frame):
             persist_ok = False
             logging.warning("[sync_chat_messages] incremental DB save failed for %s: %s",
                             remote_jid, exc)
+
+        # Outside the block above, and guarded on its own. This is bookkeeping
+        # for the staleness net and nothing reads it to decide correctness —
+        # letting it raise in there would set persist_ok False and report a
+        # perfectly good fetch as a failed one, which is how a diagnostic
+        # starts causing the resync loop it was added to help diagnose.
+        if message_fetch_satisfied:
+            try:
+                self._note_chat_verified_now(remote_jid)
+            except Exception as exc:
+                logging.warning("[sync_chat_messages] could not record the "
+                                "verification time for %s: %s", remote_jid, exc)
 
         # Reports whether this chat's sync FAILED, which neither an empty delta
         # nor a chat_not_found did: the retry for those is carried by

--- a/tests/test_periodic_poll_delta.py
+++ b/tests/test_periodic_poll_delta.py
@@ -20,6 +20,7 @@ a plain stub — the same pattern the other main.py tests use.
 """
 
 import threading
+import time
 import types
 
 import pytest
@@ -39,6 +40,12 @@ class _StopLoop(Exception):
 class _PollStub:
     def __init__(self):
         self.chats = {A: _chat(A), B: _chat(B)}
+        # Every chat was fetched moments ago: these stubs model a warm,
+        # already-synced account. Left unset they read as never verified and
+        # _plan_message_sync()'s staleness net (issue #181) promotes them,
+        # which is correct but is not what these tests measure. That net has
+        # its own tests in tests/test_stale_chat_recheck.py.
+        self._chat_verified_at = {j: int(time.time()) for j in self.chats}
         self.settings = {"storage": {"auto_download_media": True}}
         self._wa_connected = True
         self._initial_sync_running = False

--- a/tests/test_repair_state_durability.py
+++ b/tests/test_repair_state_durability.py
@@ -20,6 +20,7 @@ use.
 
 import pathlib
 import threading
+import time
 import types
 
 from main import MainWindow
@@ -63,6 +64,11 @@ class _StateStub:
         # Taken by _persist_message_retry_jids() before it reads the set.
         self._sync_failures_lock = threading.Lock()
         self._chats_awaiting_messages = set()
+        # Warm account: every chat was fetched moments ago. Left unset they
+        # read as never verified and _plan_message_sync()'s staleness net
+        # (issue #181) promotes them — correct, but not what these tests
+        # measure. It has its own tests in tests/test_stale_chat_recheck.py.
+        self._chat_verified_at = {j: int(time.time()) for j in self.chats}
         self._partial_history_counts = {}
         self._history_gap_jids = set()
         self._message_retry_jids = set()
@@ -158,6 +164,9 @@ class TestWhatIsRestoredActuallyDrivesTheNextRound:
         all — which is the entire reason the incremental path exists."""
         stub = _StateStub()
         stub.chats = {PHONE: _chat(PHONE)}
+        # Fetched moments ago, so the staleness net (issue #181) has no reason
+        # to promote it — otherwise this control measures that net instead.
+        stub._chat_verified_at = {PHONE: int(time.time())}
         baseline = {PHONE: MainWindow._capture_chat_sync_baseline(stub)[PHONE]}
 
         full, incremental, skipped, _reasons = stub._plan_message_sync(baseline)
@@ -197,6 +206,7 @@ class TestTheOneMarkerThatIsDeliberatelyNotDurable:
     def test_a_completed_fetch_this_session_settles_it(self):
         stub = _StateStub()
         stub.chats = {PHONE: self._behind(PHONE)}
+        stub._chat_verified_at = {PHONE: int(time.time())}
         baseline = {PHONE: MainWindow._capture_chat_sync_baseline(stub)[PHONE]}
         stub._note_verified_activity(PHONE, stub.chats[PHONE])
 

--- a/tests/test_run_sync_broken_store.py
+++ b/tests/test_run_sync_broken_store.py
@@ -18,6 +18,7 @@ tests use.
 """
 
 import threading
+import time
 import types
 
 import pytest
@@ -48,6 +49,11 @@ class _Stub:
             for i in range(local_chats)
         }
         self._chat_list_high_water = high_water
+        # Warm account: every chat was fetched moments ago. Left unset they
+        # read as never verified and _plan_message_sync()'s staleness net
+        # (issue #181) promotes them — correct, but not what these tests
+        # measure. It has its own tests in tests/test_stale_chat_recheck.py.
+        self._chat_verified_at = {j: int(time.time()) for j in self.chats}
         self._broken_store_rounds = 0
 
         self._wa_connected = True

--- a/tests/test_run_sync_warm_path.py
+++ b/tests/test_run_sync_warm_path.py
@@ -33,6 +33,7 @@ The stub harness is tests/test_run_sync_broken_store.py's, imported rather than
 copied for the reason that module's own docstring gives.
 """
 
+import time
 import types
 
 import pytest
@@ -125,6 +126,12 @@ def _warm_stub():
     stub = _make([len(_JIDS)] * 2, wa_web=len(_JIDS), local_chats=len(_JIDS))
     stub.chats = {jid: _chat(jid) for jid in _JIDS}
     stub._force_full_sync = False
+    # Every chat was fetched moments ago, which is what "warm" means. Without
+    # this they read as never verified, and _plan_message_sync()'s staleness
+    # net (issue #181) correctly promotes them — so these tests would be
+    # measuring that net rather than the signal each one is about. It has its
+    # own tests in tests/test_stale_chat_recheck.py.
+    stub._chat_verified_at = {jid: int(time.time()) for jid in _JIDS}
     return _instrumented(stub)
 
 

--- a/tests/test_stale_chat_recheck.py
+++ b/tests/test_stale_chat_recheck.py
@@ -1,0 +1,85 @@
+"""The staleness net behind issue #181.
+
+Reported by a contributor on 1.1.0.2576alpha: after a normal synchronization,
+two chats stayed outdated and only F5 fixed them. The plan was
+
+    full=196 incremental=11 unchanged=88
+
+and neither affected chat was fetched. Both already held 200 local messages
+and were classified `unchanged`; F5 replanned as `full=295 incremental=0
+unchanged=0 reasons={'forced-full': 295}` and the chats gained 50 and 51
+messages, 34 and 7 of them *newer* than anything stored, moving their ends
+from 08:35 and 07:34 to 17:12 and 17:11.
+
+Two things that report rules out, and they matter for where the fix goes:
+
+  * it is not the history-repair queue's job — that asks the phone for
+    messages *older* than what is held, and these were newer;
+  * the messages were genuinely absent from the database, not just from the
+    UI, so this is a planning fault rather than a rendering one.
+
+Every signal classify_chat_sync() reads — `t`, `unreadCount`,
+`lastReceivedKey`, `lastMessage` — is chat-list *metadata*. When it goes stale
+for one chat, every signal honestly agrees nothing changed, and nothing in the
+plan can break out of that. So staleness is bounded by time instead.
+"""
+
+from core.incremental_sync import select_stale_rechecks
+from main import MainWindow
+
+HOUR = 3600
+NOW = 1_788_900_000
+
+
+class TestChoosingWhatToReCheck:
+    def test_a_chat_checked_recently_is_left_alone(self):
+        assert select_stale_rechecks(
+            ["a@g.us"], {"a@g.us": NOW - 60}, NOW, 5, HOUR) == []
+
+    def test_a_chat_past_the_interval_is_due(self):
+        assert select_stale_rechecks(
+            ["a@g.us"], {"a@g.us": NOW - HOUR}, NOW, 5, HOUR) == ["a@g.us"]
+
+    def test_a_chat_never_checked_sorts_first(self):
+        """Nothing is known about it, which is the worst case, not the best."""
+        out = select_stale_rechecks(
+            ["seen@g.us", "never@g.us"],
+            {"seen@g.us": NOW - 2 * HOUR}, NOW, 1, HOUR)
+        assert out == ["never@g.us"]
+
+    def test_the_oldest_go_first(self):
+        out = select_stale_rechecks(
+            ["new@g.us", "old@g.us", "mid@g.us"],
+            {"new@g.us": NOW - HOUR, "mid@g.us": NOW - 5 * HOUR,
+             "old@g.us": NOW - 9 * HOUR},
+            NOW, 2, HOUR)
+        assert out == ["old@g.us", "mid@g.us"]
+
+    def test_the_cost_per_round_is_fixed_however_large_the_account(self):
+        # The property a full sweep does not have, and the reason this can run
+        # on every round of a 295-chat account.
+        many = [f"{i}@g.us" for i in range(1000)]
+        assert len(select_stale_rechecks(many, {}, NOW, 5, HOUR)) == 5
+
+    def test_a_zero_budget_selects_nothing(self):
+        assert select_stale_rechecks(["a@g.us"], {}, NOW, 0, HOUR) == []
+
+    def test_junk_in_the_verified_map_is_survivable(self):
+        # It is read back off persisted metadata, so it may be anything.
+        assert select_stale_rechecks(
+            ["a@g.us"], {"a@g.us": "not-a-number"}, NOW, 5, HOUR) == ["a@g.us"]
+        assert select_stale_rechecks(["a@g.us"], None, NOW, 5, HOUR) == ["a@g.us"]
+
+    def test_blank_jids_are_ignored(self):
+        assert select_stale_rechecks(["", None], {}, NOW, 5, HOUR) == []
+
+
+class TestTheShippedBudget:
+    def test_it_covers_the_reported_account_within_the_interval(self):
+        """295 chats, a 60 s poll: 5 per round is 300 an hour, so the whole
+        account is re-verified inside the hour this bounds staleness to."""
+        per_hour = MainWindow._STALE_RECHECK_PER_ROUND * 60
+        assert per_hour >= 295
+
+    def test_the_interval_is_long_enough_not_to_be_a_second_poll(self):
+        assert MainWindow._STALE_RECHECK_AFTER >= 1800


### PR DESCRIPTION
Fixes #181.

## The cause

Every signal `classify_chat_sync()` reads is chat-list **metadata** — `t`, `unreadCount`, `lastReceivedKey`, `lastMessage`. None of them looks at content. When that metadata stops moving for one chat, every signal honestly agrees nothing changed, the chat is skipped on every round, and **nothing in the plan can break out of it**. `force_full` is the only escape, which is why the only cure users found was F5:

```
before:  full=196 incremental=11 unchanged=88     ← both chats "unchanged"
after:   full=295 incremental=0  unchanged=0  reasons={'forced-full': 295}
```

The reporter's two chats sat at 200 messages ending 08:35 and 07:34; F5 moved them to 17:12 and 17:11 by fetching 50 and 51 messages, **34 and 7 of them newer than anything stored**.

His report also settles where the fault is not: the messages were absent from the *database* and not merely from the UI, and the history-repair queue could never have covered it — that asks the phone for messages *older* than what is held, and these were newer.

## The fix

Bound staleness by time instead of trusting the markers. The chats that have gone longest without a real `get-messages` are re-checked, five per round, whatever the markers say.

- `_STALE_RECHECK_AFTER = 1 h` — how stale a chat may get.
- `_STALE_RECHECK_PER_ROUND = 5` — against a 60 s poll that is 300 chats/hour, so an account the size of the report is fully re-verified inside the hour this promises, at a cost per round that is **fixed however large the account grows** — the property a periodic full sweep does not have.

`select_stale_rechecks()` is pure and sorts a chat with no record at all first, since that is the one nothing is known about. The timestamp is persisted: a chat last fetched before a restart is exactly as stale afterwards, and starting empty would re-check the whole account on every launch.

## One thing found on the way, and it is the more dangerous of the two

`_note_chat_verified_now()` first went inside `sync_chat_messages()`' persist `try`, whose `except` sets `persist_ok = False`. Bookkeeping raising in there would report a perfectly good fetch as a **failed** one — and one failed chat holds the entire account in "not synced" (the sync-completion trap documented in CLAUDE.md), so a diagnostic added to help with a resync loop could have caused one. It now sits outside that block with its own guard, as does the persist call.

## Tests

`tests/test_stale_chat_recheck.py`. Four existing sync-plan stubs are seeded as freshly verified — they model warm, already-synced accounts, and without that they read as never verified and this net correctly promotes them, which is not what those tests measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)