### PR TITLE
Do not tear BASS down when it is already on the right device

### DIFF
--- a/client/core/sound_system.py
+++ b/client/core/sound_system.py
@@ -185,7 +185,7 @@ class SoundSystem:
         if not (self._load_bass_plugin('bass_aac.dll') or self._load_bass_plugin('bassaac.dll')):
             logging.warning("[sound_system] bass_aac.dll not loaded")
 
-    def _switch_to_default_device(self):
+    def _switch_to_default_device(self, force: bool = False):
         """Actually switch BASS back to the system default device.
 
         sound_lib.output.Output.set_device(-1) does NOT work for this:
@@ -199,7 +199,7 @@ class SoundSystem:
         stayed active. Free + reinit directly instead, skipping Output.
         set_device()'s own broken second call.
         """
-        return self._reinit_output_device(-1)
+        return self._reinit_output_device(-1, force=force)
 
     @staticmethod
     def _is_already_initialised(exc) -> bool:
@@ -207,7 +207,39 @@ class SoundSystem:
         text = str(exc)
         return "14" in text or "already" in text.lower()
 
-    def _reinit_output_device(self, device: int) -> bool:
+    def _output_device_is_healthy(self, device: int) -> bool:
+        """Whether BASS is already on `device` and that device still exists.
+
+        Both halves matter. "Already on it" alone is what the old sentinel
+        checked, and it cannot see a device that has since been unplugged —
+        BASS stays bound to an index that no longer resolves. "Still exists"
+        alone would churn BASS on every call.
+        """
+        try:
+            from sound_lib.external.pybass import (
+                BASS_DEVICEINFO, BASS_GetDevice, BASS_GetDeviceInfo, BASS_DEVICE_ENABLED,
+            )
+        except Exception:
+            return False
+        target = device
+        if target == -1:
+            target = find_default_output_device_index()
+        if target is None:
+            return False
+        try:
+            if BASS_GetDevice() != target:
+                return False
+            info = BASS_DEVICEINFO()
+            if not BASS_GetDeviceInfo(target, ctypes.byref(info)):
+                return False
+            return bool(info.flags & BASS_DEVICE_ENABLED)
+        except Exception:
+            # Unreadable is not healthy: fall through and reinitialise, which
+            # is the safe direction — a needless reinit costs the streams that
+            # are currently open, a skipped one costs all audio until restart.
+            return False
+
+    def _reinit_output_device(self, device: int, force: bool = False) -> bool:
         """Free BASS's current output device and bring `device` up, safely.
 
         Three faults lived in the two lines this replaces, and together they
@@ -248,6 +280,27 @@ class SoundSystem:
         Never raises. Returns whether a device is usable afterwards.
         """
         from sound_lib.external.pybass import BASS_SetDevice
+        if not force and self._output_device_is_healthy(device):
+            # Nothing to change, and changing it anyway is destructive: a
+            # free/init invalidates every BASS stream already created against
+            # the device, including every Sound load_sounds() built.
+            #
+            # This is what the `if self.output._device == -1: return` line this
+            # method replaced was really doing, and removing it shipped a
+            # regression: __init__ calls apply_output_device() at line 1694,
+            # load_sounds() at 1702, and _apply_configured_audio_devices() at
+            # 1741 calls apply_output_device() a second time. For a user on
+            # "system default" the second call used to be a no-op; unguarded it
+            # frees every stream that had just been loaded, so the startup
+            # sound and every effect afterwards raised "5, invalid handle".
+            # Reported by a user on a fresh install within hours of the alpha.
+            #
+            # So the sentinel is gone but the restraint is not: skip when BASS
+            # is already on the device asked for AND that device still exists.
+            # The dead-device case the sentinel could not see — a dongle
+            # unplugged, its index still cached — fails the health check and
+            # falls through to the reinit, which is the whole point.
+            return True
         try:
             self.output.free()
         except Exception as exc:
@@ -446,7 +499,10 @@ class SoundSystem:
         self._last_recovery_at = time.monotonic()
         name = self._configured_output_device
         self._warned_output_failure = True
-        if not self._switch_to_default_device():
+        # Forced: this is the recovery path, reached because a stream just
+        # failed to play. The device may look healthy from BASS's own answers
+        # and still not be usable, which is exactly why we are here.
+        if not self._switch_to_default_device(force=True):
             return False
         try:
             self.main_window.load_sounds()
@@ -726,7 +782,25 @@ class Sound(stream.FileStream):
         super().__init__(*args, file=self.file, **kwargs)
 
     def play(self):
-        super().stop()
+        # Guarded, and it has to be: this is a BASS_ChannelStop on a handle
+        # that may have been freed underneath us — the single commonest way
+        # this whole class fails. Outside the try it escaped `play()` entirely,
+        # so the recovery below never ran and the error reached the global
+        # handler, which plays a sound of its own and raised again from inside
+        # sys.excepthook. One stale handle then produced a pair of tracebacks
+        # per QR refresh, forever:
+        #
+        #   File "core/sound_system.py", line 729, in play
+        #   File "sound_lib/channel.py", line 139, in stop
+        #   sound_lib.main.BassError: 5, invalid handle
+        #
+        # Stopping a channel that is not playing, or no longer exists, is not
+        # a failure worth propagating — the caller asked for a sound, and the
+        # try below is what knows how to deliver one.
+        try:
+            super().stop()
+        except Exception as exc:
+            logging.debug("[sound_system] stop() before play: %s", exc)
         # Each sound event can be individually enabled/disabled from the
         # Settings > Sound Events tab. Sounds not tied to an event (e.g. the
         # background notification tone, resolved dynamically elsewhere) always

--- a/client/main.py
+++ b/client/main.py
@@ -27450,8 +27450,16 @@ class MainWindow(wx.Frame):
             wx.CallAfter(lambda: self.exception_handler(exc_type, exc_value, exc_traceback))
             return
 
-        #Play error sound
-        self.error_sound.play()
+        # Play error sound. Guarded because this handler is the last line of
+        # defence: a raise here lands in sys.excepthook itself, which Python
+        # reports as "Error in sys.excepthook" and then re-prints the original
+        # exception — so a broken audio device turned every unhandled error
+        # into two tracebacks and hid the one that mattered. Seen live with a
+        # stale BASS handle after a device reinit.
+        try:
+            self.error_sound.play()
+        except Exception:
+            logging.warning("[error-dialog] could not play the error sound", exc_info=True)
 
         # Create error dialog
         dialog = wx.Dialog(None, title=self.i18n.t("error").format(app_name=self.app_name), size=(600, 400), style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)

--- a/tests/test_audio_devices.py
+++ b/tests/test_audio_devices.py
@@ -607,3 +607,87 @@ class TestTheRecoveryCooldown:
         ss.handle_playback_failure()
         ss.apply_output_device("")
         assert ss._recovery_cooldown_elapsed() is True
+
+
+class TestAHealthyDeviceIsLeftAlone:
+    """The restraint the removed `if self.output._device == -1: return`
+    sentinel was really providing, and whose loss shipped a regression.
+
+    MainWindow.__init__ calls apply_output_device() at line 1694, load_sounds()
+    at 1702, and _apply_configured_audio_devices() calls apply_output_device()
+    a second time at 1741. For a user on "system default" that second call used
+    to be a no-op. Unguarded it frees and re-initialises BASS, invalidating
+    every Sound stream load_sounds() had just built — so the startup sound and
+    every effect afterwards raised "5, invalid handle". Reported by a user on a
+    fresh install within hours of the alpha:
+
+        [sound] Error playing startup sound: 5, invalid handle
+
+    The sentinel could not see the case it was removed for: a device unplugged
+    while BASS stays bound to its cached index. Hence a health check rather
+    than a sentinel — already on the requested device AND that device still
+    exists.
+    """
+
+    def _healthy(self, ss, healthy):
+        ss._output_device_is_healthy = lambda device: healthy
+
+    def test_a_second_apply_does_not_tear_bass_down(self, monkeypatch):
+        ss = _make_sound_system(monkeypatch, {})
+        self._healthy(ss, True)
+        ss.apply_output_device("")
+        ss.apply_output_device("")
+        assert ss.output.free_calls == 0
+
+    def test_an_unhealthy_device_is_still_reinitialised(self, monkeypatch):
+        ss = _make_sound_system(monkeypatch, {})
+        self._healthy(ss, False)
+        ss.apply_output_device("")
+        assert ss.output.free_calls == 1
+
+    def test_the_recovery_path_reinitialises_even_when_bass_looks_fine(self, monkeypatch):
+        """handle_playback_failure() is reached *because* a stream just failed
+        to play. BASS answering "all good" is exactly the case that needs
+        forcing — otherwise the recovery is a no-op and nothing ever plays."""
+        ss = _make_sound_system(monkeypatch, {})
+        self._healthy(ss, True)
+        assert ss.handle_playback_failure() is True
+        assert ss.output.free_calls == 1
+
+
+class TestStoppingAStaleChannelIsNotFatal:
+    """Sound.play()'s first act is a BASS_ChannelStop on a handle that may have
+    been freed underneath it. Outside the try it escaped play() entirely, so
+    the device recovery never ran and the error reached the global handler —
+    which plays a sound of its own and raised again from inside sys.excepthook,
+    producing two tracebacks per QR refresh, forever."""
+
+    def test_play_survives_a_stop_that_raises(self, monkeypatch):
+        import core.sound_system as mod
+
+        base = mod.Sound.__mro__[1]          # what super() in Sound.play() reaches
+        played = []
+        monkeypatch.setattr(
+            base, "stop",
+            lambda self: (_ for _ in ()).throw(Exception("5, invalid handle")),
+            raising=False)
+        monkeypatch.setattr(
+            base, "play",
+            lambda self, restart=False: played.append(restart), raising=False)
+
+        snd = mod.Sound.__new__(mod.Sound)
+        snd.sound_system = _make_sound_system(monkeypatch, {})
+        snd.sound_system._effects_device = None
+        snd.event_key = None
+        snd.pack_id = None
+        snd.file = "x.ogg"
+
+        mod.Sound.play(snd)                  # must not raise
+        assert played == [True]
+
+    def test_the_stop_is_inside_the_guarded_region(self):
+        """Structural, because the ordering is the whole bug: a stop() above
+        the try cannot be recovered by the except below it."""
+        import inspect
+        src = inspect.getsource(__import__("core.sound_system", fromlist=["Sound"]).Sound.play)
+        assert src.index("try:") < src.index("super().stop()")


### PR DESCRIPTION
**Regression from #189**, reported by a user on `1.1.0.2590alpha` within hours. Owning it plainly: I caused this.

## What I broke

I removed `if self.output._device == -1: return` from `_switch_to_default_device()` because it could not see a device that had been unplugged. It was doing **two** things and I accounted for one. The other was: *do not touch BASS when nothing needs changing.*

`MainWindow.__init__`:

```
1684  sound_system.start()               → Output() created
1694  apply_output_device("")            → before: no-op   | after #189: free() + init(-1)
1702  load_sounds()                      → builds every Sound stream
1741  _apply_configured_audio_devices()  → before: no-op   | after #189: free() + init(-1)
```

For a user on **"system default"** that second call was always a no-op. Unguarded it frees and re-initialises BASS *after* every Sound has been built, invalidating all of them:

```
00:19:11  [sound] Error playing startup sound: 5, invalid handle
```

The comment above line 1694 warns about exactly this — "Doing this after load_sounds() left every loaded Sound pointing at a stream BASS had already freed out from under it". It did not reach a machine with a *named* device configured, which takes the `set_device()` branch instead, which is why it was not caught locally.

## The fix

A **health check** rather than a sentinel: skip the reinit when BASS is already on the device asked for **and** that device still exists. The second half is what the old sentinel could not check and the reason it was removed, so #189's dead-device fix is kept. `handle_playback_failure()` passes `force=True` — it is reached *because* a stream failed, and BASS answering "all good" is precisely the case that needs forcing.

## Two pre-existing faults that turned one stale handle into a cascade

- `Sound.play()`'s first statement is `super().stop()` — a `BASS_ChannelStop` on a handle that may already be freed — and it sat **above** the `try`, so the device recovery below never ran and the error left `play()` entirely.
- The global exception handler plays a sound. That raise landed **inside `sys.excepthook`**, which Python reports as "Error in sys.excepthook" before re-printing the original — so every QR refresh produced two tracebacks and buried the real one.

Both are visible in the reporter's log, repeating every 20 seconds for the life of the pairing dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)