### PR TITLE
Recuperar as correcoes de revisao das PRs #156 e #157

### DIFF
--- a/client/core/profile_recovery.py
+++ b/client/core/profile_recovery.py
@@ -381,10 +381,26 @@ class ProfileHealthTracker:
     the device from their phone produces the same readings, and this will
     restore a snapshot whose credentials the server has already revoked. That
     costs one cycle — WhatsApp Web rejects it and asks to pair again, which is
-    where they were going anyway — and `_recover_suspect_profile()` runs at
-    most once per launch, so it cannot loop. Being wrong in that direction
-    costs a minute; being wrong in the other direction is what this class was
-    written for, and it cost a re-pairing.
+    where they were going anyway.
+
+    `_recover_suspect_profile()` latches, and only a session reporting
+    CONNECTED hands that latch back. Do not read that as "a revoked snapshot
+    can never restore twice", which is one step stronger than the code
+    actually guarantees: the re-arm in `_note_status_for_profile_health()`
+    reads the status *string* alone, and createSessionUtil.start() promotes a
+    session to CONNECTED off its own state listener without the live
+    isConnected() probe ever agreeing ("the event wins"). A revoked snapshot
+    that gets that far does hand the latch back — the same seam
+    websocket_client.py's `_REPAIR_DIALOG_CONFIRM_EVENTS` comment describes
+    for the QR-flood counter, which needs the probe to agree and so is *not*
+    given back by the same reading. The generation ladder does not close it
+    either: it has two rungs, and that CONNECTED resets it to the newest one.
+
+    So the real guarantee is a rate limit, not impossibility — the tracker has
+    to count FAILED_CYCLES_BEFORE_SUSPECT more failed start cycles, roughly a
+    minute each, before anything can be restored again. Being wrong in that
+    direction costs a minute; being wrong in the other direction is what this
+    class was written for, and it cost a re-pairing.
     """
 
     #: Consecutive failed start cycles before the profile is suspect.

--- a/client/core/profile_recovery.py
+++ b/client/core/profile_recovery.py
@@ -396,11 +396,16 @@ class ProfileHealthTracker:
     given back by the same reading. The generation ladder does not close it
     either: it has two rungs, and that CONNECTED resets it to the newest one.
 
-    So the real guarantee is a rate limit, not impossibility — the tracker has
-    to count FAILED_CYCLES_BEFORE_SUSPECT more failed start cycles, roughly a
-    minute each, before anything can be restored again. Being wrong in that
-    direction costs a minute; being wrong in the other direction is what this
-    class was written for, and it cost a re-pairing.
+    So the real guarantee is a rate limit, not impossibility — before
+    anything can be restored again, either the tracker counts
+    FAILED_CYCLES_BEFORE_SUSPECT more failed start cycles at roughly a minute
+    each, or a fresh flood of codes clears both of _handle_unattended_qr()'s
+    gates (past the startup grace, _REPAIR_DIALOG_CONFIRM_EVENTS consecutive
+    readings) while _auto_repair_dialog_shown is still False. The QR route is
+    the faster of the two and does not consult this tracker at all — that is
+    the seam the paragraph above describes, seen from the other side. Being
+    wrong in that direction costs a minute; being wrong in the other
+    direction is what this class was written for, and it cost a re-pairing.
     """
 
     #: Consecutive failed start cycles before the profile is suspect.

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -902,8 +902,9 @@ class WebSocketClient:
         NOT by _set_wa_connected(), which leaves _wa_connect_announced True
         and _wa_startup_time where it was. That is the right behaviour for
         this gate rather than a gap in it: once a connection has actually
-        been confirmed, the _wa_connect_announced check below returns False
-        on its own, so the clock under it no longer decides anything.
+        been confirmed, qr_within_startup_grace()'s own _wa_connect_announced
+        check returns False on its own, so the clock under it no longer
+        decides anything.
         """
         mw = self.main_window
         return qr_within_startup_grace(
@@ -1009,14 +1010,16 @@ class WebSocketClient:
             #
             # KNOWN GAP, inherited and not introduced here: "already spent"
             # also covers a restore still IN FLIGHT. _recover_suspect_profile()
-            # latches the moment it starts its thread, so the next code ~20-30s
-            # later is refused with False and lands right here, opening the
-            # pairing dialog on top of a restore_snapshot() that may still be
-            # writing into userDataDir/<session>. If the user pairs from that
-            # dialog, _reset_unattended_qr_guards() clears _qr_flood_halted and
+            # latches at the top of the method, before it has even looked for a
+            # snapshot, so the next code ~20-30s later is refused with False and
+            # lands right here, opening the pairing dialog on top of a
+            # restore_snapshot() that may still be writing into
+            # userDataDir/<session>. If the user pairs from that dialog,
+            # _reset_unattended_qr_guards() clears _qr_flood_halted and
             # /start-session launches Chrome over the directory being written —
-            # precisely what core/profile_recovery.py forbids ("restoring under
-            # a running browser manufactures the corruption it recovers from").
+            # precisely what core/profile_recovery.py forbids: restoring under a
+            # running browser is "manufacturing the exact corruption this
+            # recovers from".
             # Closing it means exposing a "restore in flight" state and holding
             # _show_repair_dialog() on it, which is a production change of its
             # own; see tests/test_qrcode_auto_repair_dialog.py::

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -861,9 +861,10 @@ class WebSocketClient:
 
         Reads exactly the pair check_wa_connection_http()'s own
         `within_grace` reads, so the two windows open and close together.
-        They are cleared as a pair by the three places that treat what
+        They are cleared as a pair by the four places that treat what
         follows as a fresh launch — MainWindow.__init__, _on_disconnect()
-        (main.py) and reset_state_for_resume() (connection_state.py) — and
+        (main.py), reset_state_for_resume() (connection_state.py) and
+        _reset_credentials_and_show_pairing() (this file) — and
         NOT by _set_wa_connected(), which leaves _wa_connect_announced True
         and _wa_startup_time where it was. That is the right behaviour for
         this gate rather than a gap in it: once a connection has actually
@@ -1009,13 +1010,19 @@ class WebSocketClient:
                 # it now has to do.
                 #
                 # play_sound=False because the halt has just played that very
-                # same error_sound object and spoken over it. Playing it again
-                # ~0 ms later does not read as two cues: sound_lib restarts
-                # the one stream, so the user hears a single truncated blip,
-                # and the halt's own line is cut mid-sentence by the
-                # MessageBox's focus announcement — which then says the same
-                # thing anyway. Same shape as the clipped speech the
-                # focus_cloak work was written for (see CLAUDE.md).
+                # same error_sound object. Replaying one stream ~0 ms later is
+                # not heard as two cues — sound_lib restarts it, so it comes
+                # out as a single truncated blip, the shape of clipped output
+                # the focus_cloak work was written for (see CLAUDE.md).
+                #
+                # It buys nothing either: the halt's spoken line is cut
+                # mid-sentence by the MessageBox's focus announcement no
+                # matter what this flag says (output(interrupt=False) queues,
+                # and the screen reader preempts on focus), and that
+                # announcement says the same thing. So the second sound has
+                # no cue left to carry. The MessageBox still raises its own
+                # MB_ICONERROR system sound, which is a different sound and
+                # not subject to that restart.
                 self._show_repair_dialog(play_sound=False)
                 return
             # Never paired: the branch above never ran because there is no
@@ -1045,8 +1052,7 @@ class WebSocketClient:
         reading still. That second route runs after the halt has already
         closed the session and announced it, which is what play_sound=False is
         for; see the call site. Either way, by the time this runs the signal
-        is at least
-        as solid as the coarse status-session string the health-check poll
+        is at least as solid as the coarse status-session string the poll
         watches (which needs several minutes of confirmation to rule out a
         normal slow boot). Surfacing the pairing dialog immediately —
         instead of leaving the user staring at "offline"

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -120,9 +120,9 @@ class WebSocketClient:
     # never paired. On one that did it is that dialog's lifetime plus ~1
     # minute: there the _REPAIR_DIALOG_CONFIRM_EVENTS'th unattended event
     # opens the re-pairing dialog, and codes are attended for as long as it
-    # stays up, so the three counted events only start once the user
-    # dismisses it. Short enough that an app left open overnight on a
-    # session WhatsApp already dropped does not ask for hundreds of codes
+    # stays up, so the _UNATTENDED_QR_LIMIT counted events only start once
+    # the user dismisses it. Short enough that an app left open overnight on
+    # a session WhatsApp already dropped does not ask for hundreds of codes
     # nobody will ever scan.
     _UNATTENDED_QR_LIMIT = 3
 
@@ -135,12 +135,24 @@ class WebSocketClient:
     # yet confirmed) on the SAME reading this dialog had already acted on
     # a QR event earlier for, seconds apart. Every other unlink-confirming
     # path in this codebase requires more than a single reading before
-    # doing anything user-visible or destructive; this one now does too,
-    # at the cost of the same ~20-30s (one more QR rotation) every other
-    # such confirmation already accepts as the price of not alarming or
-    # wiping a session that was only ever transiently unhappy. Still well
-    # under _UNATTENDED_QR_LIMIT, so the harsher close-session action is
-    # never reached before the dialog has already offered a way out.
+    # doing anything user-visible or destructive; this one now does too.
+    #
+    # What it buys is precisely that no single reading acts on its own —
+    # not a guaranteed wait. Nothing on the unattended path dedups by
+    # payload (the value check lives in _update_ui()'s `phone` refresh
+    # branch, which needs a dialog on screen), so two socket emissions
+    # carrying the SAME code satisfy this counter without any of WhatsApp's
+    # ~20-30s rotation having passed. In the steady-state flood this was
+    # written for the codes really are rotating and it does cost one
+    # rotation, the same price every other confirmation here accepts for
+    # not alarming a session that was only ever transiently unhappy; in a
+    # boot-time burst it costs almost nothing, which is why
+    # _qr_within_startup_grace() is a separate requirement rather than a
+    # stronger version of this one. Still under _UNATTENDED_QR_LIMIT
+    # either way, so the dialog is offered before the harsher close-session
+    # action — and _handle_unattended_qr() offers it after that action too,
+    # for the paired install a burst inside the grace window carried
+    # straight past this counter.
     _REPAIR_DIALOG_CONFIRM_EVENTS = 2
 
     def __init__(self, main_window, connect, instance_name):
@@ -834,9 +846,18 @@ class WebSocketClient:
         Nothing about a QR event makes it immune to the exact race the
         startup grace exists for elsewhere; it only looks immune because,
         unlike a bare status string, a code is often also genuinely
-        conclusive. Both _wa_startup_time and _wa_connect_announced are
-        reset together on every fresh (re)connect (see main.py), so this
-        re-arms correctly across reconnects, not just the first launch.
+        conclusive.
+
+        Reads exactly the pair check_wa_connection_http()'s own
+        `within_grace` reads, so the two windows open and close together.
+        They are cleared as a pair by the three places that treat what
+        follows as a fresh launch — MainWindow.__init__, _on_disconnect()
+        (main.py) and reset_state_for_resume() (connection_state.py) — and
+        NOT by _set_wa_connected(), which leaves _wa_connect_announced True
+        and _wa_startup_time where it was. That is the right behaviour for
+        this gate rather than a gap in it: once a connection has actually
+        been confirmed, the _wa_connect_announced check below returns False
+        on its own, so the clock under it no longer decides anything.
         """
         mw = self.main_window
         if getattr(mw, "_wa_connect_announced", False):
@@ -899,8 +920,9 @@ class WebSocketClient:
             return
         seen = getattr(mw, "_unattended_qr_events", 0) + 1
         mw._unattended_qr_events = seen
+        paired = bool(mw.settings.get("privateinfo", {}).get("paired"))
         if (
-            mw.settings.get("privateinfo", {}).get("paired")
+            paired
             and not getattr(mw, "_auto_repair_dialog_shown", False)
             and not self._qr_within_startup_grace()
             and seen >= self._REPAIR_DIALOG_CONFIRM_EVENTS
@@ -937,10 +959,11 @@ class WebSocketClient:
             self._show_repair_dialog()
             return
         if seen == self._UNATTENDED_QR_LIMIT:
-            # Never paired, or the dialog was already offered and is no longer
-            # up: nobody is going to scan these. Reached on the same event
-            # count either way, so the ceiling on codes requested from
-            # WhatsApp does not depend on which case we are in.
+            # Nobody is going to scan these, whichever case we are in. Reached
+            # on the same event count regardless — deliberately NOT delayed by
+            # the startup grace or the confirmation counter above, since the
+            # ceiling on codes requested from WhatsApp is the half of this
+            # protection an account was banned for not having.
             #
             # `==`, not `>=`: _halt_unattended_qr_session() latches, so asking
             # again on every later event changes nothing except filling the
@@ -954,20 +977,42 @@ class WebSocketClient:
                 "requesting codes from WhatsApp.", seen,
             )
             mw._halt_unattended_qr_session()
-            if not getattr(mw, "_auto_repair_dialog_shown", False):
-                # Never paired: the branch above never ran, so nothing has
-                # offered this install a way back — and the halt is permanent
-                # until something clears the latch, which only the pairing
-                # dialog does. Left alone the app sits offline forever with no
-                # route to re-pair at all, which is worse than the flood.
-                # Nothing can be lost by opening it here (no session, no
-                # history, nothing paired), and the halt has already played the
-                # error sound and said what happened, so this skips the
-                # MessageBox _show_repair_dialog() adds. The same latch is set
-                # so a dismissed dialog does not get re-opened every minute.
-                mw._auto_repair_dialog_shown = True
-                mw.restore_window()
-                self.connect.show_connection_dial()
+            if getattr(mw, "_auto_repair_dialog_shown", False):
+                # Already offered a way back, and dismissed: re-opening it on
+                # every flood would hand the user a fresh dialog every minute.
+                return
+            # Two different states arrive here with nothing yet offered, and
+            # `paired` is what tells them apart — _auto_repair_dialog_shown
+            # cannot, since it is also False for a paired install the branch
+            # above merely withheld (inside the startup grace, or before
+            # _REPAIR_DIALOG_CONFIRM_EVENTS confirmed it). Both are reachable
+            # in one flood: the grace is _WA_STARTUP_GRACE_SECONDS wide and
+            # nothing on this path dedups a repeated code, so a boot-time
+            # burst can spend the whole limit inside it.
+            if paired:
+                # A paired install whose session has just been closed by the
+                # halt. It needs the same explanation the branch above would
+                # have given it — the device_logged_out MessageBox — because
+                # otherwise all it is told is that a session was closed, with
+                # nothing said about the login it just lost or the re-pairing
+                # it now has to do. The halt has already played the error
+                # sound and spoken, so this repeats that cue; the specific
+                # explanation is worth hearing it twice.
+                self._show_repair_dialog()
+                return
+            # Never paired: the branch above never ran because there is no
+            # session to re-pair — and the halt is permanent until something
+            # clears the latch, which only the pairing dialog does. Left alone
+            # the app sits offline forever with no route to re-pair at all,
+            # which is worse than the flood. Nothing can be lost by opening it
+            # here (no session, no history, nothing paired), and the halt has
+            # already played the error sound and said what happened, so this
+            # skips the MessageBox _show_repair_dialog() adds — there is no
+            # logged-out device to explain. The same latch is set so a
+            # dismissed dialog does not get re-opened every minute.
+            mw._auto_repair_dialog_shown = True
+            mw.restore_window()
+            self.connect.show_connection_dial()
 
     def _show_repair_dialog(self):
         """Tell a previously-paired user their session needs re-pairing, and

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -192,12 +192,53 @@ class WebSocketClient:
     # the restore has already passed both gates and every route out of it
     # returns above the halt: the reset can only push the *dialog* out by up
     # to _REPAIR_DIALOG_CONFIRM_EVENTS - 1 further codes, and the dialog then
-    # resets the counter itself (_reset_unattended_qr_guards()). Once per
-    # recovery rather than once per launch — a session reporting CONNECTED
-    # hands _recover_suspect_profile()'s latch straight back (main.py's
-    # _note_status_for_profile_health()) — and a second allowance can only be
-    # spent on a second flood, which had its own full ceiling regardless. See
-    # TestTheProfileIsRepairedBeforeAskingTheUserToPair for both orderings.
+    # resets the counter itself (_reset_unattended_qr_guards()). See
+    # TestTheProfileIsRepairedBeforeAskingTheUserToPair for both orderings,
+    # and tests/test_profile_recovery_wiring.py::
+    # TestASuccessfulRestoreGivesBackTheQrFloodAllowance for the production
+    # line the fake there stands in for.
+    #
+    # Once per recovery, and a launch is no longer bounded to one of those:
+    # _recover_suspect_profile() latches, but a session reporting CONNECTED
+    # hands that latch straight back (main.py's
+    # _note_status_for_profile_health() — a snapshot that connected has
+    # proved itself and may be restored again if it breaks later in the same
+    # run). It still does not widen this window, because the CONNECTED
+    # reading that re-arms the recovery is the same one
+    # _set_wa_connected(True, ...) acts on, and that zeroes this counter and
+    # clears the halt latch anyway: the second allowance can only ever be
+    # spent on a second flood, which had its own full ceiling regardless.
+    # The one seam is that the re-arm reads the status string alone while the
+    # counter reset also needs the live isConnected() probe to agree, so a
+    # CONNECTED the probe refuses gives the recovery back without giving the
+    # counter back. KNOWN, not fixed here, and written out because the cost is
+    # not the extra codes it was found for.
+    #
+    # A second recovery can therefore start mid-flood, on an event the counter
+    # has already counted — and _handle_unattended_qr() returns the moment it
+    # starts (`if mw._recover_suspect_profile(...): return`, above the halt).
+    # If that lands on the very event where `seen` reached
+    # _UNATTENDED_QR_LIMIT, the halt is not postponed: it stops being
+    # evaluated at all, because the test there is `==` and `seen` only grows
+    # from there. The only thing that makes it reachable again is a zeroing,
+    # and the only zeroing on this path is the restore succeeding — which
+    # restarts the count from 0 and pays the whole ceiling over again, rather
+    # than halting. A restore that starts and then fails never gets even that.
+    # What bounds the damage is the dialog: the branch that call sits in has
+    # already cleared the startup grace and this counter, so the next code
+    # takes the refusal straight into _show_repair_dialog() and the flood ends
+    # there. Same order of magnitude as the allowance above, which is why it
+    # is an issue and not a blocker.
+    #
+    # The fix that works is to move the re-arm into _set_wa_connected()
+    # (main.py), beside its own `self._unattended_qr_events = 0`: it runs on
+    # the same poll, right after the probe has agreed, making the re-arm and
+    # the reset one event — which is the property this comment already claims.
+    # Gating the re-arm on _wa_connected instead is the obvious alternative
+    # and does not work: it delays the recovery by a whole poll (~30 s) and
+    # breaks the case it was added for — _note_status_for_profile_health()
+    # measured 11 s between a restored profile connecting and a superseded
+    # session start force-killing its browser.
     _REPAIR_DIALOG_CONFIRM_EVENTS = 2
 
     def __init__(self, main_window, connect, instance_name):
@@ -977,10 +1018,17 @@ class WebSocketClient:
         ):
             # Try to repair the profile before sending the user off to pair by
             # hand. This event is the *earliest and strongest* evidence that
-            # the Chrome profile lost its login: as this method's own docstring
-            # says, WPPConnect only mints a code once it has decided the stored
-            # session cannot be restored — which is exactly the condition
-            # ProfileHealthTracker spends minutes trying to infer from
+            # the Chrome profile lost its login, and
+            # _halt_unattended_qr_session() (main.py) is where that is spelled
+            # out: by the time any code exists it has come through catchQR
+            # (which fires only once getQrCode() returned a urlCode, the QR
+            # itself) or from WPP.conn.startLinkDeviceCodeForPhoneNumber()
+            # behind loginByCode's own wait for WhatsApp Web's auth state,
+            # which refuses to mint at all for a registered session — and
+            # wa-js produces neither while paired and authenticated. So the
+            # stored session has already failed to restore, which is exactly
+            # the condition the profile recovery exists for and the one
+            # ProfileHealthTracker otherwise spends minutes inferring from
             # status-session strings.
             #
             # Measured on a real install on 2026-09-08: a clean Ctrl+Shift+Q
@@ -1040,6 +1088,13 @@ class WebSocketClient:
             # (_pairing_attended()) or the connection comes back, and those are
             # also what clear the latch, so a second outage does get a second
             # halt.
+            #
+            # One case does not hold that, and it is why `==` is the
+            # load-bearing half of the seam described on
+            # _REPAIR_DIALOG_CONFIRM_EVENTS: an event that returns above this
+            # line never evaluates the halt, and `seen` can only grow past the
+            # limit afterwards, so a skipped event withholds the halt for the
+            # rest of the flood rather than delaying it by one.
             logging.warning(
                 "[on_qrcode_update] %d QR/pairing codes generated with no "
                 "pairing dialog on screen — closing the session so it stops "

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import threading
 import time
@@ -1047,10 +1048,22 @@ class WebSocketClient:
             # _recover_suspect_profile() runs at most once per launch and calls
             # back when it gives up — against a re-pairing saved every time the
             # profile was the actual fault.
+            #
+            # play_sound is bound here rather than left to its default
+            # because wx.CallAfter(on_give_up) invokes this with no
+            # arguments: the restore's give-up path queues it directly behind
+            # wx.CallAfter(self._announce_profile_beyond_repair), whose very
+            # first statement is that same error_sound.play() — and whose
+            # own MessageBox then pumps the queue, so this callback runs from
+            # inside it. Two plays milliseconds apart on one stream are not
+            # two cues: sound_lib restarts it and they are heard as a single
+            # truncated blip, the same defect the post-halt route below is
+            # written around.
             if mw._recover_suspect_profile(
                     reason="WPPConnect minted a pairing code for a paired "
                            "install — the stored session could not be restored",
-                    on_give_up=self._show_repair_dialog):
+                    on_give_up=functools.partial(self._show_repair_dialog,
+                                                 play_sound=False)):
                 return
             # Nothing was started (no snapshot, or the recovery budget is
             # already spent), so a human is the only way back — and that is
@@ -1155,15 +1168,27 @@ class WebSocketClient:
         """Tell a previously-paired user their session needs re-pairing, and
         put the pairing dialog in front of them straight away.
 
-        Reached from _handle_unattended_qr() by two routes, and both mean the
-        signal has been confirmed rather than acted on once. Either it cleared
-        that method's own bar — outside the startup grace window and confirmed
-        by _REPAIR_DIALOG_CONFIRM_EVENTS consecutive readings, not a single
-        one — or the grace/counter withheld it and the flood then spent the
-        entire _UNATTENDED_QR_LIMIT inside that window, which is a stronger
-        reading still. That second route runs after the halt has already
-        closed the session and announced it, which is what play_sound=False is
-        for; see the call site. Either way, by the time this runs the signal
+        Reached from _handle_unattended_qr() by three routes, and every one
+        of them means the signal has been confirmed rather than acted on once.
+        Two cleared that method's own bar — outside the startup grace window
+        and confirmed by _REPAIR_DIALOG_CONFIRM_EVENTS consecutive readings,
+        not a single one — and differ only in what the profile repair then
+        did with it: called inline when _recover_suspect_profile() refused to
+        start one (no snapshot, or the once-per-launch budget already spent),
+        and handed to it as on_give_up for the restore that started and then
+        failed. The third runs when the grace/counter withheld those two and
+        the flood then spent the entire _UNATTENDED_QR_LIMIT inside that
+        window, which is a stronger reading still.
+
+        The last two run behind something that has already played error_sound
+        — _announce_profile_beyond_repair() on the give-up route, the halt on
+        the third — which is what play_sound=False is for; see those call
+        sites. The inline route keeps the sound: its no-snapshot sub-case
+        announces too and so doubles the cue, but its budget-spent sub-case
+        has played nothing at all, and one flag at one call site cannot tell
+        them apart. A cue too many on a route that is sometimes silent is the
+        safe direction to be wrong in; silence on a route that is sometimes
+        the only cue is not. Either way, by the time this runs the signal
         is at least as solid as the coarse status-session string the poll
         watches (which needs several minutes of confirmation to rule out a
         normal slow boot). Surfacing the pairing dialog immediately —

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -153,6 +153,17 @@ class WebSocketClient:
     # action — and _handle_unattended_qr() offers it after that action too,
     # for the paired install a burst inside the grace window carried
     # straight past this counter.
+    #
+    # The halt itself moves by one event, in both directions, and that is
+    # the whole cost in codes actually requested from WhatsApp. Measured on
+    # a paired install by counting past the limit rather than stopping at
+    # it: outside the grace the halt lands on the 5th unattended code
+    # instead of the 4th (this counter withholds the dialog for one extra
+    # event, and the dialog is what used to reset the count); inside the
+    # grace it lands on the 3rd instead of the 4th, since nothing resets the
+    # count there at all. Bounded at +-1 either way — never a widening
+    # window, which is the property that matters for an account that was
+    # banned over code volume.
     _REPAIR_DIALOG_CONFIRM_EVENTS = 2
 
     def __init__(self, main_window, connect, instance_name):
@@ -995,10 +1006,17 @@ class WebSocketClient:
                 # have given it — the device_logged_out MessageBox — because
                 # otherwise all it is told is that a session was closed, with
                 # nothing said about the login it just lost or the re-pairing
-                # it now has to do. The halt has already played the error
-                # sound and spoken, so this repeats that cue; the specific
-                # explanation is worth hearing it twice.
-                self._show_repair_dialog()
+                # it now has to do.
+                #
+                # play_sound=False because the halt has just played that very
+                # same error_sound object and spoken over it. Playing it again
+                # ~0 ms later does not read as two cues: sound_lib restarts
+                # the one stream, so the user hears a single truncated blip,
+                # and the halt's own line is cut mid-sentence by the
+                # MessageBox's focus announcement — which then says the same
+                # thing anyway. Same shape as the clipped speech the
+                # focus_cloak work was written for (see CLAUDE.md).
+                self._show_repair_dialog(play_sound=False)
                 return
             # Never paired: the branch above never ran because there is no
             # session to re-pair — and the halt is permanent until something
@@ -1014,14 +1032,20 @@ class WebSocketClient:
             mw.restore_window()
             self.connect.show_connection_dial()
 
-    def _show_repair_dialog(self):
+    def _show_repair_dialog(self, play_sound=True):
         """Tell a previously-paired user their session needs re-pairing, and
         put the pairing dialog in front of them straight away.
 
-        Called once _handle_unattended_qr() has already required everything
-        it requires before reaching here — outside the startup grace window
-        and confirmed by _REPAIR_DIALOG_CONFIRM_EVENTS consecutive readings,
-        not a single one — so by the time this runs, the signal is at least
+        Reached from _handle_unattended_qr() by two routes, and both mean the
+        signal has been confirmed rather than acted on once. Either it cleared
+        that method's own bar — outside the startup grace window and confirmed
+        by _REPAIR_DIALOG_CONFIRM_EVENTS consecutive readings, not a single
+        one — or the grace/counter withheld it and the flood then spent the
+        entire _UNATTENDED_QR_LIMIT inside that window, which is a stronger
+        reading still. That second route runs after the halt has already
+        closed the session and announced it, which is what play_sound=False is
+        for; see the call site. Either way, by the time this runs the signal
+        is at least
         as solid as the coarse status-session string the health-check poll
         watches (which needs several minutes of confirmation to rule out a
         normal slow boot). Surfacing the pairing dialog immediately —
@@ -1051,7 +1075,8 @@ class WebSocketClient:
         # everything with no prior audible cue is easy to miss
         # entirely — reported live as exactly that.
         self.main_window.restore_window()
-        self.main_window.error_sound.play()
+        if play_sound:
+            self.main_window.error_sound.play()
         wx.MessageBox(
             self.i18n.t("device_logged_out"),
             self.i18n.t("error").format(app_name=self.main_window.app_name),

--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -78,6 +78,19 @@ def phone_code_error_is_rate_limit(data) -> bool:
     return "rate-overlimit" in haystack or "RateOverlimit" in haystack
 
 
+def qr_within_startup_grace(announced, started, grace, now) -> bool:
+    """Is a QR event still inside the slow-boot window, given the four
+    values WebSocketClient._qr_within_startup_grace() reads off MainWindow?
+
+    Module-level so the window itself can be tested without a MainWindow —
+    see that method for what each value means and why the pair is read
+    exactly the way check_wa_connection_http() reads it.
+    """
+    if announced:
+        return False
+    return (now - (started or 0)) < (grace or 0)
+
+
 def _media_seconds(wpp_msg: dict):
     """Duration in whole seconds, or None when the payload never stated one.
 
@@ -155,15 +168,36 @@ class WebSocketClient:
     # straight past this counter.
     #
     # The halt itself moves by one event, in both directions, and that is
-    # the whole cost in codes actually requested from WhatsApp. Measured on
-    # a paired install by counting past the limit rather than stopping at
-    # it: outside the grace the halt lands on the 5th unattended code
-    # instead of the 4th (this counter withholds the dialog for one extra
-    # event, and the dialog is what used to reset the count); inside the
-    # grace it lands on the 3rd instead of the 4th, since nothing resets the
-    # count there at all. Bounded at +-1 either way — never a widening
+    # this counter's whole cost in codes actually requested from WhatsApp.
+    # Measured on a paired install by counting past the limit rather than
+    # stopping at it: outside the grace the halt lands on the 5th unattended
+    # code instead of the 4th (this counter withholds the dialog for one
+    # extra event, and the dialog is what used to reset the count); inside
+    # the grace it lands on the 3rd instead of the 4th, since nothing resets
+    # the count there at all. Bounded at +-1 either way — never a widening
     # window, which is the property that matters for an account that was
     # banned over code volume.
+    #
+    # The profile repair adds its own, separate allowance:
+    # _recover_suspect_profile() zeroes this counter when a restore actually
+    # succeeds (main.py), because the burst that triggered it was minted by
+    # the profile now moved aside. That zeroing happens on the restore
+    # thread, with close-session, wait_for_profile_release and a copy of a
+    # few hundred MB between the trigger and it — so it is NOT one event
+    # later, and writing it as if it were understates the one number an
+    # account was banned over. By the time it lands, 1 or 2 codes have
+    # usually been counted already and those are not given back; what the
+    # reset does hand back is the run-up, since the count towards this
+    # constant starts again from 0. Bounded, because the branch that starts
+    # the restore has already passed both gates and every route out of it
+    # returns above the halt: the reset can only push the *dialog* out by up
+    # to _REPAIR_DIALOG_CONFIRM_EVENTS - 1 further codes, and the dialog then
+    # resets the counter itself (_reset_unattended_qr_guards()). Once per
+    # recovery rather than once per launch — a session reporting CONNECTED
+    # hands _recover_suspect_profile()'s latch straight back (main.py's
+    # _note_status_for_profile_health()) — and a second allowance can only be
+    # spent on a second flood, which had its own full ceiling regardless. See
+    # TestTheProfileIsRepairedBeforeAskingTheUserToPair for both orderings.
     _REPAIR_DIALOG_CONFIRM_EVENTS = 2
 
     def __init__(self, main_window, connect, instance_name):
@@ -872,11 +906,12 @@ class WebSocketClient:
         on its own, so the clock under it no longer decides anything.
         """
         mw = self.main_window
-        if getattr(mw, "_wa_connect_announced", False):
-            return False
-        started = getattr(mw, "_wa_startup_time", 0) or 0
-        grace = getattr(mw, "_WA_STARTUP_GRACE_SECONDS", 0) or 0
-        return (time.time() - started) < grace
+        return qr_within_startup_grace(
+            getattr(mw, "_wa_connect_announced", False),
+            getattr(mw, "_wa_startup_time", 0) or 0,
+            getattr(mw, "_WA_STARTUP_GRACE_SECONDS", 0) or 0,
+            time.time(),
+        )
 
     def _handle_unattended_qr(self):
         """A real QR/pairing code arrived that no refresh branch wanted.
@@ -968,6 +1003,25 @@ class WebSocketClient:
                            "install — the stored session could not be restored",
                     on_give_up=self._show_repair_dialog):
                 return
+            # Nothing was started (no snapshot, or the recovery budget is
+            # already spent), so a human is the only way back — and that is
+            # the judgment, not the observation.
+            #
+            # KNOWN GAP, inherited and not introduced here: "already spent"
+            # also covers a restore still IN FLIGHT. _recover_suspect_profile()
+            # latches the moment it starts its thread, so the next code ~20-30s
+            # later is refused with False and lands right here, opening the
+            # pairing dialog on top of a restore_snapshot() that may still be
+            # writing into userDataDir/<session>. If the user pairs from that
+            # dialog, _reset_unattended_qr_guards() clears _qr_flood_halted and
+            # /start-session launches Chrome over the directory being written —
+            # precisely what core/profile_recovery.py forbids ("restoring under
+            # a running browser manufactures the corruption it recovers from").
+            # Closing it means exposing a "restore in flight" state and holding
+            # _show_repair_dialog() on it, which is a production change of its
+            # own; see tests/test_qrcode_auto_repair_dialog.py::
+            # TestTheProfileIsRepairedBeforeAskingTheUserToPair for both
+            # orderings, the losing one pinned as today's real behaviour.
             self._show_repair_dialog()
             return
         if seen == self._UNATTENDED_QR_LIMIT:

--- a/client/main.py
+++ b/client/main.py
@@ -8454,12 +8454,18 @@ class MainWindow(wx.Frame):
         It does not, and the distinction is worth keeping straight. That
         grace protects the USER from acting on one reading — the re-pairing
         dialog that wipes history — and says nothing about whether the code
-        is real. By the time any code exists, it has come through catchQR (a
-        QR event) or through loginByCode's own auth-state gate (a pairing
-        code — on a session started with a phone number, host.layer.js never
-        registers catchQR at all), and both proceed only once getQrCode()
-        has returned a urlCode: wa-js hands one out only while unpaired and
-        not authenticated, so the stored auth has already failed to restore.
+        is real. By the time any code exists, it has come through one of two
+        routes, and each proves the same thing by its own means. A QR event
+        reaches catchQR only once getQrCode() returned a urlCode, and that
+        urlCode *is* the code. A pairing code — on a session started with a
+        phone number, host.layer.js never registers catchQR at all — is minted
+        by WPP.conn.startLinkDeviceCodeForPhoneNumber() behind loginByCode's
+        own gate, which is a wait for WhatsApp Web's auth state (probed
+        through getQrCode(), but as a readiness check; the urlCode is thrown
+        away and is not the code) and which returns without minting anything
+        the moment needsToScan() says the session is registered. wa-js
+        produces neither while paired and authenticated, so on either route
+        the stored auth has already failed to restore.
         Reaching _UNATTENDED_QR_LIMIT codes inside that window is stronger
         evidence than the two readings the dialog itself asks for, so the
         halt stays deliberately outside the grace.

--- a/client/main.py
+++ b/client/main.py
@@ -8447,6 +8447,19 @@ class MainWindow(wx.Frame):
         makes it mint codes in the first place, so there is nothing left to
         flush — but worth writing down, since a caller that ever reached this
         with live auth WOULD lose it.
+
+        _qr_within_startup_grace() (websocket_client.py) looks like it
+        contradicts that: it withholds judgment on a code arriving seconds
+        into a boot, on the grounds that the session may still be coming up.
+        It does not, and the distinction is worth keeping straight. That
+        grace protects the USER from acting on one reading — the re-pairing
+        dialog that wipes history — and says nothing about whether the code
+        is real. By the time any code exists, catchQR has already fired,
+        which happens only after getQrCode() returned a urlCode, i.e. after
+        wa-js reached require_auth and restoring the stored auth had failed.
+        Reaching _UNATTENDED_QR_LIMIT codes inside that window is stronger
+        evidence than the two readings the dialog itself asks for, so the
+        halt stays deliberately outside the grace.
         """
         if getattr(self, "_qr_flood_halted", False):
             return

--- a/client/main.py
+++ b/client/main.py
@@ -8454,9 +8454,12 @@ class MainWindow(wx.Frame):
         It does not, and the distinction is worth keeping straight. That
         grace protects the USER from acting on one reading — the re-pairing
         dialog that wipes history — and says nothing about whether the code
-        is real. By the time any code exists, catchQR has already fired,
-        which happens only after getQrCode() returned a urlCode, i.e. after
-        wa-js reached require_auth and restoring the stored auth had failed.
+        is real. By the time any code exists, it has come through catchQR (a
+        QR event) or through loginByCode's own auth-state gate (a pairing
+        code — on a session started with a phone number, host.layer.js never
+        registers catchQR at all), and both proceed only once getQrCode()
+        has returned a urlCode: wa-js hands one out only while unpaired and
+        not authenticated, so the stored auth has already failed to restore.
         Reaching _UNATTENDED_QR_LIMIT codes inside that window is stronger
         evidence than the two readings the dialog itself asks for, so the
         halt stays deliberately outside the grace.

--- a/client/main.py
+++ b/client/main.py
@@ -8458,8 +8458,9 @@ class MainWindow(wx.Frame):
         routes, and each proves the same thing by its own means. A QR event
         reaches catchQR only once getQrCode() returned a urlCode, and that
         urlCode *is* the code. A pairing code — on a session started with a
-        phone number, host.layer.js never registers catchQR at all — is minted
-        by WPP.conn.startLinkDeviceCodeForPhoneNumber() behind loginByCode's
+        phone number, host.layer.js never registers checkQrCode at all, so
+        catchQR is never reached — is minted by
+        WPP.conn.startLinkDeviceCodeForPhoneNumber() behind loginByCode's
         own gate, which is a wait for WhatsApp Web's auth state (probed
         through getQrCode(), but as a readiness check; the urlCode is thrown
         away and is not the code) and which returns without minting anything

--- a/tests/test_check_connection_status_local_auth.py
+++ b/tests/test_check_connection_status_local_auth.py
@@ -71,6 +71,29 @@ def _synchronous_ui(monkeypatch):
     monkeypatch.setattr(connect_module.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
     monkeypatch.setattr(connect_module.wx, "MessageBox", lambda *a, **kw: None)
     monkeypatch.setattr(connect_module.wx, "IsMainThread", lambda: True)
+    # The unpaired branch fires a daemon thread that POSTs close-session.
+    # Today it never leaves the process only by accident: _wpp_headers()
+    # reads main_window.wpp_api_key, which _FakeMainWindow does not have, and
+    # the AttributeError is swallowed by that thread's own try/except before
+    # api_post runs. Giving the fake a wpp_api_key — an entirely plausible
+    # edit — would silently turn these into tests that hit 127.0.0.1:6300.
+    monkeypatch.setattr(connect_module, "api_post",
+                        lambda *a, **kw: _Response(200))
+
+
+def _assert_paired_survives(mw):
+    """`paired` surviving is the load-bearing half of keeping the account.
+
+    Everything protecting this database downstream reads it: with `paired`
+    gone, _handle_local_auth_rejected() (main.py) takes its own
+    `if not ... get("paired")` branch and calls _on_disconnect() with the
+    default wipe=True on the FIRST health-check tick, skipping the whole
+    strike/veto machinery — the database dies ~30 s in instead of surviving.
+    Asserting only clear_local_data_calls would let a refactor that drops
+    the pop("paired") out of this branch keep the suite green.
+    """
+    assert mw.settings["privateinfo"]["paired"] is True
+    assert mw.save_settings_calls == 0
 
 
 class TestCheckConnectionSession401:
@@ -85,6 +108,7 @@ class TestCheckConnectionSession401:
         assert result is True
         assert mw.clear_local_data_calls == 0
         assert mw.set_wa_token_calls == []
+        _assert_paired_survives(mw)
 
     def test_never_paired_account_still_gets_wiped(self, monkeypatch):
         """Nothing to preserve for an account that never finished pairing —
@@ -128,6 +152,7 @@ class TestStatusSessionFallback401:
         assert mw.clear_local_data_calls == 0
         assert mw.set_wa_token_calls == []
         assert calls["n"] == 2
+        _assert_paired_survives(mw)
 
     def test_never_paired_account_is_wiped_by_the_first_branch_already(self, monkeypatch):
         """paired=False never reaches the fallback at all: the

--- a/tests/test_profile_recovery_wiring.py
+++ b/tests/test_profile_recovery_wiring.py
@@ -11,6 +11,9 @@ between a restore point that helps and one that makes things worse:
   needed by the flush;
 * the session must be closed before the profile is touched, or the restore
   overwrites a leveldb while Chrome holds it open;
+* a restore that succeeded has to hand back the QR-flood allowance the burst
+  that triggered it already spent, or the flood halt latches over a profile
+  that was just repaired and nothing ever starts it again;
 * and when there is nothing to restore, the user has to be *told* — this only
   ever happens while already offline, where the connection announcements have
   long since gone quiet.
@@ -53,6 +56,7 @@ class _Stub:
         self.error_sound = types.SimpleNamespace(play=lambda: None)
         self.i18n = types.SimpleNamespace(t=lambda key: key)
         self.db = _MetadataDB()
+        self.profile_released = False
 
     # Bound from the real class: the generation ladder decides *which*
     # snapshot goes back, so a stub that faked it would let the wiring drift
@@ -60,6 +64,12 @@ class _Stub:
     _PROFILE_RECOVERY_GENERATION_KEY = MainWindow._PROFILE_RECOVERY_GENERATION_KEY
     _profile_recovery_generation = MainWindow._profile_recovery_generation
     _set_profile_recovery_generation = MainWindow._set_profile_recovery_generation
+
+    def wait_for_profile_release(self, session_name, timeout=20.0):
+        """Only reached by the tests that let the restore thread run; every
+        other one is refused before this by has_snapshot."""
+        self.profile_released = True
+        return True
 
     def _shutdown_audit(self, msg):
         self.audits.append(msg)
@@ -78,6 +88,19 @@ class _Stub:
 
     def _announce_profile_restored(self):
         MainWindow._announce_profile_restored(self)
+
+
+class _InlineThread:
+    """The restore runs on its own daemon thread in production; nothing here
+    could observe what it did otherwise."""
+
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None, name=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        self._target(*self._args, **self._kwargs)
 
 
 def _note(stub, status):
@@ -360,3 +383,63 @@ class TestARestoreThatConnectedEarnsAnotherChance:
         for _ in range(5):
             _note(stub, "CLOSED")
             assert MainWindow._recover_suspect_profile(stub) is False
+
+
+class TestASuccessfulRestoreGivesBackTheQrFloodAllowance:
+    """The restore thread's own `self._unattended_qr_events = 0`.
+
+    The burst of QR/pairing codes that brought us here was minted by the
+    profile now moved aside, so counting it against
+    WebSocketClient._UNATTENDED_QR_LIMIT halts a session that is about to be
+    fine — and the halt is the expensive half: _halt_unattended_qr_session()
+    latches _qr_flood_halted, so check_wa_connection_http() never issues
+    another /start-session and the profile just restored is never started at
+    all. The user is left offline with no route back, which is exactly the
+    "worse than the flood" outcome _handle_unattended_qr() describes.
+
+    Reachable in ordinary operation: a paired install's counter normally
+    stands at 1 or 2 by the time the restore lands, because the reset happens
+    behind close-session, wait_for_profile_release and a copy of a few hundred
+    megabytes while codes keep arriving every ~20-30 s.
+    tests/test_qrcode_auto_repair_dialog.py models that timing from the QR
+    side (_FakeMainWindow.finish_restore()); this is the production line it
+    stands in for.
+    """
+
+    @pytest.fixture
+    def restoring(self, monkeypatch):
+        """Everything between the trigger and the reset, made synchronous.
+        Returns a setter for the one outcome the two tests differ on."""
+        monkeypatch.setattr("core.profile_recovery.has_snapshot", lambda *a, **kw: True)
+        monkeypatch.setattr("main.api_post", lambda *a, **kw: None)
+        monkeypatch.setattr("main.wx.CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+        monkeypatch.setattr("main.threading.Thread", _InlineThread)
+
+        def _restore_succeeds(restored):
+            monkeypatch.setattr("core.profile_recovery.restore_snapshot",
+                                lambda *a, **kw: restored)
+        return _restore_succeeds
+
+    def test_the_flood_counter_is_cleared_once_the_restore_succeeded(self, restoring):
+        restoring(True)
+        stub = _Stub()
+        stub._unattended_qr_events = 2      # one code short of the halt
+
+        assert MainWindow._recover_suspect_profile(stub) is True
+
+        assert stub.profile_released
+        assert stub._unattended_qr_events == 0
+        assert "profile_restored_from_snapshot" in stub.announced
+
+    def test_a_failed_restore_leaves_the_flood_counter_alone(self, restoring):
+        """Nothing was moved aside, so the codes counted so far are real ones
+        and the ceiling on them has to keep applying — the halt is the only
+        thing that stops WhatsApp being asked for more."""
+        restoring(False)
+        stub = _Stub()
+        stub._unattended_qr_events = 2
+
+        MainWindow._recover_suspect_profile(stub)
+
+        assert stub._unattended_qr_events == 2
+        assert "profile_corrupted_repair_needed" in stub.announced

--- a/tests/test_qrcode_auto_repair_dialog.py
+++ b/tests/test_qrcode_auto_repair_dialog.py
@@ -36,8 +36,11 @@ class _FakeI18n:
 
 
 class _FakeSound:
+    def __init__(self):
+        self.plays = 0
+
     def play(self):
-        pass
+        self.plays += 1
 
 
 class _FakeSpeakOutput:
@@ -82,6 +85,9 @@ class _FakeMainWindow:
         # nothing to restore, so the pairing dialog is the outcome.
         self.profile_restore_available = False
         self.recover_calls = []
+        # Every on_give_up handed over, kept so a test can fire one the way
+        # the restore thread does — see fail_restore().
+        self.give_up_callbacks = []
         # Defaults put every pre-existing test well past the startup grace
         # window (already connected once before, or started long ago) —
         # only the dedicated grace-window tests below override these.
@@ -102,6 +108,7 @@ class _FakeMainWindow:
         # refresh calling this again, so what it does with the NEXT code is
         # exactly what these tests are about.
         self.recover_calls.append(reason)
+        self.give_up_callbacks.append(on_give_up)
         # Mirrors the real contract: on_give_up fires only when a restore was
         # started and then failed. A False return means nothing was started,
         # and the caller handles it inline — see _recover_suspect_profile().
@@ -130,6 +137,19 @@ class _FakeMainWindow:
         TestASuccessfulRestoreGivesBackTheQrFloodAllowance.
         """
         self._unattended_qr_events = 0
+
+    def fail_restore(self):
+        """The restore thread's give-up path, in the order production runs it.
+
+        _recover_suspect_profile() queues wx.CallAfter(
+        self._announce_profile_beyond_repair) — whose *first* statement is
+        error_sound.play() — and immediately behind it wx.CallAfter(
+        on_give_up), which passes no arguments at all. Both land on the wx
+        main thread milliseconds apart, so what the callback does with the
+        sound is the whole question here.
+        """
+        self.error_sound.play()           # _announce_profile_beyond_repair()
+        self.give_up_callbacks[-1]()      # wx.CallAfter(on_give_up): no args
 
     def _is_pairing_dialog_active(self):
         return self._pairing_dialog_active
@@ -340,6 +360,43 @@ class TestTheProfileIsRepairedBeforeAskingTheUserToPair:
         s.on_qrcode_update(QR_EVENT)
 
         assert mw.recover_calls == []
+
+    def test_a_failed_restore_sends_the_user_to_pair_without_a_second_sound(self):
+        """The give-up route is a third caller of _show_repair_dialog(), and
+        nothing used to bind its play_sound.
+
+        wx.CallAfter(on_give_up) invokes it with no arguments, so it took the
+        default — and it is queued directly behind
+        wx.CallAfter(self._announce_profile_beyond_repair), whose first
+        statement is error_sound.play() and whose MessageBox then pumps the
+        queue this callback is sitting in. The two plays therefore landed on
+        one stream milliseconds apart, which sound_lib restarts: heard as a
+        single truncated blip rather than as two cues, the same defect the
+        post-halt route is written around (see
+        tests/test_qrcode_unattended_session.py, which pins that one).
+
+        So exactly one error sound belongs on this route — the
+        announcement's, which has already explained itself in words the
+        second one cannot add to."""
+        mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
+        mw.profile_restore_available = True
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        s.on_qrcode_update(QR_EVENT)
+        s.on_qrcode_update(QR_EVENT)          # this one starts the restore
+        assert mw.restore_starts == 1
+        assert mw.error_sound.plays == 0      # nothing has been played yet
+
+        mw.fail_restore()
+
+        # The user is still sent to pair by hand — the repair is what failed,
+        # not the reading that prompted it.
+        assert connect.show_connection_dial_calls == 1
+        assert mw.restore_window_calls == 1
+        assert mw.error_sound.plays == 1, (
+            "the give-up route played the error sound again on top of "
+            "_announce_profile_beyond_repair()'s own")
 
     def test_a_qr_refresh_after_the_restore_finished_does_not_retry_it(self):
         # Codes rotate every ~20-30 s. _recover_suspect_profile() latches on

--- a/tests/test_qrcode_auto_repair_dialog.py
+++ b/tests/test_qrcode_auto_repair_dialog.py
@@ -26,7 +26,7 @@ import time
 
 import pytest
 
-from core.websocket_client import WebSocketClient
+from core.websocket_client import WebSocketClient, qr_within_startup_grace
 from main import MainWindow
 
 
@@ -91,22 +91,42 @@ class _FakeMainWindow:
             time.time() - (self._WA_STARTUP_GRACE_SECONDS * 10)
             if wa_startup_time is None else wa_startup_time
         )
+        # Modelling the restore's own two effects separately, because they
+        # land at very different moments — see finish_restore() below.
+        self._recovery_spent = False
+        self.restore_starts = 0
 
     def _recover_suspect_profile(self, reason=None, on_give_up=None):
-        # Mirrors the real method's own "runs at most once per launch" latch
-        # (main.py: _profile_recovery_attempted) — the caller
-        # (_handle_unattended_qr) does not itself guard against a later QR
-        # refresh calling this again, so the fake has to model the latch or
-        # a test asserting "no second attempt" would pass for the wrong
-        # reason.
-        if getattr(self, "_profile_recovery_attempted", False):
-            return False
-        self._profile_recovery_attempted = True
+        # Every call is recorded, including the ones the latch refuses: the
+        # caller (_handle_unattended_qr) does not guard against a later QR
+        # refresh calling this again, so what it does with the NEXT code is
+        # exactly what these tests are about.
         self.recover_calls.append(reason)
         # Mirrors the real contract: on_give_up fires only when a restore was
         # started and then failed. A False return means nothing was started,
         # and the caller handles it inline — see _recover_suspect_profile().
-        return bool(self.profile_restore_available)
+        if not self.profile_restore_available or self._recovery_spent:
+            return False
+        # The latch is what the real one does synchronously: it is set before
+        # the restore thread is even started, so a second call is refused
+        # whether or not that thread has finished.
+        self._recovery_spent = True
+        self.restore_starts += 1
+        return True
+
+    def finish_restore(self):
+        """The restore thread reaching `self._unattended_qr_events = 0`.
+
+        Kept separate from _recover_suspect_profile() on purpose. In
+        production that line runs on a background thread, after close-session
+        (10 s timeout), wait_for_profile_release (20 s) and a copy of a few
+        hundred MB — while codes keep arriving every ~20-30 s. Zeroing the
+        counter inline here would model a race production does not reliably
+        win, and every test resting on it would be asserting a guarantee the
+        app does not have. So the tests say when it lands, and both orderings
+        are covered.
+        """
+        self._unattended_qr_events = 0
 
     def _is_pairing_dialog_active(self):
         return self._pairing_dialog_active
@@ -318,37 +338,108 @@ class TestTheProfileIsRepairedBeforeAskingTheUserToPair:
 
         assert mw.recover_calls == []
 
-    def test_a_qr_refresh_during_the_restore_does_not_retry_it(self):
+    def test_a_qr_refresh_after_the_restore_finished_does_not_retry_it(self):
         # Codes rotate every ~20-30 s. _recover_suspect_profile() latches on
-        # its own (main.py: _profile_recovery_attempted), so a second attempt
-        # is never started. Two events reach _REPAIR_DIALOG_CONFIRM_EVENTS and
-        # start the restore.
+        # its own, so the code after the one that started the restore is
+        # refused — and when the restore thread's own reset has already
+        # landed, that refusal has nothing to fall through into: the counter
+        # is back at 0, so the next code is only the first of a fresh run and
+        # _REPAIR_DIALOG_CONFIRM_EVENTS is not met.
         mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
         mw.profile_restore_available = True
         connect = _FakeConnect(mw)
         s = _Stub(mw, connect)
 
         s.on_qrcode_update(QR_EVENT)
+        s.on_qrcode_update(QR_EVENT)          # this one starts the restore
+        assert mw.restore_starts == 1
+        mw.finish_restore()
+
         s.on_qrcode_update(QR_EVENT)
 
-        assert len(mw.recover_calls) == 1
+        assert mw.restore_starts == 1
         assert connect.show_connection_dial_calls == 0
+        assert mw.halt_calls == 0
 
-        # KNOWN GAP (not introduced by this branch — see PR #183, already on
-        # upstream/main): a THIRD event, arriving while the restore from the
-        # second is still unresolved, calls _recover_suspect_profile() again.
-        # Its latch correctly refuses to start a second restore and returns
-        # False — but _handle_unattended_qr() treats every False the same
-        # way ("nothing was started, send the user to pair by hand") and
-        # falls through to _show_repair_dialog() anyway, even though a
-        # restore it started one event ago may still be in flight or may
-        # have already quietly succeeded. The bare boolean return of
-        # _recover_suspect_profile() cannot currently tell those two "False"
-        # cases apart. Documented here rather than silently asserted around,
-        # since a passing assert on this line would hide a real interaction
-        # this test suite does not otherwise cover.
+    def test_a_qr_refresh_while_the_restore_still_runs_opens_the_dialog_today(self):
+        """The other ordering, which is the one production usually gets: the
+        restore thread is still inside close-session / wait_for_profile_release
+        / the profile copy when the next code arrives ~20-30 s later.
+
+        Nothing resets the counter in time, so the refused code is still the
+        _REPAIR_DIALOG_CONFIRM_EVENTS'th one and the pairing dialog goes up on
+        top of a restore still in flight. Pinned as today's behaviour rather
+        than as desired behaviour: pairing from that dialog starts a session
+        over the very directory restore_snapshot() may still be writing, which
+        is the known gap recorded beside _show_repair_dialog()'s call in
+        _handle_unattended_qr(). Closing it needs an "in flight" state this
+        test would then update."""
+        mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
+        mw.profile_restore_available = True
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
         s.on_qrcode_update(QR_EVENT)
+        s.on_qrcode_update(QR_EVENT)          # this one starts the restore
+        s.on_qrcode_update(QR_EVENT)          # the restore thread has not landed
+
+        assert mw.restore_starts == 1         # never retried, whichever way it goes
         assert connect.show_connection_dial_calls == 1
+
+    @pytest.mark.parametrize(
+        "reset_after_code, dialog_opens_on_code",
+        [
+            (None, WebSocketClient._REPAIR_DIALOG_CONFIRM_EVENTS + 1),
+            (WebSocketClient._REPAIR_DIALOG_CONFIRM_EVENTS,
+             WebSocketClient._REPAIR_DIALOG_CONFIRM_EVENTS * 2),
+        ],
+        ids=["reset-never-lands", "reset-lands-while-codes-keep-arriving"],
+    )
+    def test_what_the_restores_counter_reset_costs_in_codes(
+            self, reset_after_code, dialog_opens_on_code):
+        """The restore thread zeroes _unattended_qr_events when it succeeds,
+        and the cost of that has to stay bounded and stated: an account was
+        banned over the volume of codes requested from WhatsApp.
+
+        Calling it "one more event" would be optimistic in exactly the wrong
+        direction, because the zeroing lands on the restore thread, behind
+        close-session, wait_for_profile_release and a copy of a few hundred
+        MB — codes counted before it arrives are not given back, and the
+        run-up to _REPAIR_DIALOG_CONFIRM_EVENTS starts over. What holds is
+        that it can only push the dialog out by that run-up once: the repair
+        is attempted only after both gates have passed, both routes out of it
+        return above the halt, and the dialog then resets the counter itself.
+
+        So the halt never fires in this flood either way — the dialog is what
+        ends it, on the code named by the parametrization. Both are ceilings;
+        which one applies is what changes here, and only the dialog's moves.
+        """
+        mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
+        mw.profile_restore_available = True
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        for code in range(1, dialog_opens_on_code + 1):
+            s.on_qrcode_update(QR_EVENT)
+            if code == reset_after_code:
+                mw.finish_restore()
+            # Told apart on purpose: one message for both would read "the
+            # dialog opened on code 3, expected it on 3" in the case where it
+            # never opened at all, which is the one worth naming plainly.
+            if code == dialog_opens_on_code:
+                assert connect.show_connection_dial_calls == 1, (
+                    "no dialog on code %d, where it was expected" % code)
+            else:
+                assert connect.show_connection_dial_calls == 0, (
+                    "the dialog opened on code %d, expected it on %d"
+                    % (code, dialog_opens_on_code))
+            assert mw.halt_calls == 0, (
+                "the halt fired on code %d; the dialog is what ends this "
+                "flood" % code)
+
+        # Once per recovery: the latch means no later code starts a second
+        # restore, so the allowance above cannot be taken twice.
+        assert mw.restore_starts == 1
 
 
 class TestStartupGraceWindow:
@@ -419,3 +510,23 @@ class TestStartupGraceWindow:
         s.on_qrcode_update(QR_EVENT)
 
         assert connect.show_connection_dial_calls == 1
+
+
+class TestQrWithinStartupGraceIsPureLogic:
+    """The window itself, with no MainWindow and no socket in the way —
+    _qr_within_startup_grace() is the four-value reader in front of it."""
+
+    def test_a_confirmed_connection_ends_the_window_whatever_the_clock_says(self):
+        assert qr_within_startup_grace(True, 1000.0, 60.0, 1000.0) is False
+
+    def test_inside_the_window_when_no_connection_was_ever_confirmed(self):
+        assert qr_within_startup_grace(False, 1000.0, 60.0, 1030.0) is True
+
+    def test_outside_the_window_once_the_grace_has_elapsed(self):
+        assert qr_within_startup_grace(False, 1000.0, 60.0, 1061.0) is False
+
+    def test_a_missing_startup_time_or_grace_never_opens_the_window(self):
+        # getattr(..., 0) or 0 is what the caller passes when MainWindow has
+        # not written either attribute yet; that must read as "not in a grace
+        # window", never as an open-ended one.
+        assert qr_within_startup_grace(False, 0, 0, 1000.0) is False

--- a/tests/test_qrcode_auto_repair_dialog.py
+++ b/tests/test_qrcode_auto_repair_dialog.py
@@ -124,7 +124,10 @@ class _FakeMainWindow:
         counter inline here would model a race production does not reliably
         win, and every test resting on it would be asserting a guarantee the
         app does not have. So the tests say when it lands, and both orderings
-        are covered.
+        are covered. The production line this stands in for has its own test,
+        against the real MainWindow method that runs it:
+        tests/test_profile_recovery_wiring.py::
+        TestASuccessfulRestoreGivesBackTheQrFloodAllowance.
         """
         self._unattended_qr_events = 0
 

--- a/tests/test_qrcode_unattended_session.py
+++ b/tests/test_qrcode_unattended_session.py
@@ -82,6 +82,14 @@ class _FakeConnect:
         # looking at the pairing UI, so both unattended-QR guards are dropped.
         # Without this the fake made the flood limit look one event closer
         # than production ever reaches it.
+        #
+        # It does NOT mirror the other half: the real dialog is modal, so in
+        # production every later code is attended and the counter is reset by
+        # _pairing_attended() on each one. Here it keeps counting after the
+        # call. No test relies on that difference today — the dismissal tests
+        # model a dialog already closed — but a test that opens the dialog and
+        # then expects production's counts must set _pairing_dialog_active
+        # itself.
         self.main_window._reset_unattended_qr_guards()
 
     def display_qrcode_image(self, base64_img):
@@ -486,6 +494,30 @@ class TestAPairedInstallBarredByTheGraceWindowStillGetsTheExplanation:
         assert mw.halt_calls == 1
         assert boxes == []
         assert connect.show_connection_dial_calls == 1
+
+    def test_a_dismissed_dialog_is_not_reopened_for_a_paired_install(self, monkeypatch):
+        """The dismissal check has to keep running BEFORE the `paired` split.
+
+        Both guard the same block, and only the order separates them: swap
+        the two and a paired user who already dismissed the dialog gets a
+        fresh device_logged_out MessageBox on every flood. The pre-existing
+        cover for this branch is paired=False, which passes either way."""
+        boxes = []
+        monkeypatch.setattr(
+            "core.websocket_client.wx.MessageBox",
+            lambda text, *a, **kw: boxes.append(text),
+        )
+        mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
+        mw._auto_repair_dialog_shown = True
+        connect = _FakeConnect(mode="qrcode", main_window=mw)
+        s = _Stub(mw, connect)
+
+        for _ in range(WebSocketClient._UNATTENDED_QR_LIMIT * 3):
+            s.on_qrcode_update(QR_EVENT)
+
+        assert mw.halt_calls == 1
+        assert boxes == []
+        assert connect.show_connection_dial_calls == 0
 
 
 class TestConnectedSessionStillWins:

--- a/tests/test_qrcode_unattended_session.py
+++ b/tests/test_qrcode_unattended_session.py
@@ -84,9 +84,11 @@ class _FakeConnect:
         # than production ever reaches it.
         #
         # It does NOT mirror the other half: the real dialog is modal, so in
-        # production every later code is attended and the counter is reset by
-        # _pairing_attended() on each one. Here it keeps counting after the
-        # call. No test relies on that difference today — the dismissal tests
+        # production every later code is attended and _update_ui() zeroes the
+        # counter on each one, before any branch runs (websocket_client.py) —
+        # _pairing_attended() is only the condition it tests, never the thing
+        # that writes. Here it keeps counting after the call.
+        # No test relies on that difference today — the dismissal tests
         # model a dialog already closed — but a test that opens the dialog and
         # then expects production's counts must set _pairing_dialog_active
         # itself.

--- a/tests/test_qrcode_unattended_session.py
+++ b/tests/test_qrcode_unattended_session.py
@@ -214,6 +214,11 @@ class TestNoAnnouncementWithoutADialog:
 
         assert connect.show_connection_dial_calls == 1
         assert mw.restore_window_calls == 1
+        # Nothing has been closed or announced on this route, so the sound is
+        # the only cue the user gets before the modal takes focus. It is the
+        # other half of the post-halt route's play_sound=False: asserting one
+        # without the other lets the default be flipped with the suite green.
+        assert mw.error_sound.plays == 1
 
 
 class TestNormalRotationStillWorks:
@@ -473,6 +478,14 @@ class TestAPairedInstallBarredByTheGraceWindowStillGetsTheExplanation:
         assert boxes == ["device_logged_out"]
         assert connect.show_connection_dial_calls == 1
         assert mw.restore_window_calls == 1
+        # play_sound=False on this route: the real halt has just played this
+        # very error_sound object and spoken over it, and replaying the same
+        # stream ~0 ms later is heard as one truncated blip, not two cues.
+        # (_FakeMainWindow._halt_unattended_qr_session() plays nothing, so
+        # this counts only what _show_repair_dialog() itself did.) The
+        # MessageBox still carries its own MB_ICONERROR system sound, which
+        # is a different sound and not subject to that restart.
+        assert mw.error_sound.plays == 0
 
     def test_a_never_paired_install_still_skips_the_logged_out_message(self, monkeypatch):
         """The other side of the same routing: with nothing paired there is

--- a/tests/test_qrcode_unattended_session.py
+++ b/tests/test_qrcode_unattended_session.py
@@ -417,6 +417,77 @@ class TestNeverPairedGetsARouteBack:
         assert connect.show_connection_dial_calls == 1
 
 
+class TestAPairedInstallBarredByTheGraceWindowStillGetsTheExplanation:
+    """The one case the startup grace and _REPAIR_DIALOG_CONFIRM_EVENTS
+    changed the behaviour of, and the one nothing else covers: paired,
+    inside the grace window, and a full _UNATTENDED_QR_LIMIT of unattended
+    events.
+
+    TestStartupGraceWindow (tests/test_qrcode_auto_repair_dialog.py) stops at
+    two events, and the flood tests above are all outside the grace window —
+    one with paired=False, the other already past the dialog. In between,
+    every event walks past the proactive branch (withheld by the grace) and
+    reaches the halt with _auto_repair_dialog_shown still False, which is the
+    never-paired route: /close-session, which force-kills without flushing
+    auth, and then the generic pairing dialog with no word about the login
+    that was just lost. Routing that on `paired` instead is what keeps the
+    device_logged_out explanation for the user who has something to re-pair.
+
+    The halt itself must NOT move: it is the half of this protection an
+    account was banned for not having, so neither new condition may delay
+    it."""
+
+    def test_the_halt_still_fires_at_the_limit_and_the_user_is_told_why(self, monkeypatch):
+        boxes = []
+        monkeypatch.setattr(
+            "core.websocket_client.wx.MessageBox",
+            lambda text, *a, **kw: boxes.append(text),
+        )
+        mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)
+        # A (re)connect that has never confirmed a live connection, seconds
+        # old: exactly the window _qr_within_startup_grace() withholds
+        # judgment for. Codes are not deduped on this path, so a boot-time
+        # burst spends the whole limit inside it.
+        mw._wa_connect_announced = False
+        mw._wa_startup_time = time.time()
+        connect = _FakeConnect(mode="qrcode", main_window=mw)
+        s = _Stub(mw, connect)
+
+        for _ in range(WebSocketClient._UNATTENDED_QR_LIMIT - 1):
+            s.on_qrcode_update(QR_EVENT)
+        # Withheld so far — that is what the grace window is for.
+        assert connect.show_connection_dial_calls == 0
+        assert mw.halt_calls == 0
+
+        s.on_qrcode_update(QR_EVENT)
+
+        assert mw.halt_calls == 1
+        assert boxes == ["device_logged_out"]
+        assert connect.show_connection_dial_calls == 1
+        assert mw.restore_window_calls == 1
+
+    def test_a_never_paired_install_still_skips_the_logged_out_message(self, monkeypatch):
+        """The other side of the same routing: with nothing paired there is
+        no logged-out device to explain, and the halt has already played the
+        error sound and said what happened — so that install gets the pairing
+        dialog and no MessageBox, exactly as before."""
+        boxes = []
+        monkeypatch.setattr(
+            "core.websocket_client.wx.MessageBox",
+            lambda text, *a, **kw: boxes.append(text),
+        )
+        mw = _FakeMainWindow(paired=False, pairing_dialog_active=False)
+        connect = _FakeConnect(mode="qrcode", main_window=mw)
+        s = _Stub(mw, connect)
+
+        for _ in range(WebSocketClient._UNATTENDED_QR_LIMIT):
+            s.on_qrcode_update(QR_EVENT)
+
+        assert mw.halt_calls == 1
+        assert boxes == []
+        assert connect.show_connection_dial_calls == 1
+
+
 class TestConnectedSessionStillWins:
     def test_a_live_connection_ignores_the_event_entirely(self):
         mw = _FakeMainWindow(paired=True, pairing_dialog_active=False)


### PR DESCRIPTION
As PRs #156 e #157 passaram por várias rodadas de revisão e ganharam correções de comportamento, testes e comentários. As branches foram rebaseadas e as duas PRs acabaram mergeadas a partir dessa versão rebaseada, **sem** essas correções. O trabalho original está no `main`; o que a revisão produziu não. Esta PR leva essas correções ao `main`.

São nove commits: oito cherry-picks (com `(cherry picked from commit ...)`) mais um de acabamento.

## Comportamento

- **O bloco pós-halt passa a rotear por `paired`.** Sem isso, uma instalação *pareada* que a janela de graça segurou cai no ramo comentado como "nunca pareado": tem a sessão fechada e não recebe a explicação `device_logged_out`, ficando só com "uma sessão foi encerrada" e nada sobre o login perdido ou o re-pareamento que terá de fazer.
- **`_show_repair_dialog(play_sound=...)`, com `False` nas rotas que chegam atrás de um som já tocado.** Tocar o *mesmo* objeto `error_sound` ~0 ms depois não produz duas deixas: o `sound_lib` reinicia o stream e sai um blip truncado, e a fala anterior é cortada pelo anúncio de foco do modal, que repete a mesma informação. É a forma de saída cortada que o trabalho de `focus_cloak` documenta.
- **`qr_within_startup_grace()` extraída para função de módulo**, com o método ficando como leitor dos quatro valores — testável direto, sem `wx.Frame`.

## Testes

Cada um pega uma regressão real, verificada por mutação:

- o ramo do diálogo já dispensado com `paired=True` (a cobertura existente era só `paired=False`, e passa com os dois `if` invertidos — o efeito seria um `MessageBox` novo a cada enxurrada para quem já dispensou);
- as duas ordenações do reset do contador durante um restore, com `finish_restore()` explícito no fake — inclusive a ordenação que *perde* a corrida, fixada como o comportamento real de hoje;
- o custo em códigos pedidos ao WhatsApp, parametrizado — importa porque um stream de códigos que ninguém está olhando já custou o banimento de uma conta;
- o `self._unattended_qr_events = 0` que vive dentro da thread `_restore()`, e que **não tinha teste nenhum**: apagá-lo deixava a suíte inteira verde, e a regressão seria um perfil restaurado que nunca é iniciado, com o usuário offline sem rota de volta;
- da #157, a asserção de que `paired` sobrevive ao 401 — é o campo do qual depende todo o veto a jusante, e sem ela um refactor que perdesse o `pop` mataria o banco no primeiro tick do health check com a suíte verde — mais o stub de `api_post` que impede o teste de alcançar `127.0.0.1:6300`.

## Comentários

Várias afirmações no código estavam factualmente erradas e foram corrigidas contra o código real (inclusive lendo o `host.layer.js` em `node_modules`): a aritmética do custo do halt, os quatro pontos que limpam a janela de graça (eram descritos como três), quem de fato zera o contador, o portão do `loginByCode` no runtime 2.3.2+, e o registro completo da costura entre o re-arme da recuperação de perfil e o contador de flood.

## Nota sobre o transporte

Os commits da #156 foram escritos sobre uma reestruturação de `_handle_unattended_qr()` que **não chegou ao `main`** (o reparo de perfil rodando no primeiro código, com a graça segurando apenas o diálogo). O conteúdo foi re-mirado na estrutura que o `main` realmente tem, em vez de copiar prosa descrevendo código inexistente — cada commit traz uma "Transport note" dizendo o que foi reajustado e por quê. Um teste precisou ser reescrito porque o fenômeno que ele media não existe nesta estrutura; a versão nova mede o que vale aqui e afirma, além disso, que o halt não dispara — o que a original não fazia.

A lacuna que a reestruturação fechava está registrada em #203.

## Verificação

Suíte completa, sem `--run-wx-gui`: **6517 passed**. Cada correção foi verificada por mutação, não por leitura.

Follow-ups relacionados: #198, #199, #200, #201, #202, #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
