### PR TITLE
Ask the phone for older history only in chats the user opened

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -10805,6 +10805,12 @@ class MainWindow(wx.Frame):
         else:
             self._older_requested_chats = {}
 
+        # Conversations the user has actually opened — the gate on asking the
+        # phone for older history. Persisted: a chat opened last week is still
+        # a chat whose history the user cares about.
+        _opened = self.db.get_metadata_json("opened_conversations_v1", [])
+        self._opened_conversations = set(_opened) if isinstance(_opened, list) else set()
+
         # When get-messages last actually ran for each chat, for the staleness
         # net in _plan_message_sync(). Persisted on purpose: a chat last
         # fetched before a restart is exactly as stale afterwards, and starting
@@ -18174,6 +18180,59 @@ class MainWindow(wx.Frame):
             self._chats_awaiting_messages.add(canonical)
             self._partial_history_counts[canonical] = count
 
+    def _note_conversation_opened(self, remote_jid: str) -> None:
+        """Remember that the user opened this conversation, durably.
+
+        Gates the *phone* request in _backfill_empty_chats(). Everything else
+        the backfill does is local and free; asking the phone is the one step
+        that puts a notification on the user's own device, and until this
+        existed it was spent on every chat in the account.
+
+        Measured on the reporting install: 82 chats short of the 200-message
+        target, marching one phone request every two minutes for hours, for
+        conversations the user had never opened — on an account synced for
+        weeks. His words, twice: it should be following new messages, not
+        fetching old history for other conversations in the background.
+
+        Opening a conversation is the signal that its history is worth a
+        notification, and it is exactly the moment the user would accept one.
+        Scrolling up (fetch_older_messages) is unaffected and always was —
+        that request is attended by definition.
+        """
+        jid = self._normalize_jid(remote_jid or "")
+        if not jid:
+            return
+        opened = getattr(self, "_opened_conversations", None)
+        if not isinstance(opened, set):
+            opened = self._opened_conversations = set()
+        forms = {jid}
+        try:
+            forms.update(f for f in self._jid_address_forms(jid) if f)
+        except Exception:
+            pass
+        if forms <= opened:
+            return
+        opened.update(forms)
+        try:
+            if getattr(self, "db", None) is not None:
+                self.db.set_metadata_json(
+                    "opened_conversations_v1", sorted(opened))
+        except Exception as exc:
+            logging.warning("[history-sync] could not persist opened conversations: %s", exc)
+
+    def _user_has_opened(self, jid: str) -> bool:
+        """Whether the phone may be asked about this chat's older history."""
+        opened = getattr(self, "_opened_conversations", None)
+        if not isinstance(opened, set) or not opened:
+            return False
+        forms = {jid}
+        try:
+            forms.update(f for f in self._jid_address_forms(jid) if f)
+            forms.add(self._canonical_backfill_jid(jid))
+        except Exception:
+            pass
+        return bool(forms & opened)
+
     def _retire_chat_without_older_history(self, jid: str) -> None:
         """Record, durably, that the phone has no older history for this chat.
 
@@ -18606,6 +18665,12 @@ class MainWindow(wx.Frame):
                         # had nothing older. Re-queuing it here is what made
                         # that answer worthless — see the retirement below.
                         self._remove_backfill_pending(jid)
+                        continue
+                    if not self._user_has_opened(jid):
+                        # Never opened, so nobody is waiting on its history and
+                        # nobody would welcome a notification about it. The
+                        # local fetch above still runs and still stores whatever
+                        # WhatsApp Web has; only the phone is left alone.
                         continue
                     asked_at = getattr(self, "_older_requested_chats", {}).get(jid)
                     if MainWindow._older_history_is_exhausted(

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -1661,6 +1661,15 @@ class ConversationsPanel(wx.Panel):
             # Conversation already open — just focus the message input field.
             wx.CallAfter(self.message_field.SetFocus)
             return
+        # Record that the user actually looked at this conversation. It is the
+        # gate on asking the *phone* for its older history: every such request
+        # notifies the phone, so it is spent on chats the user opens rather
+        # than on every chat in the account. See _note_conversation_opened().
+        try:
+            self.main_window._note_conversation_opened(
+                conversation.get("remoteJid") or "")
+        except Exception:
+            logging.exception("[conversations] could not record the open (non-fatal)")
         self._stop_typing_for_current_conversation()
         self._cancel_active_recording()
         # Leaving the conversation invalidates any pending auto-chain timers —

--- a/tests/test_phone_history_needs_an_open_chat.py
+++ b/tests/test_phone_history_needs_an_open_chat.py
@@ -1,0 +1,115 @@
+"""Who gets to put a notification on the user's phone.
+
+Everything the backfill does is local and free except one step: asking the
+phone for older history. That request lights up the user's own lock screen,
+and when the phone cannot satisfy it the follow-up reads "Sync paused. Open
+WhatsApp to resume." — an error, for a conversation they never opened.
+
+Measured on the reporting install after the earlier rate and per-chat bounds
+were already shipped: 82 chats short of the 200-message target, one phone
+request every two minutes, marching through the account for hours. The bounds
+held; the queue was simply the whole address book. The user's own summary,
+twice: it should be following new messages, not fetching old history for other
+conversations in the background.
+
+So opening a conversation is the gate. It is the signal that its history is
+worth something, and the moment a notification about it is welcome. Scrolling
+up (fetch_older_messages) is unaffected and always was — that request is
+attended by definition.
+"""
+
+import types
+
+from main import MainWindow
+
+
+class _Stub:
+    _note_conversation_opened = MainWindow._note_conversation_opened
+    _user_has_opened = MainWindow._user_has_opened
+    _normalize_jid = staticmethod(MainWindow._normalize_jid)
+    _jid_address_forms = MainWindow._jid_address_forms
+    _canonical_backfill_jid = MainWindow._canonical_backfill_jid
+
+    def __init__(self):
+        self._lid_to_phone = {}
+        self._phone_to_lid = {}
+        self.db = types.SimpleNamespace(
+            set_metadata_json=lambda k, v: self.persisted.update({k: v}),
+            get_metadata_json=lambda k, d=None: self.persisted.get(k, d),
+        )
+        self.persisted = {}
+
+
+PHONE = "5511900000000@s.whatsapp.net"
+LID = "123456789012345@lid"
+
+
+class TestTheGate:
+    def test_a_chat_never_opened_is_refused(self):
+        assert _Stub()._user_has_opened(PHONE) is False
+
+    def test_opening_it_opens_the_gate(self):
+        stub = _Stub()
+        stub._note_conversation_opened(PHONE)
+        assert stub._user_has_opened(PHONE) is True
+
+    def test_opening_one_chat_does_not_open_another(self):
+        stub = _Stub()
+        stub._note_conversation_opened(PHONE)
+        assert stub._user_has_opened("5511911111111@s.whatsapp.net") is False
+
+    def test_it_is_recognised_under_the_other_address_form(self):
+        """The backfill queue keys chats by @lid while the UI opens them under
+        the phone JID, and vice versa — one bridge, two names for one chat."""
+        stub = _Stub()
+        stub._lid_to_phone = {LID: PHONE}
+        stub._phone_to_lid = {PHONE: LID}
+        stub._note_conversation_opened(PHONE)
+        assert stub._user_has_opened(LID) is True
+
+    def test_the_legacy_c_us_form_resolves_too(self):
+        stub = _Stub()
+        stub._note_conversation_opened("5511900000000@c.us")
+        assert stub._user_has_opened(PHONE) is True
+
+    def test_a_blank_jid_records_nothing(self):
+        stub = _Stub()
+        stub._note_conversation_opened("")
+        stub._note_conversation_opened(None)
+        assert stub._user_has_opened(PHONE) is False
+
+
+class TestItSurvivesARestart:
+    def test_the_open_is_persisted(self):
+        stub = _Stub()
+        stub._note_conversation_opened(PHONE)
+        assert PHONE in stub.persisted["opened_conversations_v1"]
+
+    def test_reopening_the_same_chat_does_not_rewrite_it(self):
+        stub = _Stub()
+        stub._note_conversation_opened(PHONE)
+        writes = []
+        stub.db.set_metadata_json = lambda k, v: writes.append(k)
+        stub._note_conversation_opened(PHONE)
+        assert writes == []
+
+    def test_a_database_that_refuses_the_write_is_not_fatal(self):
+        """The gate still opens for this session; losing it costs one chat's
+        history backfill after a restart, never a message."""
+        stub = _Stub()
+
+        def _boom(_k, _v):
+            raise OSError("disk full")
+
+        stub.db.set_metadata_json = _boom
+        stub._note_conversation_opened(PHONE)
+        assert stub._user_has_opened(PHONE) is True
+
+
+class TestTheBackfillHonoursIt:
+    def test_the_phone_request_is_gated_on_it(self):
+        import inspect
+        src = inspect.getsource(MainWindow._backfill_empty_chats)
+        assert "_user_has_opened" in src
+        # ...and before the request is built, not after it went out.
+        assert src.index("_user_has_opened") < src.index("request_older_messages(jid)")


### PR DESCRIPTION
The rate and per-chat bounds from #182 and #185 both held on the reporting install — one request every two minutes, two attempts per chat, exactly as designed. What neither bounded is the **size of the queue**:

```
20:08:21  [backfill-queue] pass=26 short=82 deep=16 unnamed=100
```

82 chats short of the 200-message target, up from 18, because a Chrome profile restore rolled WhatsApp Web's own store back and dozens of conversations came back looking short. One request every two minutes across 82 chats at two attempts each is a trickle of phone notifications lasting **hours**, for conversations the user has never opened, on an account synced for weeks.

His own summary, twice: it should be following new messages, not fetching old history for other conversations in the background — and *"eu nem dei home em nenhuma conversa para puxar histórico antigo"*.

## The gate

Everything the backfill does is local and free **except this one step**. Asking the phone lights up the user's own lock screen, and when the phone cannot satisfy the request the follow-up reads "Sync paused. Open WhatsApp to resume." — an error, about a chat nobody was waiting on.

So opening a conversation is the gate. It is the signal that a chat's history is worth something, and the moment a notification about it is welcome. The local `get-messages` still runs for every chat and still stores whatever WhatsApp Web has; only the phone is left alone. A chat opened later joins the queue then, paying the notification when it finally means something.

The record is persisted (a chat opened last week is still one whose history the user cares about) and resolves both address forms of the same chat, since the backfill queue keys by `@lid` while the UI opens by phone JID — plus the legacy `@c.us` spelling.

`fetch_older_messages()` is unaffected and always was: scrolling up is attended by definition.

## Tests

`tests/test_phone_history_needs_an_open_chat.py`, including the `@lid` ↔ phone bridge, persistence, and a structural check that the gate sits *before* the request is built rather than after it went out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)