### PR TITLE
Decide the local-data wipe from the number, not from whether a token can be resumed

### DIFF
--- a/client/ui/dialogs/connect.py
+++ b/client/ui/dialogs/connect.py
@@ -771,19 +771,19 @@ class Connect:
         # in. Only a token that predates our own minting stands for a real,
         # authenticated session.
         #
-        # Known cost of dropping it, and it is a limitation rather than a
-        # judgement: paired account → QR → back to phone → same number typed
-        # in still ends up wiping the local database, even though `paired`
-        # and the stored WA_phone_number both agree it is the same account
-        # and the history is therefore still valid. The database's validity
-        # depends on the NUMBER, not on which WPPConnect session is alive;
-        # what wipes it is _bg_pairing_flow() keying clear_local_data() on
-        # "is this token reusable", so a missing token drags the wipe along
-        # with it. on_switch_to_qrcode() right below shows the inconsistency
-        # plainly — it preserves on `was_paired` alone, with no number check
-        # at all, while this path has strictly more information and deletes.
-        # The coherent fix is to decide the wipe from the number and drop
-        # that coupling; deliberately out of scope for this change.
+        # Dropping it no longer costs the local database, though it used to,
+        # and the reason is worth keeping: paired account → QR → back to
+        # phone → same number typed in wiped everything, even with `paired`
+        # and the stored WA_phone_number both agreeing it was the same
+        # account. A database's validity depends on the NUMBER, not on which
+        # WPPConnect session is alive, and _bg_pairing_flow() was keying
+        # clear_local_data() on "is this token reusable" — so a missing token
+        # dragged the wipe along with it. on_switch_to_qrcode() right below
+        # showed the inconsistency plainly: it preserves on `was_paired`
+        # alone, with no number check at all, while this path had strictly
+        # more information and deleted. The two questions are now asked
+        # separately — see _is_same_account() — so this capture being
+        # discarded costs only the session resume it was ever about.
         _live_token = self.main_window._get_wa_token()
         if _live_token and _live_token == self._started_new_session_token:
             logging.info(
@@ -1115,6 +1115,46 @@ class Connect:
             wx.MessageBox(f"{self.i18n.t('websocket_init_failed')} {format_exc()}", self.i18n.t("connection_error"), wx.OK | wx.ICON_ERROR)
 
     @staticmethod
+    def _is_same_account(privateinfo: dict, phone_number: str) -> bool:
+        """True when the number just typed is the one the local database
+        belongs to — the question that decides whether it may be wiped.
+
+        Split out of _can_reuse_existing_session() because the two questions
+        it used to answer at once have different answers. Whether a WPPConnect
+        *session* can be resumed depends on holding a token for it; whether
+        the stored history is still this account's depends only on the
+        NUMBER. Asked as one, a missing token dragged the wipe along with it:
+        paired account → QR mode → back to phone → same number typed in still
+        deleted the whole database, because the QR detour deliberately
+        discards the reuse capture (on_switch_to_phone's own comment says why
+        — that token stands for a session that never authenticated) and
+        _close_active_session() had already cleared WA_token. Nothing about
+        either of those says the history stopped belonging to this number.
+
+        Deliberately not weaker than the check it came out of: `paired` is
+        still required, and the digits are still compared exactly. A tolerant
+        comparison is what let +49 211 1234567's session be resumed by
+        somebody typing +49 211 234567.
+
+        Not the final word on identity, and does not need to be — this only
+        decides an upfront guess. MainWindow._wipe_local_data_if_another_number_linked()
+        asks WhatsApp itself which phone actually ended up linked once
+        pairing closes (see show_connection_dial()), and wipes then if they
+        diverge. Being wrong here in the preserving direction costs one
+        deferred wipe; being wrong in the deleting direction costs history
+        that nothing can bring back.
+        """
+        if not isinstance(privateinfo, dict):
+            return False
+        stored_raw = "".join(
+            c for c in (privateinfo.get("WA_phone_number") or "") if c.isdigit()
+        )
+        phone_digits = "".join(c for c in (phone_number or "") if c.isdigit())
+        if not phone_digits or stored_raw != phone_digits:
+            return False
+        return bool(privateinfo.get("paired", False))
+
+    @staticmethod
     def _can_reuse_existing_session(privateinfo: dict, phone_number: str,
                                     existing_token: str) -> bool:
         """True when a stored WPPConnect token is worth reusing for this number.
@@ -1148,15 +1188,8 @@ class Connect:
         comparison is what let the session of +49 211 1234567 be resumed, and
         that account connected, for somebody typing +49 211 234567.
         """
-        if not isinstance(privateinfo, dict):
-            return False
-        stored_raw = "".join(
-            c for c in (privateinfo.get("WA_phone_number") or "") if c.isdigit()
-        )
-        phone_digits = "".join(c for c in (phone_number or "") if c.isdigit())
-        if not phone_digits or stored_raw != phone_digits:
-            return False
-        return bool(existing_token) and bool(privateinfo.get("paired", False))
+        return (Connect._is_same_account(privateinfo, phone_number)
+                and bool(existing_token))
 
     def on_continue(self, event):
         """Phone-number pairing flow (asynchronous to prevent GUI freeze).
@@ -1231,9 +1264,17 @@ class Connect:
                 _instance_exists = self._can_reuse_existing_session(
                     _privateinfo, self.phone_number, existing_token
                 )
+                # Two questions, deliberately no longer one — see
+                # _is_same_account(). A session that cannot be resumed still
+                # has to wait for messages.set, because it will sync from
+                # scratch; only a DIFFERENT account justifies deleting what
+                # is on disk. Keyed together, the phone→QR→phone round trip
+                # wiped a database whose owner had not changed, purely
+                # because the detour left no token to resume.
                 if not _instance_exists:
-                    # New pairing: reset sync flag so we wait for messages.set
+                    # New session: sync from scratch, so wait for messages.set
                     self.main_window.messages_set_completed = False
+                if not self._is_same_account(_privateinfo, self.phone_number):
                     self.main_window.clear_local_data()
 
                 if _instance_exists:

--- a/client/ui/dialogs/connect.py
+++ b/client/ui/dialogs/connect.py
@@ -126,6 +126,19 @@ class Connect:
         # stands for one specific pre-close session, so a pairing attempt
         # clears it as it reads it and a switch back to QR mode drops it.
         self._token_before_mode_switch: str = ""
+
+        # privateinfo["WA_phone_number"] as it stood before this dialog's
+        # current pairing attempt overwrote it, or None when no attempt has.
+        # _bg_pairing_flow() writes that key the instant a phone code
+        # arrives — long before the pairing concludes — and nothing used to
+        # put the previous value back when the attempt was abandoned, so the
+        # key could end up naming a number the local database has nothing to
+        # do with. That was harmless while it only fed
+        # _can_reuse_existing_session(), which also required a token the
+        # abandonment had cleared; it stopped being harmless when
+        # _is_same_account() started deciding the wipe from that key alone.
+        # See _close_active_session(), which restores it.
+        self._phone_number_before_attempt = None
         # Token of a BRAND-NEW WPPConnect session this dialog started itself
         # (empty whenever it reused an existing one, or closed the one it
         # started). Minting a new session overwrites the settings token and,
@@ -703,6 +716,37 @@ class Connect:
             ).start()
 
     def _close_active_session(self, sync=False):
+        # Every route out of an unfinished pairing attempt comes through
+        # here — switching mode either way, Cancel/Escape, Quit — so this is
+        # the one place that has to undo what the attempt wrote to
+        # privateinfo["WA_phone_number"]. Left standing, that number outlives
+        # the attempt that never completed and _is_same_account() reads it as
+        # the local database's owner: type a second number, get a code for
+        # it, abandon, pair that number for real, and its sync lands on top
+        # of the first account's chats, media and voice notes.
+        #
+        # Never after a pairing that actually succeeded, which is what
+        # _wa_connected distinguishes: there the number this attempt wrote is
+        # the correct one and the capture is merely dropped. That is also why
+        # the restore lives here rather than on each caller — a path added
+        # later gets it for free, and missing one is silent.
+        # getattr-guarded like the other dialog state this method reads: the
+        # stubs that bind it unbound carry only what the path under test
+        # touches (tests/test_token_not_logged.py).
+        if getattr(self, "_phone_number_before_attempt", None) is not None:
+            if not getattr(self.main_window, "_wa_connected", False):
+                privateinfo = self.main_window.settings.setdefault("privateinfo", {})
+                logging.info(
+                    "[_close_active_session] Pairing attempt abandoned — "
+                    "restoring the previous WA_phone_number."
+                )
+                if self._phone_number_before_attempt:
+                    privateinfo["WA_phone_number"] = self._phone_number_before_attempt
+                else:
+                    privateinfo.pop("WA_phone_number", None)
+                self.main_window.save_settings()
+            self._phone_number_before_attempt = None
+
         # Retrieve the active token from the dialog state
         token = getattr(self, 'raw_token', '')
         if not token:
@@ -1264,13 +1308,10 @@ class Connect:
                 _instance_exists = self._can_reuse_existing_session(
                     _privateinfo, self.phone_number, existing_token
                 )
-                # Two questions, deliberately no longer one — see
-                # _is_same_account(). A session that cannot be resumed still
-                # has to wait for messages.set, because it will sync from
-                # scratch; only a DIFFERENT account justifies deleting what
-                # is on disk. Keyed together, the phone→QR→phone round trip
-                # wiped a database whose owner had not changed, purely
-                # because the detour left no token to resume.
+                # Two questions, deliberately no longer one — a session
+                # that cannot be resumed still has to sync from scratch,
+                # while only a DIFFERENT account justifies deleting what is
+                # on disk. See _is_same_account().
                 if not _instance_exists:
                     # New session: sync from scratch, so wait for messages.set
                     self.main_window.messages_set_completed = False
@@ -1438,6 +1479,16 @@ class Connect:
                     # Only now persist the token — pairing has actually started.
                     if "privateinfo" not in self.main_window.settings:
                         self.main_window.settings["privateinfo"] = {}
+                    # Remember what this key said before, so an attempt that
+                    # never completes can put it back — see
+                    # _close_active_session(). Captured once per dialog: the
+                    # first attempt is the only one that can still see the
+                    # value the database's real owner left behind.
+                    if self._phone_number_before_attempt is None:
+                        self._phone_number_before_attempt = (
+                            self.main_window.settings["privateinfo"].get(
+                                "WA_phone_number") or ""
+                        )
                     self.main_window.settings["privateinfo"]["WA_phone_number"] = self.phone_number
                     self.main_window._set_wa_token(self.main_window.token)
                     wx.CallAfter(self._on_pairing_code_success, pairing_code)

--- a/tests/test_wipe_decided_by_number.py
+++ b/tests/test_wipe_decided_by_number.py
@@ -1,0 +1,218 @@
+"""Tests for the wipe decision in _bg_pairing_flow(), and the split that made
+it its own question — Connect._is_same_account().
+
+_can_reuse_existing_session() used to answer two things at once: "can this
+WPPConnect session be resumed?" and, by being the only input to
+clear_local_data(), "does this database still belong to whoever is pairing?".
+The first needs a token; the second does not. Asked together, a missing token
+dragged the wipe along with it, and the round trip that produces exactly that
+is ordinary: a paired account switches to QR mode and back to phone. Both
+sides of the detour deliberately leave no reusable token —
+_close_active_session() clears WA_token, and on_switch_to_qrcode() drops the
+mode-switch capture on purpose (it would stand for a session that never
+authenticated) — so Continue with the very same number still deleted the whole
+local database, with `paired` and the stored WA_phone_number both saying it
+was the same account.
+
+The upfront decision is only ever a guess, on both paths: QR pairing cannot
+know which phone is about to scan. MainWindow._wipe_local_data_if_another_number_linked()
+asks WhatsApp itself once pairing closes and wipes then if the linked number
+diverges (tests/test_another_number_linked_wipe.py). That is what makes the
+asymmetry here correct rather than lax: guessing "preserve" wrongly costs one
+deferred wipe, guessing "delete" wrongly costs history nothing can restore.
+
+Connect is a plain class — same approach as
+tests/test_qrcode_repair_preserves_local_data.py, whose fakes this reuses.
+"""
+
+import threading
+
+import ui.dialogs.connect as connect_module
+from ui.dialogs.connect import Connect
+
+from tests.test_qrcode_repair_preserves_local_data import (
+    _FakeMainWindow, _Panel, _Field, _Dial, _Button,
+)
+
+
+NUMBER = "5511999999999"
+
+
+class TestIsSameAccount:
+    """The question on its own: does this number own the local database?"""
+
+    def _pi(self, **kw):
+        base = {"paired": True, "WA_phone_number": NUMBER}
+        base.update(kw)
+        return base
+
+    def test_same_number_on_a_paired_account(self):
+        assert Connect._is_same_account(self._pi(), NUMBER) is True
+
+    def test_no_token_is_needed_to_answer_it(self):
+        """The whole point of the split — the answer does not depend on any
+        session being alive or resumable."""
+        assert Connect._is_same_account(self._pi(), NUMBER) is True
+        assert Connect._can_reuse_existing_session(self._pi(), NUMBER, "") is False
+
+    def test_a_different_number_is_a_different_account(self):
+        assert Connect._is_same_account(self._pi(), "5511888888888") is False
+
+    def test_a_never_paired_account_owns_nothing_to_keep(self):
+        assert Connect._is_same_account(self._pi(paired=False), NUMBER) is False
+
+    def test_the_comparison_stays_exact(self):
+        """A tolerant comparison is what once let +49 211 1234567's session be
+        resumed by somebody typing +49 211 234567."""
+        assert Connect._is_same_account(
+            {"paired": True, "WA_phone_number": "492111234567"}, "49211234567"
+        ) is False
+
+    def test_formatting_of_the_same_number_still_matches(self):
+        assert Connect._is_same_account(
+            {"paired": True, "WA_phone_number": "+55 (11) 99999-9999"}, NUMBER
+        ) is True
+
+    def test_nothing_stored_matches_nothing(self):
+        assert Connect._is_same_account({"paired": True}, NUMBER) is False
+        assert Connect._is_same_account(self._pi(), "") is False
+        assert Connect._is_same_account(None, NUMBER) is False
+
+
+class TestReuseStillNeedsAToken:
+    """The refactor must not have loosened the resume test: everything
+    _can_reuse_existing_session() rejected before, it still rejects."""
+
+    def test_same_account_but_no_token_cannot_resume(self):
+        pi = {"paired": True, "WA_phone_number": NUMBER}
+        assert Connect._can_reuse_existing_session(pi, NUMBER, "") is False
+
+    def test_token_but_a_different_number_cannot_resume(self):
+        pi = {"paired": True, "WA_phone_number": NUMBER}
+        assert Connect._can_reuse_existing_session(pi, "5511888888888", "t") is False
+
+    def test_token_but_never_paired_cannot_resume(self):
+        pi = {"paired": False, "WA_phone_number": NUMBER}
+        assert Connect._can_reuse_existing_session(pi, NUMBER, "t") is False
+
+    def test_same_account_with_a_token_resumes(self):
+        pi = {"paired": True, "WA_phone_number": NUMBER}
+        assert Connect._can_reuse_existing_session(pi, NUMBER, "sess1:h1") is True
+
+
+def _connect_for(mw, typed_number=NUMBER):
+    c = Connect(mw)
+    c.qrcode_panel = _Panel()
+    c.phone_panel = _Panel()
+    c.phone_field = _Field(typed_number)
+    c.connection_dial = _Dial()
+    c.continue_btn = _Button()
+    c._create_instance = lambda token: None
+    return c
+
+
+def _switch_to_qrcode_and_back(c):
+    """The detour that leaves no reusable token behind.
+
+    start_qrcode_connection() is stubbed out: it goes to the network and, on
+    failure, straight to a wx.MessageBox that needs a real wx.App. What this
+    file is about is the state the detour leaves — WA_token cleared by
+    _close_active_session(), the mode-switch capture dropped on purpose — and
+    both of those come from the switch methods themselves. What
+    start_qrcode_connection() does with preserve_local_data is
+    tests/test_qrcode_repair_preserves_local_data.py's subject.
+    """
+    c.start_qrcode_connection = lambda preserve_local_data=False: None
+    c.on_switch_to_qrcode(None)
+    c.on_switch_to_phone(None)
+
+
+def _run_pairing_flow(c, monkeypatch):
+    """Drive on_continue() through the wipe decision and back out again.
+
+    The decision runs before any network call, so failing every request is
+    enough to keep the test to the branch under test instead of waiting 90 s
+    for a phoneCode that will never arrive. _bg_pairing_flow()'s own except
+    clause handles it, and GetApp() answering None is what keeps its error
+    MessageBox from needing a real wx.App.
+    """
+    monkeypatch.setattr(connect_module.wx, "GetApp", lambda: None)
+    monkeypatch.setattr(
+        connect_module, "api_post",
+        lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("no network in tests")),
+    )
+    decided = threading.Event()
+    real_same_account = c._is_same_account
+
+    def _tripwire(privateinfo, phone_number):
+        # Wraps rather than replaces: the real answer is what the assertions
+        # are about; this only records that the decision was reached at all,
+        # so a flow that died earlier fails loudly instead of silently
+        # asserting "clear_local_data was not called".
+        answer = real_same_account(privateinfo, phone_number)
+        decided.set()
+        return answer
+
+    c._is_same_account = _tripwire
+    c.on_continue(None)
+    assert decided.wait(5), "the pairing flow never reached the wipe decision"
+
+
+class TestTheRoundTripKeepsItsHistory:
+    """paired → QR → back to phone → the same number typed in."""
+
+    def test_no_wipe_when_the_number_has_not_changed(self, monkeypatch):
+        mw = _FakeMainWindow(paired=True, token="sess1:hash1")
+        mw.settings["privateinfo"]["WA_phone_number"] = NUMBER
+        c = _connect_for(mw)
+
+        _switch_to_qrcode_and_back(c)
+        assert mw._get_wa_token() == "", "precondition: no token to resume"
+
+        before = mw.clear_local_data_calls
+        _run_pairing_flow(c, monkeypatch)
+
+        assert mw.clear_local_data_calls == before
+
+    def test_a_different_number_still_wipes(self, monkeypatch):
+        """The protection is about identity, not about being lenient."""
+        mw = _FakeMainWindow(paired=True, token="sess1:hash1")
+        mw.settings["privateinfo"]["WA_phone_number"] = NUMBER
+        c = _connect_for(mw, typed_number="5511888888888")
+
+        _switch_to_qrcode_and_back(c)
+
+        before = mw.clear_local_data_calls
+        _run_pairing_flow(c, monkeypatch)
+
+        assert mw.clear_local_data_calls == before + 1
+
+    def test_a_never_paired_account_still_wipes(self, monkeypatch):
+        """Nothing to lose, and a leftover from an abandoned pairing is not
+        history worth keeping."""
+        mw = _FakeMainWindow(paired=False, token="")
+        mw.settings["privateinfo"]["WA_phone_number"] = NUMBER
+        c = _connect_for(mw)
+
+        before = mw.clear_local_data_calls
+        _run_pairing_flow(c, monkeypatch)
+
+        assert mw.clear_local_data_calls == before + 1
+
+
+class TestWaitingForTheSyncIsStillKeyedOnTheSession:
+    """The two flags were split apart on purpose: a session that cannot be
+    resumed syncs from scratch and must still wait for messages.set, whether
+    or not the account changed."""
+
+    def test_the_same_account_on_a_new_session_still_waits(self, monkeypatch):
+        mw = _FakeMainWindow(paired=True, token="sess1:hash1")
+        mw.settings["privateinfo"]["WA_phone_number"] = NUMBER
+        mw.messages_set_completed = True
+        c = _connect_for(mw)
+
+        _switch_to_qrcode_and_back(c)
+        _run_pairing_flow(c, monkeypatch)
+
+        assert mw.messages_set_completed is False
+        assert mw.clear_local_data_calls == 0

--- a/tests/test_wipe_decided_by_number.py
+++ b/tests/test_wipe_decided_by_number.py
@@ -132,11 +132,19 @@ def _run_pairing_flow(c, monkeypatch):
 
     The decision runs before any network call, so failing every request is
     enough to keep the test to the branch under test instead of waiting 90 s
-    for a phoneCode that will never arrive. _bg_pairing_flow()'s own except
-    clause handles it, and GetApp() answering None is what keeps its error
-    MessageBox from needing a real wx.App.
+    for a phoneCode that will never arrive; _bg_pairing_flow()'s own except
+    clause handles it.
+
+    on_continue() rebinds wx.GetApp on the module itself — going through
+    monkeypatch keeps that out of the rest of the suite, the same reason
+    tests/test_qrcode_repair_preserves_local_data.py gives. CallAfter goes
+    with it: there is no wx.App in this file, so the marshalling
+    _bg_pairing_flow()'s failure path does would assert inside the pairing
+    thread and surface as a PytestUnhandledThreadExceptionWarning that has
+    nothing to do with what is being tested.
     """
     monkeypatch.setattr(connect_module.wx, "GetApp", lambda: None)
+    monkeypatch.setattr(connect_module.wx, "CallAfter", lambda *a, **kw: None)
     monkeypatch.setattr(
         connect_module, "api_post",
         lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("no network in tests")),
@@ -186,6 +194,13 @@ class TestTheRoundTripKeepsItsHistory:
         _run_pairing_flow(c, monkeypatch)
 
         assert mw.clear_local_data_calls == before + 1
+        # The whole safety argument for splitting the two flags is that the
+        # wipe branch is a SUBSET of the reset branch — a different account
+        # can never have a resumable session, so everything that reaches the
+        # wipe has already passed the reset. This is that proof as a test:
+        # it is what fails if someone later re-keys the reset on
+        # _is_same_account() for symmetry.
+        assert mw.messages_set_completed is False
 
     def test_a_never_paired_account_still_wipes(self, monkeypatch):
         """Nothing to lose, and a leftover from an abandoned pairing is not
@@ -216,3 +231,95 @@ class TestWaitingForTheSyncIsStillKeyedOnTheSession:
 
         assert mw.messages_set_completed is False
         assert mw.clear_local_data_calls == 0
+
+
+class TestAnAbandonedAttemptDoesNotRenameTheDatabasesOwner:
+    """_bg_pairing_flow() writes privateinfo["WA_phone_number"] the instant a
+    phone code arrives — long before the pairing concludes — and nothing used
+    to put the previous value back when the attempt was abandoned.
+
+    Harmless while that key only fed _can_reuse_existing_session(), which also
+    required a token the abandonment had cleared. Not harmless once
+    _is_same_account() decides the wipe from it alone: account A is paired,
+    the user types B, gets a code, abandons, then pairs B for real — and the
+    stale key says "same account", so B's sync lands on top of A's chats,
+    media and voice notes. The backstop only catches that when
+    WA_phone_number_linked already exists (main.py's another_number_check
+    learns the number instead of deleting when it does not), so this must not
+    depend on it.
+    """
+
+    def _dialog_that_got_a_code_for(self, mw, number):
+        """The state an attempt leaves behind once a code has arrived."""
+        c = _connect_for(mw, typed_number=number)
+        privateinfo = mw.settings["privateinfo"]
+        c._phone_number_before_attempt = privateinfo.get("WA_phone_number") or ""
+        privateinfo["WA_phone_number"] = number
+        return c
+
+    def test_the_previous_number_comes_back_when_the_attempt_is_abandoned(self):
+        mw = _FakeMainWindow(paired=True, token="sess1:hash1")
+        mw.settings["privateinfo"]["WA_phone_number"] = NUMBER
+        c = self._dialog_that_got_a_code_for(mw, "5511888888888")
+
+        c._close_active_session()
+
+        assert mw.settings["privateinfo"]["WA_phone_number"] == NUMBER
+
+    def test_the_other_number_is_then_read_as_another_account(self):
+        """The point of restoring it: the wipe decision has to see the number
+        the database actually belongs to."""
+        mw = _FakeMainWindow(paired=True, token="sess1:hash1")
+        mw.settings["privateinfo"]["WA_phone_number"] = NUMBER
+        c = self._dialog_that_got_a_code_for(mw, "5511888888888")
+
+        c._close_active_session()
+
+        assert c._is_same_account(
+            mw.settings["privateinfo"], "5511888888888") is False
+        assert c._is_same_account(mw.settings["privateinfo"], NUMBER) is True
+
+    def test_a_completed_pairing_keeps_its_own_number(self):
+        """_wa_connected is what separates "abandoned" from "succeeded": the
+        number a successful attempt wrote is the correct one, and restoring
+        over it would rename a database that had just been paired."""
+        mw = _FakeMainWindow(paired=True, token="sess1:hash1")
+        mw.settings["privateinfo"]["WA_phone_number"] = NUMBER
+        c = self._dialog_that_got_a_code_for(mw, "5511888888888")
+        mw._wa_connected = True
+
+        c._close_active_session()
+
+        assert mw.settings["privateinfo"]["WA_phone_number"] == "5511888888888"
+
+    def test_an_account_that_had_no_number_gets_the_key_removed_again(self):
+        """Restoring "" as a value would leave a key that reads as a real
+        stored number to anything comparing digits."""
+        mw = _FakeMainWindow(paired=False, token="")
+        c = self._dialog_that_got_a_code_for(mw, "5511888888888")
+
+        c._close_active_session()
+
+        assert "WA_phone_number" not in mw.settings["privateinfo"]
+
+    def test_the_restore_happens_only_once(self):
+        """One-shot, like the mode-switch capture: a second close must not
+        put the number back over whatever legitimately replaced it."""
+        mw = _FakeMainWindow(paired=True, token="sess1:hash1")
+        mw.settings["privateinfo"]["WA_phone_number"] = NUMBER
+        c = self._dialog_that_got_a_code_for(mw, "5511888888888")
+
+        c._close_active_session()
+        mw.settings["privateinfo"]["WA_phone_number"] = "5511777777777"
+        c._close_active_session()
+
+        assert mw.settings["privateinfo"]["WA_phone_number"] == "5511777777777"
+
+    def test_nothing_is_touched_when_no_attempt_wrote_anything(self):
+        mw = _FakeMainWindow(paired=True, token="sess1:hash1")
+        mw.settings["privateinfo"]["WA_phone_number"] = NUMBER
+        c = _connect_for(mw)
+
+        c._close_active_session()
+
+        assert mw.settings["privateinfo"]["WA_phone_number"] == NUMBER


### PR DESCRIPTION
`Connect._can_reuse_existing_session()` answered two questions at once: "can this WPPConnect session be resumed?" and, by being the only input to `clear_local_data()` in `_bg_pairing_flow()`, "does this database still belong to whoever is pairing?". The first needs a token; the second does not.

Asked together, a missing token dragged the wipe along with it — and the round trip that produces exactly that is ordinary: **a paired account switches to QR mode and back to phone.** Both sides of the detour deliberately leave no reusable token (`_close_active_session()` clears `WA_token`, and `on_switch_to_qrcode()` drops the mode-switch capture because it would stand for a session that never authenticated), so Continue with the very same number deleted the whole local database, with `paired` and the stored `WA_phone_number` both saying it was the same account. `on_switch_to_phone()`'s own comment named this as a known limitation and left the fix out of scope; this is that fix.

`_is_same_account()` now asks only the identity question — no token, `paired` still required, digits still compared exactly (the +49 211 1234567 regression that comment guards is carried over verbatim). `_can_reuse_existing_session()` becomes it plus the token, which is the same conjunction reordered, so no input behaves differently.

The two flags are split on purpose: a session that cannot be resumed still syncs from scratch and still waits for `messages.set`; only a *different* account justifies deleting what is on disk. That is safe rather than merely likely — `_instance_exists` is `_is_same_account(...) ∧ bool(token)`, so everything reaching the wipe has already passed the reset, and a test pins that coupling.

**The upfront decision is only ever a guess on both paths** — QR pairing cannot know which phone is about to scan. `MainWindow._wipe_local_data_if_another_number_linked()` asks WhatsApp itself which number ended up linked once pairing closes, and wipes then if it diverges. That is what makes the asymmetry correct rather than lax: guessing "preserve" wrongly costs one deferred wipe, guessing "delete" wrongly costs history nothing can bring back.

## Second commit: closing the stale-number window this opened

Making `WA_phone_number` the sole upfront gate exposed a property `main.py:11496` already documented: `_bg_pairing_flow()` writes that key the instant a phone code arrives — long before pairing concludes — and nothing put the previous value back when the attempt was abandoned.

Harmless while it only fed `_can_reuse_existing_session()`, which also required a token the abandonment had cleared. Not harmless once it decides the wipe alone: account A is paired, the user types B, gets a code, abandons, then pairs B for real — the stale key reads "same account" and B's sync lands on top of A's chats, media and voice notes. The backstop only catches that when `WA_phone_number_linked` already exists; without it, `another_number_check` learns the number instead of deleting, and the two accounts stay merged.

The restore lives in `_close_active_session()`, which every route out of an unfinished attempt goes through (mode switch either way, Cancel/Escape, Quit) — a path added later gets it for free, and missing one would be silent. Never after a pairing that succeeded, which `_wa_connected` distinguishes.

## Tests

`tests/test_wipe_decided_by_number.py`, 21 tests: `_is_same_account()` in isolation, `_can_reuse_existing_session()` still rejecting everything it rejected, the phone→QR→phone round trip driving the real `on_continue()` (same number preserves, different number wipes, never-paired wipes), and the abandoned-attempt restore including the completed-pairing case that must *not* restore.

Verified the tests fail against the unfixed code rather than passing either way: reverting the decision split fails two of them, and disabling the restore fails three more.

Full suite: 6615 passed. The 18 failures on my machine are all `client/api` ↔ `client/api_patches` drift (git-ignored, stale locally); this diff touches no Node file.