### PR TITLE
Stop a superseded session start from killing the session that replaced it

### DIFF
--- a/client/api_patches/src/util/createSessionUtil.ts
+++ b/client/api_patches/src/util/createSessionUtil.ts
@@ -579,12 +579,52 @@ export default class CreateSessionUtil {
       // precise process-tree kill first and only falls back to the
       // userDataDir scan when no live page/pid is reachable yet.
       const killBrowserOrFallback = () => {
+        // Refuse the userDataDir fallback once this create() has been
+        // superseded. That scan kills whatever browser currently holds the
+        // profile, and after a takeover that is somebody else's — measured
+        // live, and it cost a working session:
+        //
+        //   03:55:50  Connected / inChat        (restored profile, syncing)
+        //   03:56:01  Auth probe has failed for 30s straight — giving up
+        //   03:56:02  shouldClose detected in statusFind. Force-killing browser.
+        //   03:56:02  browserClose
+        //
+        // The 30 s auth-probe bound belonged to a create() started 45 s
+        // earlier against the *broken* profile. While it was still counting,
+        // WinZapp restored the profile and the health poll started a second
+        // session that connected and began syncing. The old create() then
+        // timed out, could not reach its own page (`wppClient` is still in the
+        // temporal dead zone during create(), which is why the fallback exists
+        // at all), and killed the profile's browser by directory — the new
+        // one. WhatsApp logged that session out on the next load, and the
+        // once-per-launch profile recovery had already been spent.
+        //
+        // A precise kill stays unconditional: if forceKillBrowserProcess()
+        // can reach this create()'s own page, it is killing its own browser
+        // and cannot touch a successor.
         let killed = false;
         try {
           killed = forceKillBrowserProcess(wppClient?.page, req.logger);
         } catch (e) {}
-        if (!killed)
-          forceKillByUserDataDir(`userDataDir/${session}`, req.logger);
+        if (killed) return;
+        const current: any = clientsArray[session];
+        if (current && current !== client) {
+          req.logger.warn(
+            `[${session}] not killing the browser by userDataDir: this session ` +
+              `start was superseded by a newer one, which owns that profile now.`
+          );
+          return;
+        }
+        forceKillByUserDataDir(`userDataDir/${session}`, req.logger);
+      };
+
+      // Same reasoning for the slot itself: clearing it would drop a
+      // successor's client, leaving the session unreachable while its browser
+      // keeps running.
+      const clearSessionSlotIfStillOurs = () => {
+        if (clientsArray[session] === undefined || clientsArray[session] === client) {
+          clientsArray[session] = undefined;
+        }
       };
 
       // Wrapped in a thunk purely so the stale-profile recovery below can call
@@ -625,7 +665,7 @@ export default class CreateSessionUtil {
                   `[${session}] shouldClose detected in catchLinkCode. Force-killing browser.`
                 );
                 killBrowserOrFallback();
-                clientsArray[session] = undefined;
+                clearSessionSlotIfStillOurs();
                 return;
               }
               this.exportPhoneCode(req, client.config.phone, code, client, res);
@@ -666,7 +706,7 @@ export default class CreateSessionUtil {
                   `[${session}] shouldClose detected in catchQR. Force-killing browser.`
                 );
                 killBrowserOrFallback();
-                clientsArray[session] = undefined;
+                clearSessionSlotIfStillOurs();
                 return;
               }
               this.exportQR(req, base64Qr, urlCode, client, res);
@@ -681,7 +721,7 @@ export default class CreateSessionUtil {
                     `[${session}] shouldClose detected in statusFind. Force-killing browser.`
                   );
                   killBrowserOrFallback();
-                  clientsArray[session] = undefined;
+                  clearSessionSlotIfStillOurs();
                   return;
                 }
                 eventEmitter.emit(
@@ -759,7 +799,7 @@ export default class CreateSessionUtil {
           );
           clearInterval(shouldClosePoller);
           killBrowserOrFallback();
-          clientsArray[session] = undefined;
+          clearSessionSlotIfStillOurs();
         }
       }, 2000);
 

--- a/client/main.py
+++ b/client/main.py
@@ -8580,11 +8580,30 @@ class MainWindow(wx.Frame):
                 from core.profile_recovery import ProfileHealthTracker
                 tracker = self._profile_health = ProfileHealthTracker()
             paired = bool(self.settings.get("privateinfo", {}).get("paired"))
-            if ((status or "").upper() == "CONNECTED"
-                    and self._profile_recovery_generation()):
-                # Whatever was put back is working. The ladder starts over, so
-                # a future break restores the newest snapshot first again.
-                self._set_profile_recovery_generation(0)
+            if (status or "").upper() == "CONNECTED":
+                if self._profile_recovery_generation():
+                    # Whatever was put back is working. The ladder starts over,
+                    # so a future break restores the newest snapshot first again.
+                    self._set_profile_recovery_generation(0)
+                if getattr(self, "_profile_recovery_attempted", False):
+                    # A restore that reached CONNECTED has proved the snapshot
+                    # good, so the once-per-launch budget it spent is earned
+                    # back. Measured live: a restore connected and began
+                    # syncing at 00:55:51, a superseded session start
+                    # force-killed its browser 11 s later, and the relaunch
+                    # found a profile WhatsApp then logged out of — with the
+                    # only recovery of the launch already spent, so the user
+                    # was sent to the pairing dialog with a good snapshot
+                    # still sitting on disk.
+                    #
+                    # The bound this relaxes exists to stop a restore loop on a
+                    # snapshot that does not work. One that connected is not
+                    # that snapshot, and nothing here can loop without a
+                    # CONNECTED in between.
+                    logging.info("[profile-recovery] the restored profile "
+                                 "connected — allowing another recovery if it "
+                                 "breaks again this launch.")
+                    self._profile_recovery_attempted = False
             if tracker.note_status(status, paired=paired):
                 self._recover_suspect_profile()
         except Exception:

--- a/tests/test_profile_recovery_wiring.py
+++ b/tests/test_profile_recovery_wiring.py
@@ -304,3 +304,59 @@ class TestARunThatNeverConnectedMayNotOverwriteTheRestorePoint:
         assert not hasattr(stub, "_profile_health")
         MainWindow._capture_profile_snapshot(stub, "sess123", True, None)
         assert len(captured) == 1
+
+
+class TestARestoreThatConnectedEarnsAnotherChance:
+    """The once-per-launch bound, and the case where it is the wrong answer.
+
+    Measured live on 2026-09-09. The QR-triggered recovery fired, the snapshot
+    went back, and the session connected and began syncing at 00:55:51. Eleven
+    seconds later a *superseded* session start — a create() from 45 s earlier,
+    still counting down its 30 s auth-probe bound against the profile that had
+    since been replaced — timed out and force-killed the browser by
+    userDataDir, taking the healthy session with it. The relaunch found a
+    profile WhatsApp then logged out of, and the launch's only recovery had
+    already been spent, so the user reached the pairing dialog with a good
+    snapshot still on disk.
+
+    The bound exists to stop a restore loop on a snapshot that does not work.
+    A snapshot that reached CONNECTED is not that snapshot.
+    """
+
+    def test_the_budget_is_spent_by_a_first_recovery(self, monkeypatch):
+        stub = _Stub()
+        monkeypatch.setattr("core.profile_recovery.has_snapshot",
+                            lambda *a, **kw: False)
+        monkeypatch.setattr("main.wx.CallAfter", lambda fn, *a, **kw: None)
+        MainWindow._recover_suspect_profile(stub)
+        assert stub._profile_recovery_attempted is True
+
+    def test_a_connection_gives_it_back(self):
+        stub = _Stub()
+        stub._profile_recovery_attempted = True
+        _note(stub, "CONNECTED")
+        assert stub._profile_recovery_attempted is False
+
+    def test_a_second_break_after_that_connection_recovers_again(self, monkeypatch):
+        stub = _Stub()
+        monkeypatch.setattr("core.profile_recovery.has_snapshot",
+                            lambda *a, **kw: True)
+        monkeypatch.setattr("main.threading.Thread",
+                            lambda *a, **kw: types.SimpleNamespace(start=lambda: None))
+        assert MainWindow._recover_suspect_profile(stub) is True
+        assert MainWindow._recover_suspect_profile(stub) is False
+        _note(stub, "CONNECTED")
+        assert MainWindow._recover_suspect_profile(stub) is True
+
+    def test_without_a_connection_it_still_runs_once(self, monkeypatch):
+        """The loop guard is intact: nothing here can re-arm without a
+        CONNECTED in between."""
+        stub = _Stub()
+        monkeypatch.setattr("core.profile_recovery.has_snapshot",
+                            lambda *a, **kw: True)
+        monkeypatch.setattr("main.threading.Thread",
+                            lambda *a, **kw: types.SimpleNamespace(start=lambda: None))
+        assert MainWindow._recover_suspect_profile(stub) is True
+        for _ in range(5):
+            _note(stub, "CLOSED")
+            assert MainWindow._recover_suspect_profile(stub) is False

--- a/tests/test_stale_browser_lock_recovery.py
+++ b/tests/test_stale_browser_lock_recovery.py
@@ -148,3 +148,72 @@ class TestTheKillCanActuallyBeAwaited:
         assert "if (!userDataDir) return Promise.resolve();" in kill
         # One for the Windows PowerShell path, one for the POSIX pkill path.
         assert kill.count("resolve()") >= 2
+
+
+class TestASupersededCreateMustNotKillItsSuccessor:
+    """The userDataDir kill is a fallback, and it is not always safe.
+
+    `killBrowserOrFallback()` tries a precise process-tree kill through
+    `wppClient?.page` first, but `wppClient` is only assigned once create()
+    returns — so during create() itself it is in the temporal dead zone and the
+    fallback always runs. That fallback kills whatever browser currently holds
+    the profile, which after a takeover is somebody else's.
+
+    Measured live on 2026-09-09:
+
+        03:55:50  Connected / inChat        (restored profile, syncing)
+        03:56:01  Auth probe has failed for 30s straight — giving up
+        03:56:02  shouldClose detected in statusFind. Force-killing browser.
+        03:56:02  browserClose
+
+    The 30 s auth-probe bound belonged to a create() started 45 s earlier
+    against the *broken* profile. While it counted, WinZapp restored the
+    profile and the health poll started a second session that connected and
+    began syncing. The old create() then timed out and killed the new one's
+    browser by directory. WhatsApp logged that session out on the next load,
+    and the once-per-launch profile recovery had already been spent.
+    """
+
+    def _kill_helper(self, source):
+        start = source.index("const killBrowserOrFallback = () => {")
+        return source[start:source.index("};", start)]
+
+    def test_a_precise_kill_is_still_unconditional(self, source):
+        """It can only reach this create()'s own page, so it cannot touch a
+        successor and must not be gated on ownership."""
+        body = self._kill_helper(source)
+        assert body.index("forceKillBrowserProcess") < body.index("clientsArray[session]")
+
+    def test_the_directory_scan_is_gated_on_still_owning_the_session(self, source):
+        body = self._kill_helper(source)
+        gate = body.index("current !== client")
+        assert gate < body.index("forceKillByUserDataDir")
+
+    def test_a_superseded_create_returns_without_killing(self, source):
+        body = self._kill_helper(source)
+        superseded = body[body.index("current !== client"):]
+        assert "return;" in superseded[:superseded.index("forceKillByUserDataDir")]
+
+    def test_the_refusal_is_logged(self, source):
+        """Silently not killing is as hard to diagnose as wrongly killing."""
+        body = self._kill_helper(source)
+        assert "superseded" in body
+
+    def test_the_session_slot_is_only_cleared_when_it_is_ours(self, source):
+        """Clearing it would drop a successor's client, leaving the session
+        unreachable while its browser keeps running."""
+        helper = source[source.index("const clearSessionSlotIfStillOurs = () => {"):]
+        helper = helper[:helper.index("};")]
+        assert "clientsArray[session] === client" in helper
+
+    @pytest.mark.parametrize("branch", ["catchLinkCode", "catchQR", "statusFind", "poller"])
+    def test_every_shouldClose_branch_uses_the_guarded_clear(self, source, branch):
+        marker = f"shouldClose detected in {branch}." if branch != "poller" \
+            else "shouldClose detected by poller."
+        # rindex: the same sentence appears in killBrowserOrFallback()'s own
+        # comment, which quotes the log line this was diagnosed from.
+        tail = source[source.rindex(marker):]
+        end = tail.index("}, 2000);") if branch == "poller" else 400
+        window = tail[:end]
+        assert "clearSessionSlotIfStillOurs()" in window
+        assert "clientsArray[session] = undefined" not in window


### PR DESCRIPTION
Also settles the question the audit was instrumented for in #185.

## The shutdown is not the cause

The login-store fingerprints came back **byte-identical** across the restart that lost the session:

```
00:53:56  Chrome released ... login_store=files=73 bytes=124671875 newest=1788926031
00:54:16  STARTUP        ... login_store=files=73 bytes=124671875 newest=1788926031
```

Nothing wrote to the profile between the shutdown and the next launch, so the profile WinZapp left is exactly the one WhatsApp Web then rejected. That rules out a lost write, a race, and a mid-write kill, and leaves the stale-credential hypothesis as the only one standing. `_stop_wpp_server` is cleared.

## Why the restored session dropped again

```
03:55:50  Connected / inChat        (restored profile, syncing)
03:56:01  Auth probe has failed for 30s straight — giving up
03:56:02  shouldClose detected in statusFind. Force-killing browser.
03:56:02  browserClose
```

That 30 s bound belonged to a `create()` started **45 seconds earlier**, against the *broken* profile. While it counted, the QR-triggered recovery from #183 restored the profile and the health poll started a second session that connected and began syncing.

The old `create()` then timed out and called `killBrowserOrFallback()`. Its precise kill cannot work during `create()` — `wppClient` is still in the temporal dead zone, which is exactly why the fallback exists — so it fell through to `forceKillByUserDataDir()` and killed whatever held that profile: **the new browser**.

The directory scan is now refused once `clientsArray[session]` holds a different client. The precise kill stays unconditional, since it can only ever reach this `create()`'s own page. The same reasoning applies to the slot itself — clearing it would drop a successor's client and leave the session unreachable with its browser still running — so all four `shouldClose` branches go through `clearSessionSlotIfStillOurs()`.

## Why the second break never recovered

`_profile_recovery_attempted` is once per launch and the first recovery had spent it at 00:55:31, so when the force-kill produced a profile WhatsApp logged out of, the user reached the pairing dialog with a good snapshot still sitting on disk. A restore that reaches CONNECTED has proved the snapshot works and earns its budget back. The loop guard is intact — nothing can re-arm without a CONNECTED in between.

## Note on the drift test

`tests/test_api_patches_in_sync.py` fails locally until `setup_api.py` propagates the TypeScript into `client/api/`. CI skips it (`client/api/` is not built there) and the alpha build runs `setup_api.py` itself, so the published alpha carries the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)