### PR TITLE
Session losses: WinZapp refused every Windows shutdown, and a failed start wedged the account offline

### DIFF
--- a/client/api_patches/src/util/createSessionUtil.ts
+++ b/client/api_patches/src/util/createSessionUtil.ts
@@ -626,9 +626,27 @@ export default class CreateSessionUtil {
     session: string,
     res?: any
   ) {
+    // Resolved once this attempt has taken ownership of the slot, so the catch
+    // at the bottom can tell whether the client it is about to touch is still
+    // its own. `client` itself is declared inside the try and is out of scope
+    // there, which is why the old catch had to re-resolve it through
+    // getClient() — and why it could not tell a superseded attempt apart.
+    let ownClient: any = null;
     try {
       let client = this.getClient(session) as any;
-      if (client.status != null && client.status !== 'CLOSED') return;
+      if (client.status != null && client.status !== 'CLOSED') {
+        // Silent until now, and the silence is most of why the deadlock below
+        // was so hard to see: this returns without starting anything while
+        // startSession() still answers HTTP 200, so WinZapp logs "Sent
+        // auto-start session command" every 30 s for a session that no code
+        // path is ever going to start.
+        req.logger?.info?.(
+          `[${session}] start-session ignored: status is ${client.status}, ` +
+            `not CLOSED — another attempt owns this session.`
+        );
+        return;
+      }
+      ownClient = client;
       client.status = 'INITIALIZING';
       client.config = req.body;
 
@@ -968,9 +986,51 @@ export default class CreateSessionUtil {
       }
     } catch (e) {
       req.logger.error(e);
-      if (e instanceof Error && e.name == 'TimeoutError') {
-        const client = this.getClient(session) as any;
-        client.status = 'CLOSED';
+      // A create() that threw owns no browser: whatever went wrong, this
+      // attempt is over. Leaving the status at INITIALIZING is not neutral,
+      // it is permanent — and it takes the whole account offline in silence.
+      // createSessionUtil() returns early for any status other than CLOSED
+      // (right at the top of this method), and WinZapp's health checker skips
+      // /start-session for every "active" state, so after one failed start
+      // neither side ever starts a session again. Upstream reset the status
+      // only for a TimeoutError, which covers exactly one of the ways create()
+      // can fail.
+      //
+      // Measured on 2026-09-09: a start-session that raced a profile restore
+      // failed with `The browser is already running for <userDataDir>` — an
+      // Error, not a TimeoutError, so the old branch did not fire. The
+      // recovery finished 6 s later and put a profile back that had
+      // authenticated fine hours earlier, and there was nothing left able to
+      // start it. status-session answered INITIALIZING for the rest of the
+      // process's life, with no chrome.exe in existence, while /start-session
+      // kept returning 200 and launching nothing. Only closing the app cleared
+      // it, because the wedged status lives in this process's memory.
+      //
+      // Two conditions, both load-bearing:
+      //
+      // * the slot must still hold OUR client. A create() superseded by a
+      //   newer one must never write CLOSED over the successor's status, or
+      //   the next /start-session launches a duplicate Chrome onto a profile a
+      //   live session is using — the same failure killBrowserOrFallback()
+      //   above refuses the userDataDir scan for, and it cost a working
+      //   session once already.
+      // * the status must still be INITIALIZING. Anything else means something
+      //   already promoted this session to a real state, and the throw came
+      //   from one of the webhook wirings that run past this.start(); reporting
+      //   a connected session as CLOSED would hand it the same duplicate
+      //   launch.
+      const failed: any = ownClient;
+      if (
+        failed &&
+        clientsArray[session] === failed &&
+        failed.status === 'INITIALIZING'
+      ) {
+        failed.status = 'CLOSED';
+        failed.qrcode = null;
+        req.logger.warn(
+          `[${session}] session start failed before it reached a real state — ` +
+            `status reset to CLOSED so the next /start-session can run.`
+        );
       }
     }
   }

--- a/client/main.py
+++ b/client/main.py
@@ -2436,8 +2436,49 @@ class MainWindow(wx.Frame):
         # come back corrupted, which looks exactly like being unlinked even
         # though the phone still shows the session. Ask Windows to hold the
         # shutdown while we close WPPConnect properly.
-        self.Bind(wx.EVT_QUERY_END_SESSION, self._on_query_end_session)
-        self.Bind(wx.EVT_END_SESSION, self._on_end_session)
+        #
+        # **On the wx.App, never on this frame.** wxMSW routes both messages to
+        # wxTheApp and to nothing else — `wxWindowMSW::HandleQueryEndSession()`
+        # and `HandleEndSession()` build the wxCloseEvent and dispatch it with
+        # `wxTheApp->SafelyProcessEvent(event)` — and a wxCloseEvent is not a
+        # command event, so it never propagates to a frame. Bound here, these
+        # two handlers could not run, and did not: a shutdown_audit.log
+        # covering 159 launches carries seventeen runs that ended with no
+        # teardown at all, eleven of them overnight, and not one line from
+        # either handler. Confirmed live by sending WM_QUERYENDSESSION to the
+        # running app's own window: delivered, and no audit line.
+        #
+        # What ran instead is wxApp's own static table entry, and it is the
+        # rest of the bug (src/msw/app.cpp):
+        #
+        #     void wxApp::OnQueryEndSession(wxCloseEvent& event)
+        #     {
+        #         if (GetTopWindow())
+        #             if (!GetTopWindow()->Close(!event.CanVeto()))
+        #                 event.Veto(true);
+        #     }
+        #
+        # `Close()` on this frame fires EVT_CLOSE, which is _on_close() — and
+        # _on_close() hides to the tray and **vetoes**, because that is the
+        # right answer when a human clicks the X. So WinZapp answered "no, you
+        # may not shut down" to Windows on every single shutdown. Measured on
+        # the live app: 0, a veto. Windows then puts up the blocking-apps
+        # screen and, on the way past it, terminates the process outright —
+        # which is precisely the STARTUP-with-no-_stop_wpp_server pattern that
+        # comes back as a profile WhatsApp Web refuses.
+        #
+        # A dynamic Bind is searched before the class's static event table, so
+        # binding here replaces that default rather than adding to it. Which is
+        # also why neither handler may call event.Skip(): skipping resumes the
+        # search, reaches wxApp::OnQueryEndSession, and restores the veto.
+        _app = wx.GetApp()
+        if _app is not None:
+            _app.Bind(wx.EVT_QUERY_END_SESSION, self._on_query_end_session)
+            _app.Bind(wx.EVT_END_SESSION, self._on_end_session)
+        else:
+            logging.error("[init_UI] no wx.App to bind the Windows shutdown "
+                          "handlers to — WPPConnect will not be closed cleanly "
+                          "on a Windows shutdown.")
 
         # System sleep/resume: the socket.io client, its underlying TCP
         # connection, and the local Puppeteer/Chrome session all go stale the
@@ -8328,12 +8369,22 @@ class MainWindow(wx.Frame):
     def _on_query_end_session(self, event):
         """Windows is asking whether it may shut down. We say yes.
 
+        Saying yes is the whole job, and it is what this handler exists to do:
+        left to wxApp's own default (see the Bind in init_UI) WinZapp answered
+        FALSE, because that default closes the top window and _on_close() vetoes
+        to hide to the tray. Windows then blocks, times out, and kills us
+        mid-flush — the corruption this path exists to prevent.
+
+        Returning WITHOUT event.Skip() is what answers TRUE. Not skipping means
+        the event is fully handled here, so wx reports mayEnd = !GetVeto() =
+        true; skipping would resume the handler search, reach
+        wxApp::OnQueryEndSession, and put the veto straight back.
+
         The ShutdownBlockReason registered here does NOT buy extra time, and it
         is important not to believe otherwise: Windows only holds a shutdown for
-        an app that ALSO answers FALSE to WM_QUERYENDSESSION, and `event.Skip()`
-        below answers TRUE. All the reason string does is name us on the
-        blocking-apps screen if something else vetoes. It is kept for that, and
-        because _on_end_session has to destroy it either way.
+        an app that ALSO answers FALSE. All the reason string does is name us on
+        the blocking-apps screen if something else vetoes. It is kept for that,
+        and because _on_end_session has to destroy it either way.
 
         So the real deadline for _on_end_session is Windows' hung-app timeout,
         ~5s — which is why it passes _WINDOWS_SHUTDOWN_BUDGET rather than
@@ -8365,7 +8416,8 @@ class MainWindow(wx.Frame):
             )
         except Exception:
             pass
-        event.Skip()
+        # No event.Skip() — see the docstring. Skipping hands the event on to
+        # wxApp::OnQueryEndSession, which is the veto.
 
     # How long to wait after WM_ENDSESSION before assuming the shutdown was
     # cancelled and undoing _shutting_down. Per Windows docs bEnding can in
@@ -8428,7 +8480,9 @@ class MainWindow(wx.Frame):
                 ctypes.windll.user32.ShutdownBlockReasonDestroy(self.GetHandle())
             except Exception:
                 pass
-            event.Skip()
+            # No Skip: wxApp::OnEndSession would run DeleteAllTLWs(), OnExit()
+            # and exit() after we have already spent the Windows budget, and
+            # the process is terminated the moment this returns anyway.
             return
 
         def _unstick_if_still_running():
@@ -8480,7 +8534,7 @@ class MainWindow(wx.Frame):
             ctypes.windll.user32.ShutdownBlockReasonDestroy(self.GetHandle())
         except Exception:
             pass
-        event.Skip()
+        # No Skip, for the same reason as the branch above.
 
     # How long to wait for WPPConnect's /close-session request to confirm
     # Chrome closed gracefully before giving up and force-killing.

--- a/client/main.py
+++ b/client/main.py
@@ -8168,9 +8168,10 @@ class MainWindow(wx.Frame):
     # above are free: they only ever elapse when something is genuinely wrong.
     # On WM_ENDSESSION we are on a clock we do not control. _on_query_end_session
     # registers a ShutdownBlockReason but still lets the shutdown proceed
-    # (event.Skip() answers TRUE to WM_QUERYENDSESSION — registering a reason
-    # without ALSO vetoing buys no extra time; see that method), so what we
-    # really have is Windows' hung-app timeout, ~5s by default.
+    # (handling the event without skipping answers TRUE to WM_QUERYENDSESSION —
+    # registering a reason without ALSO vetoing buys no extra time; see that
+    # method), so what we really have is Windows' hung-app timeout, ~5s by
+    # default.
     #
     # Left unbounded, the phases below sum to ~40s (10 POST + 15 flush + 15
     # profile release). Windows would cut that off partway — which is the very

--- a/client/main.py
+++ b/client/main.py
@@ -8735,8 +8735,40 @@ class MainWindow(wx.Frame):
                 wx.CallAfter(self._announce_profile_beyond_repair)
                 if on_give_up is not None:
                     wx.CallAfter(on_give_up)
+            finally:
+                # Released only once the profile is back in place, so the very
+                # next health poll starts a session on the restored profile
+                # rather than on the broken one.
+                self._recovery_restart_active = False
 
-        threading.Thread(target=_restore, daemon=True).start()
+        # This sequence is a close/kill/restore cycle that owns the browser and
+        # the profile for as long as it runs — up to ~25 s of it spent inside
+        # wait_for_profile_release() while Chrome still holds the directory.
+        # It is exactly what _recovery_restart_active exists to announce, and
+        # not setting it cost a session on 2026-09-09: the 30 s health poll
+        # landed 14 s in, read CLOSED, and fired its own /start-session into a
+        # profile that was still locked. That start failed with "The browser is
+        # already running", which (before the createSessionUtil.ts fix that
+        # ships with this change) left the session wedged in INITIALIZING for
+        # good — so the restore completed onto a profile nothing could start
+        # any more, and the app sat offline in silence until it was restarted
+        # by hand.
+        #
+        # Setting it also makes _self_inflicted_teardown_expected() true for
+        # the duration, which is correct on its own terms: the close-session
+        # above is ours, so the CLOSED/loggedOut readings that follow it are
+        # the expected result of this call and not WhatsApp unlinking the
+        # device. And _yield_to_in_progress_self_restart() will now give a quit
+        # landing mid-restore a few seconds to let the profile finish being put
+        # back, instead of tearing down on top of a half-copied leveldb.
+        self._recovery_restart_active = True
+        try:
+            threading.Thread(target=_restore, daemon=True).start()
+        except Exception:
+            # A flag nobody clears blocks every future auto-start for the life
+            # of the process — worse than the race it guards against.
+            self._recovery_restart_active = False
+            raise
         return True
 
     _PROFILE_RECOVERY_GENERATION_KEY = "profile_recovery_generation"

--- a/tests/test_end_session_unstick.py
+++ b/tests/test_end_session_unstick.py
@@ -65,7 +65,11 @@ class TestShuttingDownIsSetImmediately:
 
         assert s._shutting_down is True
         assert s.stop_wpp_server_calls == 1
-        assert event.skipped is True
+        # Deliberately NOT skipped: Skip() resumes the handler search and
+        # reaches wxApp::OnEndSession (DeleteAllTLWs/OnExit/exit()), spending a
+        # Windows budget this teardown has already used. See
+        # tests/test_windows_shutdown_handlers.py.
+        assert event.skipped is False
 
     def test_signals_teardown_complete_when_it_owns_teardown(self):
         """A real_exit()/_ipc_quit() call that lost the lock race waits on
@@ -99,7 +103,11 @@ class TestDoesNotDoubleTeardownWhenAlreadyInProgress:
 
         assert s.stop_wpp_server_calls == 0
         assert s.flush_calls == 0
-        assert event.skipped is True
+        # Deliberately NOT skipped: Skip() resumes the handler search and
+        # reaches wxApp::OnEndSession (DeleteAllTLWs/OnExit/exit()), spending a
+        # Windows budget this teardown has already used. See
+        # tests/test_windows_shutdown_handlers.py.
+        assert event.skipped is False
 
     def test_does_not_signal_completion_for_teardown_it_does_not_own(self):
         """This path only skips out of the way -- the OTHER path (still

--- a/tests/test_end_session_waits_for_owned_teardown.py
+++ b/tests/test_end_session_waits_for_owned_teardown.py
@@ -86,7 +86,11 @@ class TestTeardownOwnedElsewhere:
             "the losing branch returned immediately — Windows then terminates "
             "the process while the owning path is still mid _stop_wpp_server()"
         )
-        assert evt.skipped
+        # Deliberately NOT skipped: Skip() resumes the handler search and
+        # reaches wxApp::OnEndSession (DeleteAllTLWs/OnExit/exit()), spending a
+        # Windows budget this teardown has already used. See
+        # tests/test_windows_shutdown_handlers.py.
+        assert evt.skipped is False
         # It must NOT start a competing teardown of its own; that is exactly
         # what the lock is there to prevent.
         assert stub.stopped_with is None
@@ -99,7 +103,11 @@ class TestTeardownOwnedElsewhere:
 
         assert stub.stopped_with == stub._WINDOWS_SHUTDOWN_BUDGET
         assert stub._shutting_down is True
-        assert evt.skipped
+        # Deliberately NOT skipped: Skip() resumes the handler search and
+        # reaches wxApp::OnEndSession (DeleteAllTLWs/OnExit/exit()), spending a
+        # Windows budget this teardown has already used. See
+        # tests/test_windows_shutdown_handlers.py.
+        assert evt.skipped is False
 
 
 class TestUnstickTimer:

--- a/tests/test_wedged_initializing_session.py
+++ b/tests/test_wedged_initializing_session.py
@@ -1,0 +1,251 @@
+"""A failed session start must never be able to wedge the account offline.
+
+Measured on a real install on 2026-09-09, and the account was offline in
+silence for the rest of the launch:
+
+    09:49:38  QR for a paired install -> _recover_suspect_profile() starts;
+              close-session, then wait_for_profile_release() for up to 20 s
+    09:49:52  the 30 s health poll reads CLOSED and fires its own
+              /start-session into a profile Chrome is still holding
+    09:49:54  Error: The browser is already running for ...userDataDir\\47d16ae...
+    09:49:58  Python kills the ten Chrome processes holding the lock
+    09:49:59  profile restored from the snapshot -- the same bytes that had
+              connected fine eight hours earlier
+    09:50:22  status-session INITIALIZING ... and every 30 s after that,
+              forever, with no chrome.exe in existence
+
+The restore worked. Nothing could start a session on it. Confirmed live
+against the still-running server: status-session answered INITIALIZING and
+POST /start-session answered HTTP 200 while launching no browser at all.
+
+Two independent faults, either one enough on its own, so both are pinned here:
+
+* createSessionUtil()'s catch reset the status to CLOSED only for a
+  TimeoutError. "The browser is already running" is a plain Error, so the
+  status stayed INITIALIZING -- and INITIALIZING is terminal on both sides:
+  createSessionUtil() returns early for any status but CLOSED, and
+  check_wa_connection_http() skips /start-session for every "active" state.
+* _recover_suspect_profile() owns the browser and the profile for the whole
+  close/kill/restore cycle and said so to nobody, so the health poll raced it.
+  _recovery_restart_active is the flag that exists for exactly this.
+
+The TypeScript only compiles inside client/api/, which does not exist in the
+test job, so the Node half is asserted against the patched source the way
+tests/test_stale_browser_lock_recovery.py does for the same file.
+"""
+
+import re
+import types
+from pathlib import Path
+
+import pytest
+
+import connection_state as cs
+from main import MainWindow
+
+
+PATCHED_UTIL = (
+    Path(__file__).resolve().parents[1]
+    / "client" / "api_patches" / "src" / "util" / "createSessionUtil.ts"
+)
+
+
+@pytest.fixture(scope="module")
+def source():
+    return PATCHED_UTIL.read_text(encoding="utf-8")
+
+
+def _strip_comments(text):
+    """Comments explain the very failures these assertions look for, so they
+    would satisfy a substring check on their own."""
+    return "\n".join(line for line in text.splitlines()
+                     if not line.lstrip().startswith("//"))
+
+
+def _catch_block(source):
+    """createSessionUtil()'s own trailing catch, sliced out by structure rather
+    than by a quoted copy of its body -- a copy would keep passing after the
+    real one was narrowed back to TimeoutError."""
+    start = source.index("  async createSessionUtil(")
+    end = source.index("  async opendata(", start)
+    body = source[start:end]
+    catch = body.rindex("} catch (e) {")
+    return _strip_comments(body[catch:])
+
+
+class TestAFailedStartLeavesTheSessionStartable:
+    def test_the_reset_is_no_longer_limited_to_a_timeout(self, source):
+        """The exact error that wedged the reporting install was
+        `Error: The browser is already running for <userDataDir>` -- name
+        'Error', not 'TimeoutError'. Gating the reset on the error type means
+        every other way create() can fail is permanent."""
+        catch = _catch_block(source)
+        assert "TimeoutError" not in catch, (
+            "the status reset is gated on the error type again; a start that "
+            "fails any other way leaves the session INITIALIZING forever"
+        )
+        assert re.search(r"\.status\s*=\s*'CLOSED'", catch), (
+            "nothing in the catch resets the status, so a failed start is "
+            "terminal for the whole account"
+        )
+
+    def test_it_only_touches_this_attempts_own_client(self, source):
+        """A create() superseded by a newer one must never write CLOSED over
+        the successor's status: the next /start-session would then launch a
+        duplicate Chrome onto a profile a live session is using. That is the
+        same failure killBrowserOrFallback() refuses the userDataDir scan for,
+        and it cost a working session on 2026-09-08."""
+        catch = _catch_block(source)
+        assert "clientsArray[session] === failed" in catch, (
+            "the catch no longer checks that the slot still holds this "
+            "attempt's client"
+        )
+
+    def test_it_only_rewrites_a_status_nothing_else_promoted(self, source):
+        """The try covers everything past this.start() too -- the webhook
+        wirings. A throw from one of those comes from a session that already
+        reached a real state, and reporting it CLOSED hands it the same
+        duplicate launch."""
+        catch = _catch_block(source)
+        assert "failed.status === 'INITIALIZING'" in catch
+
+    def test_the_client_is_captured_where_ownership_is_taken(self, source):
+        """`client` is declared inside the try and is out of scope in the
+        catch, which is why the old code had to re-resolve it through
+        getClient() -- and why it could not tell a superseded attempt apart.
+        The capture has to happen after the CLOSED guard, or it names a client
+        this attempt never owned."""
+        start = source.index("  async createSessionUtil(")
+        body = source[start:source.index("  async opendata(", start)]
+        assert body.index("ownClient = client") > body.index(
+            "if (client.status != null && client.status !== 'CLOSED')")
+        assert body.index("ownClient = client") < body.index(
+            "client.status = 'INITIALIZING'")
+
+    def test_the_silent_early_return_is_logged(self, source):
+        """startSession() answers HTTP 200 either way, so WinZapp logged
+        'Sent auto-start session command' every 30 s for a session no code path
+        was ever going to start. The silence is most of why this took a live
+        probe to find."""
+        start = source.index("  async createSessionUtil(")
+        body = source[start:source.index("  async opendata(", start)]
+        guard = body[:body.index("client.status = 'INITIALIZING'")]
+        assert "start-session ignored" in guard
+
+
+class _MetadataDB:
+    def __init__(self):
+        self.values = {}
+
+    def get_metadata_json(self, key, default=None):
+        return self.values.get(key, default)
+
+    def set_metadata_json(self, key, value):
+        self.values[key] = value
+
+
+class _SyncThread:
+    """Runs the restore body on .start(), so a test can observe the flag both
+    during the cycle (recorded from inside) and after it."""
+
+    def __init__(self, target=None, daemon=None):
+        self._target = target
+
+    def start(self):
+        self._target()
+
+
+class _Stub:
+    """Carries only what _recover_suspect_profile() actually touches."""
+
+    def __init__(self):
+        self.settings = {"privateinfo": {"paired": True}}
+        self.token = "sess123:tok"
+        self.global_dir = "/g"
+        self.wpp_server = "http://127.0.0.1"
+        self.wpp_port = 6300
+        self.audits = []
+        self.announced = []
+        self.db = _MetadataDB()
+        self.error_sound = types.SimpleNamespace(play=lambda: None)
+        self.i18n = types.SimpleNamespace(t=lambda key: key)
+        self._recovery_restart_active = False
+        self.flag_while_waiting = None
+
+    _PROFILE_RECOVERY_GENERATION_KEY = MainWindow._PROFILE_RECOVERY_GENERATION_KEY
+    _profile_recovery_generation = MainWindow._profile_recovery_generation
+    _set_profile_recovery_generation = MainWindow._set_profile_recovery_generation
+
+    def _shutdown_audit(self, msg):
+        self.audits.append(msg)
+
+    def output(self, text, interrupt=False):
+        self.announced.append(text)
+
+    def wait_for_profile_release(self, session_name, timeout=None):
+        # The 20 s window the health poll landed in on the reporting install.
+        self.flag_while_waiting = self._recovery_restart_active
+        return True
+
+    def _announce_profile_restored(self):
+        MainWindow._announce_profile_restored(self)
+
+    def _announce_profile_beyond_repair(self):
+        MainWindow._announce_profile_beyond_repair(self)
+
+
+@pytest.fixture
+def stub(monkeypatch):
+    s = _Stub()
+    monkeypatch.setattr("main.threading.Thread", _SyncThread)
+    monkeypatch.setattr("main.wx.CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+    monkeypatch.setattr("main.api_post", lambda *a, **kw: None)
+    monkeypatch.setattr("core.profile_recovery.has_snapshot", lambda *a, **kw: True)
+    return s
+
+
+class TestTheRestoreOwnsTheBrowserWhileItRuns:
+    def test_the_health_poll_is_blocked_for_the_whole_cycle(self, stub, monkeypatch):
+        monkeypatch.setattr("core.profile_recovery.restore_snapshot",
+                            lambda *a, **kw: True)
+        assert MainWindow._recover_suspect_profile(stub) is True
+        assert stub.flag_while_waiting is True, (
+            "the profile restore ran without claiming the browser, so a "
+            "competing /start-session can fire into a still-locked profile"
+        )
+
+    def test_the_flag_is_the_one_the_health_check_consults(self, stub, monkeypatch):
+        """Pinned against connection_state rather than restated: a flag nothing
+        reads would satisfy the test above and change nothing."""
+        monkeypatch.setattr("core.profile_recovery.restore_snapshot",
+                            lambda *a, **kw: True)
+        MainWindow._recover_suspect_profile(stub)
+        assert cs.auto_start_block_reason(
+            pairing_dialog_active=False, qr_flood_halted=False,
+            recovery_restart_active=True, self_inflicted_teardown=False,
+        ) == cs.AUTO_START_BLOCKED_RECOVERY_RESTART
+
+    def test_it_is_released_once_the_profile_is_back(self, stub, monkeypatch):
+        """Held any longer and the very poll that should start a session on the
+        restored profile is the one being blocked."""
+        monkeypatch.setattr("core.profile_recovery.restore_snapshot",
+                            lambda *a, **kw: True)
+        MainWindow._recover_suspect_profile(stub)
+        assert stub._recovery_restart_active is False
+
+    def test_a_restore_that_fails_releases_it_too(self, stub, monkeypatch):
+        monkeypatch.setattr("core.profile_recovery.restore_snapshot",
+                            lambda *a, **kw: False)
+        MainWindow._recover_suspect_profile(stub)
+        assert stub._recovery_restart_active is False
+
+    def test_a_restore_that_raises_releases_it_too(self, stub, monkeypatch):
+        """A flag nobody clears blocks every auto-start for the life of the
+        process -- strictly worse than the race it guards against."""
+        def boom(*a, **kw):
+            raise RuntimeError("disk went away")
+
+        monkeypatch.setattr("core.profile_recovery.restore_snapshot", boom)
+        MainWindow._recover_suspect_profile(stub)
+        assert stub._recovery_restart_active is False
+        assert "profile_corrupted_repair_needed" in stub.announced

--- a/tests/test_windows_shutdown_handlers.py
+++ b/tests/test_windows_shutdown_handlers.py
@@ -1,0 +1,174 @@
+"""WinZapp must not answer "no" when Windows asks to shut down.
+
+Diagnosed on 2026-09-09, after an overnight PC shutdown came back with a
+profile WhatsApp Web refused. `shutdown_audit.log` covering 159 launches
+carried seventeen runs that ended with no teardown line at all -- eleven of
+them overnight gaps of 7-12 h, exactly the shape of Windows ending the session
+with WinZapp open -- and **not one line from either shutdown handler**, though
+both audit as their first statement.
+
+Two faults, and the second is the damaging one:
+
+* wxMSW routes WM_QUERYENDSESSION and WM_ENDSESSION to `wxTheApp` and to
+  nothing else (`wxWindowMSW::HandleQueryEndSession` /`HandleEndSession` both
+  end in `wxTheApp->SafelyProcessEvent(event)`), and a wxCloseEvent is not a
+  command event, so it never propagates to a frame. Bound on the MainWindow,
+  as they were, the handlers could not run. Confirmed live by sending
+  WM_QUERYENDSESSION to the running app's own window: delivered, no audit line.
+* So wxApp's own static table entry ran instead, and it is this:
+
+      void wxApp::OnQueryEndSession(wxCloseEvent& event)
+      {
+          if (GetTopWindow())
+              if (!GetTopWindow()->Close(!event.CanVeto()))
+                  event.Veto(true);
+      }
+
+  `Close()` fires EVT_CLOSE on the main window, which is `_on_close()` -- and
+  `_on_close()` hides to the tray and **vetoes**, correctly, because that is
+  what the X button should do. The veto reached Windows: WinZapp refused every
+  shutdown. Measured against the live app, which answered 0 to
+  WM_QUERYENDSESSION. Windows blocks on that, then terminates the process on
+  the way past its own timeout -- no WM_ENDSESSION, no teardown, node.exe and
+  Chrome killed mid-write, and the profile comes back rejected.
+
+These tests drive the real wx dispatch rather than restating it, because every
+step above is wx behaviour rather than WinZapp behaviour, and the whole bug was
+a wrong belief about where wx sends an event.
+"""
+
+import ast
+import inspect
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+import wx
+
+from main import MainWindow
+from tests.conftest import hidden_frame
+
+
+MAIN_PY = Path(__file__).resolve().parents[1] / "client" / "main.py"
+
+
+def _query_event():
+    event = wx.CloseEvent(wx.wxEVT_QUERY_END_SESSION, wx.ID_ANY)
+    # Exactly what HandleQueryEndSession() sets before dispatching.
+    event.SetCanVeto(True)
+    return event
+
+
+@pytest.fixture
+def tray_style_app(wx_app):
+    """A top window that vetoes its close event, like MainWindow does while the
+    tray icon is up -- and a clean app afterwards, since wx_app is shared by the
+    whole run."""
+    frame = hidden_frame()
+    frame.Bind(wx.EVT_CLOSE, lambda e: e.Veto())
+    previous = wx_app.GetTopWindow()
+    wx_app.SetTopWindow(frame)
+    try:
+        yield wx_app, frame
+    finally:
+        wx_app.SetTopWindow(previous)
+        frame.Destroy()
+
+
+class TestTheBugThisReplaces:
+    def test_with_nothing_bound_on_the_app_winzapp_vetoes_the_shutdown(
+            self, tray_style_app):
+        """The shipped behaviour until 2026-09-09, reproduced end to end: the
+        frame-bound handlers never see the event, wxApp's default closes the top
+        window, the tray close handler vetoes, and the veto is what Windows is
+        told. A veto here is a process Windows kills instead of one it lets
+        finish."""
+        app, _frame = tray_style_app
+        event = _query_event()
+        app.SafelyProcessEvent(event)
+        assert event.GetVeto() is True
+
+    def test_binding_on_the_frame_does_not_help(self, tray_style_app):
+        """Why the fix is a different Bind target and not a different handler
+        body: the event is dispatched to the app, and a wxCloseEvent does not
+        propagate to windows."""
+        app, frame = tray_style_app
+        ran = []
+        frame.Bind(wx.EVT_QUERY_END_SESSION, lambda e: ran.append(1))
+        event = _query_event()
+        app.SafelyProcessEvent(event)
+        assert ran == [], "a frame-bound EVT_QUERY_END_SESSION handler ran"
+        assert event.GetVeto() is True
+
+
+class TestTheFix:
+    def test_a_handler_bound_on_the_app_runs_and_allows_the_shutdown(
+            self, tray_style_app):
+        app, _frame = tray_style_app
+        ran = []
+        handler = lambda e: ran.append(1)          # noqa: E731 - mirrors the real shape
+        app.Bind(wx.EVT_QUERY_END_SESSION, handler)
+        try:
+            event = _query_event()
+            app.SafelyProcessEvent(event)
+        finally:
+            app.Unbind(wx.EVT_QUERY_END_SESSION, handler=handler)
+        assert ran == [1]
+        assert event.GetVeto() is False, (
+            "the shutdown is still vetoed, so Windows will kill the process "
+            "instead of letting the teardown flush the profile"
+        )
+
+    def test_skipping_puts_the_veto_straight_back(self, tray_style_app):
+        """The one detail that makes the fix fragile, pinned so it cannot be
+        'tidied' back in: a dynamic Bind is searched before the class's static
+        event table, so binding on the app replaces wxApp::OnQueryEndSession --
+        but event.Skip() resumes the search and reaches it anyway."""
+        app, _frame = tray_style_app
+        handler = lambda e: e.Skip()               # noqa: E731
+        app.Bind(wx.EVT_QUERY_END_SESSION, handler)
+        try:
+            event = _query_event()
+            app.SafelyProcessEvent(event)
+        finally:
+            app.Unbind(wx.EVT_QUERY_END_SESSION, handler=handler)
+        assert event.GetVeto() is True
+
+
+class TestWinZappBindsAndAnswersTheRightWay:
+    """Structural, because the real binding happens inside MainWindow's UI
+    construction, which needs the whole app to stand up."""
+
+    def test_the_handlers_are_bound_on_the_app(self):
+        source = MAIN_PY.read_text(encoding="utf-8")
+        for evt in ("EVT_QUERY_END_SESSION", "EVT_END_SESSION"):
+            assert re.search(
+                r"_app\.Bind\(wx\.%s," % evt, source), (
+                f"{evt} is not bound on the wx.App; wxMSW dispatches it to "
+                f"wxTheApp and nowhere else, so a frame binding never runs"
+            )
+            assert not re.search(r"self\.Bind\(wx\.%s," % evt, source), (
+                f"{evt} is bound on the frame again — that binding is dead, "
+                f"and wxApp's default vetoes the shutdown in its place"
+            )
+
+    @pytest.mark.parametrize(
+        "method", [MainWindow._on_query_end_session, MainWindow._on_end_session],
+        ids=["_on_query_end_session", "_on_end_session"])
+    def test_neither_handler_skips(self, method):
+        """Skipping reaches wxApp's defaults: the veto for the query, and
+        DeleteAllTLWs()/OnExit()/exit() for the end — the second one spending a
+        budget the teardown has already used, in a process Windows terminates
+        the moment the handler returns."""
+        tree = ast.parse(textwrap.dedent(inspect.getsource(method)))
+        skips = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "Skip"
+        ]
+        assert skips == [], (
+            f"{method.__name__} calls Skip(), which resumes the handler search "
+            f"and reaches wxApp's own default"
+        )


### PR DESCRIPTION
Duas causas independentes por trás das perdas de sessão de 08–09/09. A primeira explica **por que o perfil quebra**; a segunda explica **por que o app não se recupera depois**.

---

## 1. O WinZapp recusava TODO desligamento do Windows

Não é corrida — acontecia em todo shutdown.

O `shutdown_audit.log` de 159 launches tem dezessete execuções que terminaram **sem nenhuma linha de teardown**, onze delas buracos noturnos de 7–12h, e **nenhuma linha dos dois handlers de shutdown**, embora ambos auditem como primeira instrução.

**Falha A.** O wxMSW entrega `WM_QUERYENDSESSION`/`WM_ENDSESSION` ao `wxTheApp` e a mais nada — `wxWindowMSW::HandleQueryEndSession()` e `HandleEndSession()` terminam ambos em `wxTheApp->SafelyProcessEvent(event)` — e um `wxCloseEvent` não é command event, então nunca propaga para um frame. Ligados no `MainWindow`, como estavam, os handlers **não tinham como rodar**. Confirmado ao vivo: mandei `WM_QUERYENDSESSION` para a janela do app em execução — entregue, nenhuma linha de auditoria.

**Falha B, a que causa o dano.** No lugar deles rodava a entrada da tabela estática do próprio wxApp (`src/msw/app.cpp`):

```cpp
void wxApp::OnQueryEndSession(wxCloseEvent& event)
{
    if (GetTopWindow())
        if (!GetTopWindow()->Close(!event.CanVeto()))
            event.Veto(true);
}
```

`Close()` dispara `EVT_CLOSE` na janela principal, que é o `_on_close()` — e o `_on_close()` esconde na bandeja e **veta**, corretamente, porque é isso que o X deve fazer. **O veto era o que chegava no Windows.** Medido contra o app rodando: ele respondia `0` ao `WM_QUERYENDSESSION`, uma recusa. O Windows trava nisso, mostra a tela de "app impedindo o desligamento" e mata o processo ao passar do próprio timeout — sem `WM_ENDSESSION`, sem teardown. O node.exe e o Chrome morrem no meio da escrita e o perfil volta como um que o WhatsApp Web recusa.

**Correção:** ambos passam a ser ligados no `wx.App`. Um `Bind` dinâmico é pesquisado antes da tabela estática da classe, então isso *substitui* o default do wxApp em vez de somar a ele — e nenhum dos dois handlers pode chamar `event.Skip()`, porque skip retoma a busca e alcança o default assim mesmo. Essa é a parte frágil, e tem teste próprio.

---

## 2. Um start que falha travava a conta offline para sempre

Reportado ao vivo em 09/09: o app avisou que o perfil estava danificado, restaurou, e **parou ali** — offline, sem mensagem de logout, sem nova tentativa.

**A restauração não falhou.** O perfil que ela colocou de volta é byte-a-byte idêntico ao que conectou normalmente oito horas antes. O que falhou é que nada mais conseguia iniciar uma sessão em cima dele:

```
09:49:38  QR num install pareado -> _recover_suspect_profile() começa
09:49:52  o poll de saúde (30s) lê CLOSED e dispara o próprio /start-session
          contra um perfil que o Chrome ainda segura
09:49:54  Error: The browser is already running for ...userDataDir\47d16ae
09:49:59  profile restored from snapshot
09:50:22  status-session INITIALIZING ... de 30 em 30s, até o fim do log
```

Confirmado contra o servidor ainda rodando: `status-session` respondia `INITIALIZING` **sem nenhum chrome.exe existindo**, e `POST /start-session` respondia HTTP 200 sem lançar navegador nenhum.

`createSessionUtil()` devolvia o status para `CLOSED` **só** em `TimeoutError`. `The browser is already running` é um `Error` comum — e `INITIALIZING` é terminal dos dois lados: o Node retorna cedo para qualquer status ≠ CLOSED, e `check_wa_connection_http()` pula `/start-session` para todo estado "ativo".

Agora reseta em qualquer falha, com duas condições que carregam peso: o slot precisa ainda conter o client **desta** tentativa (um `create()` superado nunca pode escrever CLOSED por cima do sucessor — custou uma sessão boa em 08/09), e o status precisa ainda ser `INITIALIZING` (o `try` cobre também os wirings de webhook depois de `this.start()`). O retorno silencioso do topo agora é logado.

Além disso, `_recover_suspect_profile()` passa a assumir `_recovery_restart_active` durante todo o ciclo close/kill/restore — a flag que existe exatamente para isso e que o poll consulta antes de auto-iniciar. Liberada num `finally`.

---

## Testes

- `tests/test_windows_shutdown_handlers.py` — 7 testes que dirigem o **dispatch real do wx**, incluindo reproduzir o veto de ponta a ponta, porque cada passo é comportamento do wx e o bug era uma crença errada sobre para onde o wx manda o evento.
- `tests/test_wedged_initializing_session.py` — 10 testes; a metade Node é fixada contra o source em `client/api_patches/` (o TS só compila dentro de `client/api/`, ausente no job de teste), no estilo de `test_stale_browser_lock_recovery.py`.
- As quatro asserções `event.skipped is True` nos testes de end-session existentes fixavam o comportamento *deste bug*; agora afirmam o contrário, com o motivo inline.

Suíte completa: **6388 passed, 66 skipped**. `client/api` recompilado sem erro de tipo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)