### PR TITLE
The transfer gauge must not outlive its transfer, or belong to another row

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -25697,7 +25697,8 @@ class MainWindow(wx.Frame):
 
     def on_media_download_progress(self, progress_id: str, progress: float):
         """Server-side CDN download progress, keyed by the id we sent with the
-        request. See _media_progress_id() for why the client picks that id."""
+        request — the message's own `key.id` (see the `progressId` the
+        get-media request carries), which is what the panel matches rows by."""
         if hasattr(self, "conversations_panel"):
             self.conversations_panel.update_message_download_progress(
                 progress_id, progress)

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -4722,10 +4722,13 @@ class ConversationsPanel(wx.Panel):
         self._action_save_as_btn.Hide()
         self._action_download_btn.Hide()
         self._hide_media_transfer_gauge()
-        # The transfer gauge is not a selection-specific media control.  Hiding
-        # it here made an in-flight upload/download disappear whenever focus or
-        # message selection changed.  Transfer completion / conversation exit
-        # owns its lifetime instead.
+        # The gauge IS selection-scoped, and the comment that used to sit here
+        # said the opposite while this very call contradicted it. One gauge
+        # serves every transfer, so the only reading of it that means anything
+        # is "the row you are on". Moving off hides it here; a transfer still
+        # running on the row you move back to re-shows it on its next progress
+        # tick, and _sync_pending_document_gauge() restores a pending upload
+        # when the conversation is (re)opened. See _transfer_owns_gauge().
         self._buttons_container.Hide()
         self._contact_converse_btn.Hide()
         self._contact_save_btn.Hide()
@@ -9977,7 +9980,11 @@ class ConversationsPanel(wx.Panel):
         if progress <= self._download_progress.get(msg_id, 0.0):
             return
         self._download_progress[msg_id] = progress
-        self._update_media_transfer_gauge(progress)
+        # The row always repaints — its own text carries the percentage, and it
+        # is unambiguous about which message it belongs to. The shared gauge
+        # only moves for the row the user is actually standing on.
+        if self._transfer_owns_gauge(msg_id):
+            self._update_media_transfer_gauge(progress)
         for i, msg in enumerate(self._sorted_messages):
             if msg.get("key", {}).get("id") == msg_id:
                 self.messages_list.SetItemText(i, self._render_message_line(msg))
@@ -10026,7 +10033,8 @@ class ConversationsPanel(wx.Panel):
         for index, msg in enumerate(self._sorted_messages):
             if msg.get("_local_id") != upload_id:
                 continue
-            self._update_media_transfer_gauge(progress)
+            if self._transfer_owns_gauge(upload_id):
+                self._update_media_transfer_gauge(progress)
             self.messages_list.SetItemText(index, self._render_message_line(msg))
             # wx.ListCtrl provides RefreshItem(), but the accessibility
             # fallback is a native wx.ListBox and only supports Refresh().
@@ -10087,9 +10095,58 @@ class ConversationsPanel(wx.Panel):
         self._media_action_slot.Show()
         self.conversation_panel.Layout()
 
+    def _transfer_owns_gauge(self, transfer_id: str) -> bool:
+        """Whether this transfer's progress may drive the shared gauge.
+
+        There is one gauge and any number of transfers. Nothing used to check
+        which of them was writing to it, so a background download three
+        conversations away moved the bar of whatever row the user was standing
+        on, and two concurrent transfers drove the same widget to two different
+        values — reported as bars "going up and down on top of each other".
+
+        Selection already scopes the gauge in every other direction:
+        on_message_selected() hides it through _hide_all_media_controls(), and
+        _sync_pending_document_gauge() restores "only the selected active
+        transfer". Updating it from anywhere was the odd one out.
+
+        Downloads are keyed by the WhatsApp message id and uploads by the
+        virtual `_local_id`, so both are accepted here — a row can only be one
+        of the two.
+        """
+        if not transfer_id:
+            return False
+        # Both real controls have it (CompatListBoxMessagesCtrl maps it onto
+        # GetSelection), but this runs inside a wx.CallAfter, and an
+        # AttributeError raised there is exactly how upload progress died once
+        # before — see tests/test_compat_listbox_refresh_item.py. Not knowing
+        # which row is focused means leaving the gauge alone, which is the safe
+        # direction: every symptom here is a bar that should not be on screen.
+        focused = getattr(self.messages_list, "GetFocusedItem", None)
+        if focused is None:
+            return False
+        index = focused()
+        if index < 0 or index >= len(self._sorted_messages):
+            return False
+        msg = self._sorted_messages[index]
+        if self._is_separator(msg):
+            return False
+        return transfer_id in (msg.get("key", {}).get("id", ""),
+                               msg.get("_local_id", ""))
+
     def _update_media_transfer_gauge(self, progress: float):
         gauge = getattr(self, "_media_transfer_gauge", None)
         if gauge is None:
+            return
+        if progress >= 1.0:
+            # A finished transfer has nothing left to report, and a bar parked
+            # at 100% is worse than no bar: it stays in the Tab order after the
+            # message list, where the user meets it long after the download it
+            # described is over, with no way to tell what it belongs to. This
+            # is the state the app got stuck in most often — MainWindow's bulk
+            # media sync calls update_message_download_progress(msg_id, 1.0)
+            # purely to repaint a row, and that call used to *show* the gauge
+            # at 100% and leave it there for the rest of the conversation.
+            self._hide_media_transfer_gauge()
             return
         gauge.SetValue(max(0, min(100, round(progress * 100))))
         if not gauge.IsShown():

--- a/tests/test_transfer_gauge_is_not_left_on_screen.py
+++ b/tests/test_transfer_gauge_is_not_left_on_screen.py
@@ -1,0 +1,177 @@
+"""The media transfer gauge must not outlive the transfer, or belong to a
+message the user is not on.
+
+Reported from real use: a progress bar sitting at 100% in the Tab order after
+the message list, met most often just after sending a plain text message, and
+sometimes two of them "going up and down on top of each other".
+
+There is only one gauge, and both halves of the complaint come from that:
+
+* **Parked at 100%.** Nothing hid it when a transfer finished.
+  `MainWindow._download_media_for_sync()` calls
+  `update_message_download_progress(msg_id, 1.0)` purely to repaint a row after
+  a bulk background download that ran with no progress callbacks at all — and
+  that call *showed* the gauge at 100% and left it there for the rest of the
+  conversation. Hence "random moments": it is background media sync, not
+  anything the user did. Sending a text is simply when they meet it, because
+  the send puts focus back in the message field and the next Tab walks into it.
+* **Two bars.** Any transfer wrote to the one gauge, including downloads for
+  messages in other conversations, so two concurrent ones drove the same widget
+  to two different values.
+
+Selection already scoped the gauge in every other direction — on_message_selected()
+hides it via _hide_all_media_controls(), and _sync_pending_document_gauge()
+restores "only the selected active transfer". Updating it from anywhere was the
+odd one out.
+
+The panel is a wx.Panel and cannot be instantiated without a running wx.App, so
+its methods are bound onto a stub carrying only what they touch.
+"""
+
+import pytest
+
+from ui.conversations import ConversationsPanel
+
+
+class _ListStub:
+    """Enough wx.ListCtrl surface for the two progress methods."""
+
+    def __init__(self, focused=0):
+        self._focused = focused
+        self.texts = {}
+        self.refreshed = []
+
+    def GetFocusedItem(self):
+        return self._focused
+
+    def GetFirstSelected(self):
+        return self._focused
+
+    def SetItemText(self, index, text):
+        self.texts[index] = text
+
+    def RefreshItem(self, index):
+        self.refreshed.append(index)
+
+
+class _Gauge:
+    def __init__(self):
+        self.value = None
+        self.shown = False
+
+    def SetValue(self, value):
+        self.value = value
+
+    def IsShown(self):
+        return self.shown
+
+    def Show(self):
+        self.shown = True
+
+    def Hide(self):
+        self.shown = False
+
+
+def _panel(messages, focused=0):
+    panel = ConversationsPanel.__new__(ConversationsPanel)
+    panel._sorted_messages = messages
+    panel.messages_list = _ListStub(focused)
+    panel._download_progress = {}
+    panel._media_upload_progress = {}
+    panel._upload_stages_seen = {}
+    panel._media_transfer_started = set()
+    panel._media_transfer_gauge = _Gauge()
+    panel._render_message_line = lambda msg: "rendered"
+    panel._is_separator = lambda msg: bool(msg.get("_separator"))
+    # The two layout collaborators the real helpers reach for.
+    panel._media_action_slot = type("_Slot", (), {"Show": lambda self: None})()
+    panel.conversation_panel = type("_Conv", (), {"Layout": lambda self: None})()
+    panel._sync_media_action_slot_visibility = lambda: None
+    return panel
+
+
+def _download(msg_id, **extra):
+    return {"key": {"id": msg_id}, **extra}
+
+
+class TestAFinishedTransferTakesItsBarWithIt:
+    def test_reaching_100_percent_hides_the_gauge(self):
+        panel = _panel([_download("m1")])
+        ConversationsPanel.update_message_download_progress(panel, "m1", 1.0)
+        assert panel._media_transfer_gauge.shown is False
+
+    def test_the_bulk_sync_row_repaint_does_not_raise_a_bar(self):
+        """MainWindow._download_media_for_sync() calls this with a flat 1.0 to
+        repaint a row after a download that reported no progress at all. It is
+        the commonest source of the stuck bar."""
+        panel = _panel([_download("m1")])
+        ConversationsPanel.update_message_download_progress(panel, "m1", 1.0)
+        assert panel._media_transfer_gauge.shown is False
+        assert panel.messages_list.texts == {0: "rendered"}, (
+            "the row must still repaint — that is all this call ever wanted"
+        )
+
+    def test_a_transfer_still_running_keeps_its_bar(self):
+        panel = _panel([_download("m1")])
+        ConversationsPanel.update_message_download_progress(panel, "m1", 0.4)
+        assert panel._media_transfer_gauge.shown is True
+        assert panel._media_transfer_gauge.value == 40
+
+    def test_a_finished_upload_pinned_at_100_does_not_come_back(self):
+        """_mark_message_sent() pins an upload at 1.0 when the send succeeded
+        but its real id was unparseable, and leaves the row pending on purpose.
+        _sync_pending_document_gauge() then replayed that 1.0 every time the
+        row was selected."""
+        panel = _panel([{"_local_id": "u1", "_local_pending": True}])
+        panel._media_upload_progress["u1"] = 1.0
+        panel._media_transfer_started.add("u1")
+        ConversationsPanel._sync_pending_document_gauge(panel)
+        assert panel._media_transfer_gauge.shown is False
+
+
+class TestTheBarBelongsToTheRowTheUserIsOn:
+    def test_a_download_for_another_message_does_not_move_it(self):
+        panel = _panel([_download("focused"), _download("elsewhere")], focused=0)
+        ConversationsPanel.update_message_download_progress(panel, "elsewhere", 0.5)
+        assert panel._media_transfer_gauge.shown is False
+        assert panel._media_transfer_gauge.value is None
+
+    def test_that_download_still_repaints_its_own_row(self):
+        """The row text carries the percentage and is unambiguous about which
+        message it belongs to, so it is never the part that has to be scoped."""
+        panel = _panel([_download("focused"), _download("elsewhere")], focused=0)
+        ConversationsPanel.update_message_download_progress(panel, "elsewhere", 0.5)
+        assert panel.messages_list.texts == {1: "rendered"}
+
+    def test_an_upload_for_another_row_does_not_move_it(self):
+        panel = _panel(
+            [{"_local_id": "focused"}, {"_local_id": "elsewhere"}], focused=0)
+        ConversationsPanel.update_media_upload_progress(panel, "elsewhere", 0.5)
+        assert panel._media_transfer_gauge.shown is False
+
+    def test_the_focused_rows_own_upload_does_move_it(self):
+        panel = _panel([{"_local_id": "u1"}], focused=0)
+        ConversationsPanel.update_media_upload_progress(panel, "u1", 0.5)
+        assert panel._media_transfer_gauge.shown is True
+        assert panel._media_transfer_gauge.value == 50
+
+    @pytest.mark.parametrize("focused", [-1, 5])
+    def test_no_usable_focused_row_leaves_the_gauge_alone(self, focused):
+        panel = _panel([_download("m1")], focused=focused)
+        ConversationsPanel.update_message_download_progress(panel, "m1", 0.5)
+        assert panel._media_transfer_gauge.shown is False
+
+    def test_a_separator_row_never_owns_a_transfer(self):
+        panel = _panel([{"_separator": True, "key": {"id": "m1"}}], focused=0)
+        assert ConversationsPanel._transfer_owns_gauge(panel, "m1") is False
+
+    def test_a_control_without_GetFocusedItem_does_not_raise(self):
+        """This runs inside a wx.CallAfter, where an AttributeError killed
+        upload progress once already (tests/test_compat_listbox_refresh_item.py).
+        Not knowing which row is focused means leaving the gauge alone."""
+        panel = _panel([_download("m1")])
+        del panel.messages_list.__class__.GetFocusedItem
+        try:
+            assert ConversationsPanel._transfer_owns_gauge(panel, "m1") is False
+        finally:
+            _ListStub.GetFocusedItem = lambda self: self._focused


### PR DESCRIPTION
Barras de progresso irrelevantes aparecendo na conversa, depois da lista de mensagens no Tab.

## O que estava acontecendo

Existe **uma** barra só, e os dois sintomas relatados saem daí.

**Parada em 100%.** Nada escondia a barra quando a transferência acabava. O `MainWindow._download_media_for_sync()` chama `update_message_download_progress(msg_id, 1.0)` só para **repintar a linha** depois de um download em massa que rodou sem nenhum callback de progresso — e essa chamada *mostrava* a barra em 100% e a deixava lá pelo resto da conversa.

É isso que dá a impressão de "momentos aleatórios": é a sincronização de mídia em segundo plano, não algo que você fez. Enviar um texto é só **quando** você encontra a barra — o envio devolve o foco para o campo de mensagem, e o Tab seguinte cai nela.

Uma barra em 100% é pior que barra nenhuma: não informa nada, não tem como dizer a que mensagem pertence, e fica no caminho do teclado justamente do controle mais usado.

**Duas barras "subindo e descendo".** Qualquer transferência escrevia na barra única — inclusive downloads de mensagens em *outras* conversas — então duas simultâneas empurravam o mesmo widget para dois valores diferentes.

## Correção

A seleção já limitava a barra em todas as outras direções: `on_message_selected()` a esconde via `_hide_all_media_controls()`, e `_sync_pending_document_gauge()` restaura "apenas a transferência ativa selecionada". Atualizar de qualquer lugar era a peça fora do padrão.

- `_update_media_transfer_gauge()` esconde a barra ao chegar em 100% em vez de estacioná-la lá.
- `_transfer_owns_gauge()` passa a filtrar os dois atualizadores pela linha em foco — por id de mensagem nos downloads, por `_local_id` nos uploads. Ele degrada para "não mexe na barra" quando não dá para saber a linha em foco, que é a direção segura: todo sintoma aqui é uma barra que não devia estar na tela. Isso importa porque o código roda dentro de um `wx.CallAfter`, onde um `AttributeError` já matou o progresso de upload uma vez (`tests/test_compat_listbox_refresh_item.py`).
- As linhas continuam repintando incondicionalmente: o texto da linha carrega a porcentagem e diz sem ambiguidade a que mensagem pertence, então nunca foi a parte que precisava de escopo.

Isso também aposenta um estado preso: `_mark_message_sent()` fixa um upload em 1.0 quando o envio deu certo mas o id real veio ilegível, e deixa a linha pendente de propósito — então `_sync_pending_document_gauge()` reexibia esse 100% toda vez que a linha era selecionada.

## Dois comentários corrigidos de passagem

- `_hide_all_media_controls()` tinha um comentário dizendo que a barra **não** é específica da seleção, logo acima da chamada que a esconde a cada troca de seleção.
- `MainWindow.on_media_download_progress()` apontava para um `_media_progress_id()` que não existe em lugar nenhum da árvore.

## Testes

`tests/test_transfer_gauge_is_not_left_on_screen.py` — 12 testes, no padrão de stub com métodos desligados da classe (o painel é um `wx.Panel` e não instancia sem `wx.App`). Cobrem a barra sumindo em 100%, o repaint da sync em massa não levantando barra, a barra de outra linha não movendo a atual, a linha ainda repintando, o upload fixado em 100% não voltando, e o controle sem `GetFocusedItem` não estourando.

Suíte completa: **6401 passed, 66 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)