### PR TITLE
Ask the browser to close before killing it

### DIFF
--- a/client/api_patches/src/controller/sessionController.ts
+++ b/client/api_patches/src/controller/sessionController.ts
@@ -280,7 +280,15 @@ export async function closeSession(req: Request, res: Response): Promise<any> {
       );
       client.shouldClose = true;
       try {
-        SessionUtil.forceKillSession(session, req.logger);
+        // Awaited, and with the client handed over explicitly: the slot is
+        // cleared on the next line, and the graceful close needs it.
+        //
+        // A QRCODE/notLogged status does not mean there is nothing to lose.
+        // That is exactly what a *paired* install reports when its profile
+        // has stopped being accepted — and force-killing there SIGKILLs a
+        // Chrome holding the login database open. Five seconds keeps this
+        // inside WinZapp's own 10s POST budget.
+        await SessionUtil.forceKillSession(session, req.logger, client, true, 5000);
       } catch (e) {}
       (clientsArray as any)[session] = undefined;
       return await res
@@ -348,7 +356,8 @@ export async function closeSession(req: Request, res: Response): Promise<any> {
                 `the session slot is not left stuck in CLOSING.`
             );
             try {
-              SessionUtil.forceKillSession(session, req.logger);
+              // graceful=false: close() has already had its eight seconds.
+              SessionUtil.forceKillSession(session, req.logger, undefined, false);
             } catch (e) {}
             resolve();
           }, 8000);
@@ -364,7 +373,8 @@ export async function closeSession(req: Request, res: Response): Promise<any> {
         `[${session}] Error during req.client.close(): ${closeErr}. Force killing session.`
       );
       try {
-        SessionUtil.forceKillSession(session, req.logger);
+        // graceful=false: the close is what just raised.
+        SessionUtil.forceKillSession(session, req.logger, undefined, false);
       } catch (e) {}
     } finally {
       // Do not let an old close request erase a replacement client that may

--- a/client/api_patches/src/util/createSessionUtil.ts
+++ b/client/api_patches/src/util/createSessionUtil.ts
@@ -88,6 +88,81 @@ function forceKillBrowserProcess(page: any, logger?: any): boolean {
  * `taskkill /F /T` the whole Node process tree once its grace period ran
  * out, tearing down Chrome's profile (a LevelDB store) mid-write.
  */
+/** How long a graceful browser close gets before the kill takes over. */
+const GRACEFUL_CLOSE_MS = 8000;
+
+/**
+ * Ask this session's browser to close itself, and wait for it to actually go.
+ *
+ * Every force-kill in this file is a SIGKILL-equivalent (`taskkill /F`,
+ * `Stop-Process -Force`, `pkill -9`) delivered to a Chrome that may be
+ * mid-write. What it writes is WhatsApp Web's IndexedDB — the sole carrier of
+ * the login, since WPPConnect's token store is empty on a real install — and
+ * the failure that follows is not a corrupt database. Measured across several
+ * losses on a real install: the profile comes back structurally perfect,
+ * differing from a working snapshot only by ordinary LevelDB compaction, its
+ * shutdown fingerprint identical to the one the next launch reads, and
+ * WhatsApp Web still answers `post_logout=1` seven seconds in while an older
+ * copy of the same profile authenticates. Nothing on disk is broken; the state
+ * in it has stopped matching what the server expects, which is what killing a
+ * browser part-way through a key rotation would produce.
+ *
+ * So: ask first, kill second. `client.close()` is wppconnect's own teardown
+ * (browser.close(), which lets the page run its unload path and flush), and
+ * this waits for the process to be gone rather than trusting the call.
+ *
+ * Returns true only when the browser is confirmed gone. Never throws — a
+ * failure here just means the caller force-kills, which is what it did
+ * unconditionally before.
+ */
+async function closeBrowserGracefully(
+  session: string,
+  logger?: any,
+  timeoutMs: number = GRACEFUL_CLOSE_MS,
+  candidate?: any
+): Promise<boolean> {
+  const client: any = candidate ?? clientsArray[session];
+  const page: any = client?.page;
+  let proc: any;
+  try {
+    proc = page?.browser?.()?.process?.();
+  } catch (e) {}
+  if (!client && !proc) return false;
+  try {
+    if (typeof client?.close === 'function') {
+      await Promise.race([
+        client.close(),
+        new Promise((r) => setTimeout(r, timeoutMs)),
+      ]);
+    } else if (page?.browser) {
+      await Promise.race([
+        page.browser().close(),
+        new Promise((r) => setTimeout(r, timeoutMs)),
+      ]);
+    }
+  } catch (e: any) {
+    logger?.warn?.(
+      `[${session}] graceful browser close raised: ${e?.message || e}`
+    );
+  }
+  // The call returning is not the process being gone. Poll for the exit so a
+  // caller that is about to relaunch against this very profile does not race
+  // a Chrome that is still flushing it.
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const alive = proc && proc.exitCode === null && proc.signalCode === null;
+    if (!alive) {
+      logger?.info?.(`[${session}] browser closed gracefully.`);
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  logger?.warn?.(
+    `[${session}] browser did not close within ${timeoutMs}ms — falling back to the kill.`
+  );
+  return false;
+}
+
 function forceKillByUserDataDir(
   userDataDir: string,
   logger?: any
@@ -229,7 +304,14 @@ async function launchWithStaleBrowserRecovery(
       `[${session}] Chrome is still holding this session's profile although no ` +
         'session owns it — killing it and starting once more.'
     );
-    await forceKillByUserDataDir(userDataDir, logger);
+    // The orphan holding this profile very often still has its client object
+    // in clientsArray — createSessionUtil() refuses to run unless the session
+    // reports CLOSED, but a status of CLOSED does not mean the browser went
+    // away. When it is reachable, close it properly rather than SIGKILLing a
+    // Chrome that is holding this session's login database open.
+    if (!(await closeBrowserGracefully(session, logger))) {
+      await forceKillByUserDataDir(userDataDir, logger);
+    }
     await new Promise((resolve) =>
       setTimeout(resolve, STALE_BROWSER_RELEASE_MS)
     );
@@ -504,8 +586,26 @@ async function grantPersistentStorage(page: any, logger: any, session: string) {
 }
 
 export default class CreateSessionUtil {
-  forceKillSession(session: string, logger?: any) {
-    const client: any = clientsArray[session];
+  /**
+   * `candidate` is for callers that clear `clientsArray[session]` immediately
+   * after calling this: the graceful close needs the client, and reading it
+   * back off the array would race that clear.
+   *
+   * `graceful` is false only where a close has *already* been tried and
+   * failed — asking twice would just spend the caller's budget again.
+   */
+  async forceKillSession(
+    session: string,
+    logger?: any,
+    candidate?: any,
+    graceful = true,
+    timeoutMs?: number
+  ) {
+    const client: any = candidate ?? clientsArray[session];
+    // Ask before killing — see closeBrowserGracefully() for what a SIGKILL
+    // mid-write costs here.
+    if (graceful && (await closeBrowserGracefully(session, logger, timeoutMs, client)))
+      return;
     if (!forceKillBrowserProcess(client?.page, logger)) {
       forceKillByUserDataDir(`userDataDir/${session}`, logger);
     }

--- a/client/main.py
+++ b/client/main.py
@@ -4199,9 +4199,19 @@ class MainWindow(wx.Frame):
             time.sleep(2)
         # A hibernation-suspended chrome.exe may still hold the userDataDir lock,
         # which makes the start-session below fail with "browser is already
-        # running" and hangs the session in INITIALIZING forever. Kill that
-        # orphan (this account's only) and clear its lockfile first.
-        self._kill_orphaned_chrome_for_session()
+        # running" and hangs the session in INITIALIZING forever. Clear that
+        # orphan before starting — but through wait_for_profile_release(),
+        # which is "wait for it to let go, and kill only if it never does".
+        #
+        # The bare kill this replaces ran unconditionally, moments after a
+        # close-session that had usually already worked: a SIGKILL delivered to
+        # a Chrome that was in the middle of flushing WhatsApp Web's IndexedDB,
+        # for no gain, on every wake. That database is the only carrier of the
+        # login, and the losses it produces do not look like corruption — the
+        # profile comes back structurally perfect and simply stops being
+        # accepted. See closeBrowserGracefully() in createSessionUtil.ts.
+        self.wait_for_profile_release(
+            (getattr(self, "token", "") or "").split(":")[0], timeout=10.0)
         try:
             api_post(
                 f"{self.wpp_server}:{self.wpp_port}/api/{token}/start-session",
@@ -4774,7 +4784,11 @@ class MainWindow(wx.Frame):
                 self._stop_wpp_server()
                 self.wpp_process = None
 
-                self._kill_orphaned_chrome_for_session()
+                # _stop_wpp_server() has already closed the session and waited
+                # for Chrome to release the profile. Kill only what is still
+                # holding it — same reasoning as the wake path above.
+                self.wait_for_profile_release(
+                    (getattr(self, "token", "") or "").split(":")[0], timeout=10.0)
             except Exception:
                 logging.exception("[wpp_update] Stopping the server before the "
                                   "update failed — reinstalling anyway, which is "

--- a/tests/test_shutdown_closing_state.py
+++ b/tests/test_shutdown_closing_state.py
@@ -231,3 +231,41 @@ class TestTheFlushPollWaitsOutClosing:
         timeout_line = next(l for l in stub.audit if "flush TIMEOUT" in l)
         assert "0.1s" in timeout_line
         assert "15.0s" not in timeout_line
+
+
+class TestClosingAQrcodeSessionAlsoAsksFirst:
+    """A QRCODE/notLogged status does not mean there is nothing to lose.
+
+    That is exactly what a *paired* install reports once its Chrome profile has
+    stopped being accepted — and the close-session handler's fast path
+    force-killed the browser there, SIGKILLing a Chrome holding WhatsApp Web's
+    IndexedDB open. The comment above it said CONNECTED/open are closed
+    gracefully "to preserve LevelDB pairing state", which is the right instinct
+    applied to the wrong half of the condition.
+    """
+
+    @staticmethod
+    def _source():
+        return PATCHED_CONTROLLER.read_text(encoding="utf-8")
+
+    def _fast_path(self):
+        src = self._source()
+        return src[src.index("Force killing session because status is"):][:800]
+
+    def test_the_force_kill_path_is_awaited(self):
+        """The slot is cleared on the next line, so a fire-and-forget close
+        would race its own lookup of the client."""
+        assert "await SessionUtil.forceKillSession(" in self._fast_path()
+
+    def test_the_client_is_handed_over_explicitly(self):
+        assert "forceKillSession(session, req.logger, client" in self._fast_path()
+
+    def test_it_stays_inside_winzapps_own_post_budget(self):
+        """_WPP_GRACEFUL_STOP_SECONDS is 10s; the graceful attempt has to
+        answer first or WinZapp times out the POST and kills Node anyway."""
+        assert "5000" in self._fast_path()
+
+    def test_a_close_that_already_failed_is_not_asked_twice(self):
+        src = self._source()
+        for marker in ("did not settle in 8s", "Error during req.client.close()"):
+            assert "undefined, false" in src[src.index(marker):][:700]

--- a/tests/test_stale_browser_lock_recovery.py
+++ b/tests/test_stale_browser_lock_recovery.py
@@ -217,3 +217,58 @@ class TestASupersededCreateMustNotKillItsSuccessor:
         window = tail[:end]
         assert "clearSessionSlotIfStillOurs()" in window
         assert "clientsArray[session] = undefined" not in window
+
+
+class TestEveryKillAsksFirst:
+    """Force-killing a Chrome that is mid-write is the leading explanation for
+    the profile losses this file's recovery keeps having to repair.
+
+    What that Chrome is writing is WhatsApp Web's IndexedDB — the sole carrier
+    of the login, since WPPConnect's token store is empty on a real install.
+    The resulting failure is not a corrupt database, which is what made it hard
+    to see: measured across several losses, the profile comes back
+    structurally perfect, differing from a working snapshot only by ordinary
+    LevelDB compaction, with a shutdown fingerprint identical to the one the
+    next launch reads — and WhatsApp Web still answers `post_logout=1` seven
+    seconds in while an older copy of the same profile authenticates. Nothing
+    on disk is broken; the state in it stopped matching the server's, which is
+    what killing a browser part-way through a key rotation would produce.
+
+    So every kill site asks first.
+    """
+
+    def _helper(self, source, name):
+        start = source.index(f"async function {name}(")
+        return source[start:source.index("\n}\n", start)]
+
+    def test_the_graceful_close_waits_for_the_process_to_be_gone(self, source):
+        """The call returning is not the process exiting, and a caller about to
+        relaunch against this profile must not race a Chrome still flushing."""
+        body = self._helper(source, "closeBrowserGracefully")
+        assert "exitCode" in body and "deadline" in body
+
+    def test_it_never_throws(self, source):
+        """A failure here just means the caller force-kills, which is what it
+        did unconditionally before."""
+        body = self._helper(source, "closeBrowserGracefully")
+        assert "catch" in body
+
+    def test_it_reports_whether_the_browser_actually_went(self, source):
+        body = self._helper(source, "closeBrowserGracefully")
+        assert "return true;" in body and "return false;" in body
+
+    def test_the_stale_lock_recovery_asks_before_killing(self, source):
+        body = self._helper(source, "launchWithStaleBrowserRecovery")
+        assert body.index("closeBrowserGracefully") < body.index("forceKillByUserDataDir")
+
+    def test_force_kill_session_asks_before_killing(self, source):
+        start = source.index("async forceKillSession(")
+        body = source[start:source.index("\n  }\n", start)]
+        assert body.index("closeBrowserGracefully") < body.index("forceKillBrowserProcess")
+
+    def test_it_can_be_told_not_to_ask_twice(self, source):
+        """Only where a close has already been tried and failed — asking again
+        would just spend the caller's budget a second time."""
+        start = source.index("async forceKillSession(")
+        body = source[start:source.index("\n  }\n", start)]
+        assert "graceful = true" in body

--- a/tests/test_wpp_update_not_on_main_thread.py
+++ b/tests/test_wpp_update_not_on_main_thread.py
@@ -106,6 +106,14 @@ class _Stub:
     def _kill_orphaned_chrome_for_session(self):
         self.events.append("kill")
 
+    def wait_for_profile_release(self, session_name, timeout=None):
+        # The update path clears the profile through this now: wait for the
+        # release, kill only what never lets go. Recorded under the same name
+        # so the sequence assertions keep reading as "the profile was freed
+        # between the stop and the restart".
+        self.events.append("kill")
+        return True
+
     def ensure_wpp_running(self):
         self.events.append("restart")
 

--- a/tests/test_wpp_update_releases_profile.py
+++ b/tests/test_wpp_update_releases_profile.py
@@ -42,32 +42,50 @@ class TestTheUpdateReleasesTheProfile:
     def _source():
         return inspect.getsource(MainWindow._update_wpp_server)
 
-    def test_the_orphan_killer_runs_during_the_update(self):
-        assert "_kill_orphaned_chrome_for_session()" in self._source()
+    def test_the_profile_is_released_during_the_update(self):
+        """Through wait_for_profile_release(), not a bare kill.
+
+        The invariant is unchanged — nothing may still hold the profile when
+        the restarted server calls start-session — but the means matter.
+        _stop_wpp_server() has already closed the session and waited, so by
+        this point Chrome has almost always let go on its own; the bare kill
+        this replaced fired anyway, delivering a SIGKILL to a browser that was
+        very likely mid-flush of WhatsApp Web's IndexedDB. That database is the
+        only carrier of the login, and what it produces is not a corrupt file:
+        the profile comes back structurally perfect and simply stops being
+        accepted. wait_for_profile_release() waits for the release and kills
+        only what never lets go — which is the case this test was written for.
+        """
+        assert "self.wait_for_profile_release(" in self._source()
 
     def test_it_runs_after_the_stop_and_before_the_restart(self):
-        """Killing before the server is stopped would race the shutdown;
-        killing after it is back up is too late — start-session has already
+        """Clearing before the server is stopped would race the shutdown;
+        clearing after it is back up is too late — start-session has already
         failed by then."""
         source = self._source()
         stop = source.index("self._stop_wpp_server()")
-        kill = source.index("self._kill_orphaned_chrome_for_session()")
+        release = source.index("self.wait_for_profile_release(")
         restart = source.index("self.ensure_wpp_running()")
-        assert stop < kill < restart
+        assert stop < release < restart
 
     def test_it_covers_the_failed_update_path_too(self):
         """_update_wpp_server restarts the server on BOTH branches — a
         cancelled or failed reinstall still calls ensure_wpp_running(). A lock
         left over there strands the user just as badly."""
         source = self._source()
-        kill = source.index("self._kill_orphaned_chrome_for_session()")
-        # Every restart must come after the single kill.
+        release = source.index("self.wait_for_profile_release(")
         restarts = [
             i for i in range(len(source))
             if source.startswith("self.ensure_wpp_running()", i)
         ]
         assert len(restarts) >= 2
-        assert all(i > kill for i in restarts)
+        assert all(i > release for i in restarts)
+
+    def test_the_release_still_kills_a_profile_nothing_lets_go_of(self):
+        """The escape hatch the bare kill existed for is intact: a suspended
+        chrome.exe that never releases is still killed, just last."""
+        source = inspect.getsource(MainWindow.wait_for_profile_release)
+        assert "_kill_orphaned_chrome_for_session" in source
 
     def test_the_helper_still_exists_with_that_name(self):
         assert callable(getattr(MainWindow, "_kill_orphaned_chrome_for_session"))


### PR DESCRIPTION
Attacks the root cause instead of getting better at repairing it.

## What a force-kill costs here

Every force-kill in the session paths is a SIGKILL-equivalent (`taskkill /F`, `Stop-Process -Force`, `pkill -9`) delivered to a Chrome that may be mid-write. What it writes is WhatsApp Web's IndexedDB — the **sole** carrier of the login, since WPPConnect's token store is empty on a real install.

The resulting failure is not a corrupt database, which is what made it hard to see. Measured across several losses on one install:

- the profile comes back **structurally perfect**, differing from a working snapshot only by ordinary LevelDB compaction (387 files vs 384, none missing);
- its shutdown fingerprint is **byte-identical** to the one the next launch reads, so nothing wrote to it in between;
- and WhatsApp Web still answers `post_logout=1` seven seconds in, while an *older* copy of the same profile authenticates.

Nothing on disk is broken. The state in it stopped matching the server's — which is what killing a browser part-way through a key rotation would produce.

## The fix

`closeBrowserGracefully()` calls wppconnect's own `client.close()` (`browser.close()`, which lets the page run its unload path and flush) and then **waits for the process to actually exit** — the call returning is not the process being gone, and the caller is often about to relaunch against that very profile. It never throws: a failure just means the caller force-kills, which is what it did unconditionally before.

Wired into every site that had a handle to ask with:

- **`forceKillSession()`** — always has a reachable page, so the polite path is available every time. `candidate` exists for callers that clear `clientsArray[session]` on the next line; reading it back would race that clear.
- **`launchWithStaleBrowserRecovery()`** — the orphan holding the profile usually still has its client object, since `createSessionUtil()` refuses to run unless the session reports CLOSED, and CLOSED does not mean the browser went away.
- **`closeSession()`'s fast path**, which force-killed `QRCODE`/`notLogged` sessions while its own comment said CONNECTED/open are closed gracefully "to preserve LevelDB pairing state". Right instinct, wrong half of the condition: **QRCODE is exactly what a paired install reports once its profile has stopped being accepted.** Awaited, client handed over explicitly, bounded at 5s to stay inside WinZapp's 10s POST budget.
- **Both Python kills** — the wake-from-hibernation path and the WPPConnect update — which fired unconditionally moments after a `close-session` that had usually already worked. A free SIGKILL on every wake and every update. They now go through `wait_for_profile_release()`, which is "wait for the release, kill only what never lets go". The escape hatch is intact: a suspended `chrome.exe` that never releases is still killed, just last.

Deliberately **not** asked twice where a close has already been tried and failed: after the 8s race in `closeSession()`, and after `close()` itself raised.

## Note on the drift test

`tests/test_api_patches_in_sync.py` fails locally until `setup_api.py` propagates the TypeScript into `client/api/`. CI skips it and the alpha build runs `setup_api.py` itself, so the published alpha carries both patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)