### PR TITLE
Clear _verified_activity on an account-switch wipe too

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -14458,6 +14458,13 @@ class MainWindow(wx.Frame):
             # and keeps nothing else here either), so this line touches only
             # the account switch.
             self._forget_media_failures()
+            # Same family by origin as everything above (fed by
+            # _note_verified_activity(), consulted by
+            # local_history_behind_server() as a floor), inert here today
+            # only because it is deliberately never persisted — clearing it
+            # anyway keeps it out of the same leak class the moment that
+            # changes, rather than relying on that being true forever.
+            self._verified_activity = {}
 
         db_emptied = False
         try:

--- a/tests/test_clear_local_data_metadata.py
+++ b/tests/test_clear_local_data_metadata.py
@@ -100,6 +100,7 @@ class _Stub:
         self._media_failed_ids = {"3EB0ABC": 1700000000.0}
         self._chat_verified_at = {"5511988887777@s.whatsapp.net": 1700000000}
         self._opened_conversations = {"5511988887777@s.whatsapp.net"}
+        self._verified_activity = {"5511988887777@s.whatsapp.net": 1700000000}
 
         # Backfill/LID state the method already cleared before this change.
         self._sync_run_id = 3
@@ -179,7 +180,12 @@ _METADATA = ("_deleted_chats", "_archived_chats", "_pinned_chats",
              # "Synchronizing WhatsApp…"/"Sync paused" pair on B's own lock
              # screen for a conversation B never opened (issue #108), then
              # _note_conversation_opened() makes A's JIDs durable on B's disk.
-             "_opened_conversations")
+             "_opened_conversations",
+             # Same family and same origin as _chat_verified_at, just never
+             # persisted (issue #201) — inert today only because nothing
+             # currently writes it to disk, so clearing it here keeps it out
+             # of the same leak the moment that changes.
+             "_verified_activity")
 
 
 class TestAnAccountSwitchClearsTheMetadataInMemoryToo:


### PR DESCRIPTION
Fixes #201.

`clear_local_data(wipe_metadata=True)` resets ~18 in-memory collections when WinZapp detects an account switch, but `_verified_activity`, populated by _note_verified_activity(), consulted by local_history_behind_server() — was missing from that block. It's harmless today only because it's never persisted and the corrective full resync rewrites every JID the new account actually has, but the gap would become a real cross-account leak the day it's ever persisted, so it's added alongside its ~18 neighbors for consistency.