### PR TITLE
Re-arm profile recovery and reset the QR-flood counter together

### DIFF
--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -200,42 +200,38 @@ class WebSocketClient:
     # line the fake there stands in for.
     #
     # Once per recovery, and a launch is no longer bounded to one of those:
-    # _recover_suspect_profile() latches, but a session reporting CONNECTED
-    # hands that latch straight back (main.py's
-    # _note_status_for_profile_health() — a snapshot that connected has
-    # proved itself and may be restored again if it breaks later in the same
-    # run). It still does not widen this window, because the CONNECTED
-    # reading that re-arms the recovery is the same one
-    # _set_wa_connected(True, ...) acts on, and that zeroes this counter and
-    # clears the halt latch anyway: the second allowance can only ever be
-    # spent on a second flood, which had its own full ceiling regardless.
-    # The one seam is that the re-arm reads the status string alone while the
-    # counter reset also needs the live isConnected() probe to agree, so a
-    # CONNECTED the probe refuses gives the recovery back without giving the
-    # counter back. KNOWN, not fixed here, and written out because the cost is
-    # not the extra codes it was found for.
+    # _recover_suspect_profile() latches, but a connection that comes back up
+    # hands that latch straight back (main.py's _set_wa_connected() — a
+    # snapshot that connected has proved itself and may be restored again if
+    # it breaks later in the same run). That does not widen this window: the
+    # re-arm now lives in the same branch as this counter's own
+    # `self._unattended_qr_events = 0`, so the two are one event by
+    # construction, and the second allowance can only ever be spent on a
+    # second flood, which had its own full ceiling regardless.
     #
-    # A second recovery can therefore start mid-flood, on an event the counter
-    # has already counted — and _handle_unattended_qr() returns the moment it
-    # starts (`if mw._recover_suspect_profile(...): return`, above the halt).
-    # If that lands on the very event where `seen` reached
-    # _UNATTENDED_QR_LIMIT, the halt is not postponed: it stops being
-    # evaluated at all, because the test there is `==` and `seen` only grows
-    # from there. The only thing that makes it reachable again is a zeroing,
-    # and the only zeroing on this path is the restore succeeding — which
-    # restarts the count from 0 and pays the whole ceiling over again, rather
-    # than halting. A restore that starts and then fails never gets even that.
-    # What bounds the damage is the dialog: the branch that call sits in has
-    # already cleared the startup grace and this counter, so the next code
-    # takes the refusal straight into _show_repair_dialog() and the flood ends
-    # there. Same order of magnitude as the allowance above, which is why it
-    # is an issue and not a blocker.
+    # It used to live on the bare status string in
+    # _note_status_for_profile_health(), which is a weaker reading — the live
+    # isConnected() probe had not agreed yet. A CONNECTED the probe went on
+    # to refuse gave the recovery back without giving the counter back, so a
+    # second recovery could start mid-flood on an event the counter had
+    # already counted; _handle_unattended_qr() returns the moment one starts
+    # (`if mw._recover_suspect_profile(...): return`, above the halt), and
+    # landing on the very event where `seen` reached _UNATTENDED_QR_LIMIT
+    # stopped the halt being evaluated at all rather than postponing it,
+    # because that test is `==` and `seen` only grows. Fixed in #209 by
+    # moving the re-arm to the probe-agreeing branch; the seam this paragraph
+    # describes is closed, and the paragraph is kept because the shape is
+    # worth recognising if either half is ever moved again.
     #
-    # The fix that works is to move the re-arm into _set_wa_connected()
-    # (main.py), beside its own `self._unattended_qr_events = 0`: it runs on
-    # the same poll, right after the probe has agreed, making the re-arm and
-    # the reset one event — which is the property this comment already claims.
-    # Gating the re-arm on _wa_connected instead is the obvious alternative
+    # Note what did NOT move with it: the generation ladder
+    # (_profile_recovery_generation, which chooses WHICH snapshot a restore
+    # reaches for) still resets on the status-string reading, deliberately —
+    # it never interacts with this counter, and it needs to be re-asserted on
+    # every poll rather than once per transition to survive a launch whose
+    # pairing completes before prepare_sync() has opened the database. See
+    # main.py's comment at that call site.
+    #
+    # Gating the re-arm on _wa_connected instead was the obvious alternative
     # and does not work: it delays the recovery by a whole poll (~30 s) and
     # breaks the case it was added for — _note_status_for_profile_health()
     # measured 11 s between a restored profile connecting and a superseded

--- a/client/main.py
+++ b/client/main.py
@@ -4582,6 +4582,37 @@ class MainWindow(wx.Frame):
             self._qr_flood_halted = False
             self._auto_offline = False
             self._offline_announce_deferred = False
+            # Re-arm profile recovery in the same event that zeroes the QR
+            # counter above, not on the bare status string
+            # _note_status_for_profile_health() reads earlier in the same
+            # poll. createSessionUtil.start() can promote a session to
+            # CONNECTED on its own state listener before isConnected() ever
+            # agrees ("the event wins") — reading the string there re-armed
+            # recovery on a CONNECTED the probe was about to refuse, without
+            # resetting the counter this method only just zeroed above. A
+            # second recovery could then start mid-flood, on an event the
+            # counter had already counted, and the caller (on_qrcode_update())
+            # returns as soon as recovery starts — landing exactly on the
+            # event where seen == _UNATTENDED_QR_LIMIT stops the halt from
+            # ever being evaluated for the rest of that flood, since seen only
+            # grows from there (issue #202). Living here instead means both
+            # only ever happen together, on the one event this method already
+            # treats as the real online transition.
+            if self._profile_recovery_generation():
+                # Whatever was put back is working. The ladder starts over,
+                # so a future break restores the newest snapshot first again.
+                self._set_profile_recovery_generation(0)
+            if getattr(self, "_profile_recovery_attempted", False):
+                # A restore that reached here has proved the snapshot good,
+                # so the once-per-launch budget it spent is earned back —
+                # see _recover_suspect_profile()'s own docstring for the
+                # measured case this relaxes (11 s between a restored
+                # profile connecting and a superseded session start
+                # force-killing its browser).
+                logging.info("[profile-recovery] the restored profile "
+                             "connected — allowing another recovery if it "
+                             "breaks again this launch.")
+                self._profile_recovery_attempted = False
             self._apply_offline_state()
             logging.info("[connection] WhatsApp connection is up (%s)", reason or "checked")
             # Earliest moment /send-capabilities can answer anything: the
@@ -8816,30 +8847,14 @@ class MainWindow(wx.Frame):
                 from core.profile_recovery import ProfileHealthTracker
                 tracker = self._profile_health = ProfileHealthTracker()
             paired = bool(self.settings.get("privateinfo", {}).get("paired"))
-            if (status or "").upper() == "CONNECTED":
-                if self._profile_recovery_generation():
-                    # Whatever was put back is working. The ladder starts over,
-                    # so a future break restores the newest snapshot first again.
-                    self._set_profile_recovery_generation(0)
-                if getattr(self, "_profile_recovery_attempted", False):
-                    # A restore that reached CONNECTED has proved the snapshot
-                    # good, so the once-per-launch budget it spent is earned
-                    # back. Measured live: a restore connected and began
-                    # syncing at 00:55:51, a superseded session start
-                    # force-killed its browser 11 s later, and the relaunch
-                    # found a profile WhatsApp then logged out of — with the
-                    # only recovery of the launch already spent, so the user
-                    # was sent to the pairing dialog with a good snapshot
-                    # still sitting on disk.
-                    #
-                    # The bound this relaxes exists to stop a restore loop on a
-                    # snapshot that does not work. One that connected is not
-                    # that snapshot, and nothing here can loop without a
-                    # CONNECTED in between.
-                    logging.info("[profile-recovery] the restored profile "
-                                 "connected — allowing another recovery if it "
-                                 "breaks again this launch.")
-                    self._profile_recovery_attempted = False
+            # The CONNECTED re-arm that used to live here (clearing
+            # _profile_recovery_attempted / the generation ladder) moved to
+            # _set_wa_connected()'s own "connection just came back up"
+            # branch — this status string alone does not mean the live
+            # isConnected() probe agrees, and re-arming on it regardless
+            # used to let a second profile recovery start mid QR-flood on an
+            # event the flood counter had already counted (issue #202). See
+            # the comment there for the failure this was decoupled from.
             if tracker.note_status(status, paired=paired):
                 self._recover_suspect_profile()
         except Exception:

--- a/client/main.py
+++ b/client/main.py
@@ -4585,9 +4585,9 @@ class MainWindow(wx.Frame):
             self._auto_offline = False
             self._offline_announce_deferred = False
             # Re-arm profile recovery in the same event that zeroes the QR
-            # counter above, not on the bare status string
-            # _note_status_for_profile_health() reads earlier in the same
-            # poll. createSessionUtil.start() can promote a session to
+            # counter above, rather than on the bare status string
+            # _note_status_for_profile_health() used to read for this earlier
+            # in the same poll. createSessionUtil.start() can promote a session to
             # CONNECTED on its own state listener before isConnected() ever
             # agrees ("the event wins") — reading the string there re-armed
             # recovery on a CONNECTED the probe was about to refuse, without
@@ -4600,21 +4600,35 @@ class MainWindow(wx.Frame):
             # grows from there (issue #202). Living here instead means both
             # only ever happen together, on the one event this method already
             # treats as the real online transition.
-            if self._profile_recovery_generation():
-                # Whatever was put back is working. The ladder starts over,
-                # so a future break restores the newest snapshot first again.
-                self._set_profile_recovery_generation(0)
-            if getattr(self, "_profile_recovery_attempted", False):
-                # A restore that reached here has proved the snapshot good,
-                # so the once-per-launch budget it spent is earned back —
-                # see _recover_suspect_profile()'s own docstring for the
-                # measured case this relaxes (11 s between a restored
-                # profile connecting and a superseded session start
-                # force-killing its browser).
-                logging.info("[profile-recovery] the restored profile "
-                             "connected — allowing another recovery if it "
-                             "breaks again this launch.")
-                self._profile_recovery_attempted = False
+            # Wrapped, and not defensively: its old home was inside
+            # _note_status_for_profile_health()'s blanket handler AND
+            # check_wa_connection_http()'s own wrapper, whose comment states
+            # the invariant — a bug in a diagnostic must never change the
+            # connection verdict. Here it would: this runs inside the same
+            # try: whose handler ends in _set_wa_connected(False, ...), so a
+            # raise would flip a healthy connection to offline AND abandon
+            # the rest of this branch (offline state, connected sound,
+            # _wa_connect_announced, trigger_sync_if_needed) halfway. The
+            # invariant was structural before the move; this keeps it.
+            #
+            # Only the recovery budget is re-armed here. The generation
+            # ladder stays on the status-string reading in
+            # _note_status_for_profile_health() — see the comment there for
+            # what it would cost to move it.
+            try:
+                if getattr(self, "_profile_recovery_attempted", False):
+                    # A restore that reached here has proved the snapshot
+                    # good, so the once-per-launch budget it spent is earned
+                    # back — see _recover_suspect_profile()'s own docstring
+                    # for the measured case this relaxes (11 s between a
+                    # restored profile connecting and a superseded session
+                    # start force-killing its browser).
+                    logging.info("[profile-recovery] the restored profile "
+                                 "connected — allowing another recovery if it "
+                                 "breaks again this launch.")
+                    self._profile_recovery_attempted = False
+            except Exception:
+                logging.exception("[profile-recovery] re-arm failed (non-fatal)")
             self._apply_offline_state()
             logging.info("[connection] WhatsApp connection is up (%s)", reason or "checked")
             # Earliest moment /send-capabilities can answer anything: the
@@ -8930,14 +8944,33 @@ class MainWindow(wx.Frame):
                 from core.profile_recovery import ProfileHealthTracker
                 tracker = self._profile_health = ProfileHealthTracker()
             paired = bool(self.settings.get("privateinfo", {}).get("paired"))
-            # The CONNECTED re-arm that used to live here (clearing
-            # _profile_recovery_attempted / the generation ladder) moved to
-            # _set_wa_connected()'s own "connection just came back up"
-            # branch — this status string alone does not mean the live
-            # isConnected() probe agrees, and re-arming on it regardless
-            # used to let a second profile recovery start mid QR-flood on an
-            # event the flood counter had already counted (issue #202). See
-            # the comment there for the failure this was decoupled from.
+            # Only HALF of what used to happen here moved out. Clearing
+            # _profile_recovery_attempted went to _set_wa_connected()'s own
+            # "connection just came back up" branch, because this status
+            # string alone does not mean the live isConnected() probe agrees,
+            # and re-arming the recovery budget on it regardless let a second
+            # recovery start mid QR-flood on an event the flood counter had
+            # already counted (issue #202).
+            #
+            # The generation ladder deliberately stays. It never interacts
+            # with _unattended_qr_events at all — it only chooses WHICH
+            # snapshot a restore reaches for — so #202's argument does not
+            # reach it, and moving it costs a property it depends on. It is
+            # re-asserted on every CONNECTED poll rather than once per
+            # transition, which is what lets it self-heal on a launch where
+            # the write could not land: a manual re-pair completes inside
+            # Connect.show_connection_dial(), which runs BEFORE
+            # prepare_sync() opens the database, so the write
+            # _set_profile_recovery_generation() would do there is a silent
+            # no-op (see its own db guard) — and a transition-only reset
+            # never runs again for the rest of that launch, leaving a stale
+            # ladder to send the next break at a day-old .prev snapshot
+            # instead of the newest one. Idempotent and cheap, so paying for
+            # it every poll is the right trade.
+            if (status or "").upper() == "CONNECTED" and self._profile_recovery_generation():
+                # Whatever was put back is working. The ladder starts over,
+                # so a future break restores the newest snapshot first again.
+                self._set_profile_recovery_generation(0)
             if tracker.note_status(status, paired=paired):
                 self._recover_suspect_profile()
         except Exception:

--- a/tests/test_disconnect_ignores_stale_connected.py
+++ b/tests/test_disconnect_ignores_stale_connected.py
@@ -58,6 +58,12 @@ class _Stub:
         self._self_inflicted_teardown_expected = (
             MainWindow._self_inflicted_teardown_expected.__get__(self))
         self._WA_STARTUP_GRACE_SECONDS = MainWindow._WA_STARTUP_GRACE_SECONDS
+        # Not what this file is testing — a real connect just needs these two
+        # to exist so _set_wa_connected()'s own profile-recovery re-arm
+        # (issue #202, see tests/test_qr_flood_rearm_counter.py) doesn't
+        # AttributeError here.
+        self._profile_recovery_generation = lambda: 0
+        self._set_profile_recovery_generation = lambda value: None
 
         self.settings = {}
         self.token = token

--- a/tests/test_no_offline_during_wpp_update.py
+++ b/tests/test_no_offline_during_wpp_update.py
@@ -74,6 +74,11 @@ class _Stub:
     _set_wa_connected = MainWindow._set_wa_connected
     _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
     _reset_startup_probe = MainWindow._reset_startup_probe
+    # Not what this file is testing — a real connect just needs these two to
+    # exist so _set_wa_connected()'s own profile-recovery re-arm (issue #202,
+    # see tests/test_qr_flood_rearm_counter.py) doesn't AttributeError here.
+    _profile_recovery_generation = lambda self: 0
+    _set_profile_recovery_generation = lambda self, value: None
     # The real recompute, not a spy: self.offline_mode is precisely what
     # MessageQueue._run reads before sending, so the tests assert the thing
     # that actually holds the message rather than a flag they invented.

--- a/tests/test_profile_recovery_wiring.py
+++ b/tests/test_profile_recovery_wiring.py
@@ -321,6 +321,18 @@ class TestARestoreThatConnectedEarnsAnotherChance:
 
     The bound exists to stop a restore loop on a snapshot that does not work.
     A snapshot that reached CONNECTED is not that snapshot.
+
+    The re-arm itself (clearing _profile_recovery_attempted and the
+    generation ladder) used to happen right here, inside
+    _note_status_for_profile_health(), triggered by the bare status string.
+    It moved to _set_wa_connected()'s own "connection just came back up"
+    branch (issue #202 — a CONNECTED the live isConnected() probe was about
+    to refuse could re-arm recovery without the QR-flood counter it must
+    stay in lockstep with resetting alongside it; see
+    tests/test_qr_flood_rearm_counter.py for that half). What is pinned here
+    is only _recover_suspect_profile()'s own once-per-launch bound —
+    _profile_recovery_attempted is set directly to stand in for whichever
+    caller re-armed it.
     """
 
     def test_the_budget_is_spent_by_a_first_recovery(self, monkeypatch):
@@ -331,11 +343,16 @@ class TestARestoreThatConnectedEarnsAnotherChance:
         MainWindow._recover_suspect_profile(stub)
         assert stub._profile_recovery_attempted is True
 
-    def test_a_connection_gives_it_back(self):
+    def test_a_connected_status_alone_no_longer_rearms_it_here(self):
+        """Regression guard for the move described in the class docstring:
+        this status-observer path must not duplicate the re-arm any more,
+        or a CONNECTED the probe later refuses would re-arm recovery again
+        exactly as issue #202 described — just from this call site instead
+        of the old one."""
         stub = _Stub()
         stub._profile_recovery_attempted = True
         _note(stub, "CONNECTED")
-        assert stub._profile_recovery_attempted is False
+        assert stub._profile_recovery_attempted is True
 
     def test_a_second_break_after_that_connection_recovers_again(self, monkeypatch):
         stub = _Stub()
@@ -345,12 +362,11 @@ class TestARestoreThatConnectedEarnsAnotherChance:
                             lambda *a, **kw: types.SimpleNamespace(start=lambda: None))
         assert MainWindow._recover_suspect_profile(stub) is True
         assert MainWindow._recover_suspect_profile(stub) is False
-        _note(stub, "CONNECTED")
+        stub._profile_recovery_attempted = False  # what _set_wa_connected() now does
         assert MainWindow._recover_suspect_profile(stub) is True
 
     def test_without_a_connection_it_still_runs_once(self, monkeypatch):
-        """The loop guard is intact: nothing here can re-arm without a
-        CONNECTED in between."""
+        """The loop guard is intact: nothing here can re-arm on its own."""
         stub = _Stub()
         monkeypatch.setattr("core.profile_recovery.has_snapshot",
                             lambda *a, **kw: True)

--- a/tests/test_qr_flood_rearm_counter.py
+++ b/tests/test_qr_flood_rearm_counter.py
@@ -45,6 +45,14 @@ class _I18n:
         return key
 
 
+class _BoomOnBool:
+    """Raises when the re-arm tests it, standing in for any failure inside
+    the wrapped block."""
+
+    def __bool__(self):
+        raise RuntimeError("diagnostic is broken")
+
+
 class _Stub:
     # The first confirmed connection of a session also kicks off the
     # send-capabilities probe on a background thread — real HTTP, and not
@@ -162,13 +170,49 @@ class TestTheRearmAndTheCounterResetTogether:
         assert s._unattended_qr_events == 0
         assert s._profile_recovery_attempted is False
 
-    def test_the_generation_ladder_resets_alongside_them_too(self):
+    def test_the_generation_ladder_is_deliberately_left_behind(self):
+        """Only the recovery BUDGET moved here. The generation ladder — which
+        chooses WHICH snapshot a restore reaches for — stays on the
+        status-string reading in _note_status_for_profile_health(), and this
+        pins that on purpose rather than by omission.
+
+        #202 is about the budget racing the flood counter. The ladder never
+        touches _unattended_qr_events at all, so that argument does not reach
+        it — and moving it costs a property it depends on: it has to be
+        re-asserted on EVERY CONNECTED poll, not once per transition. A manual
+        re-pair completes inside Connect.show_connection_dial(), which runs
+        before prepare_sync() opens the database, so the write here would be a
+        silent no-op (_set_profile_recovery_generation() guards on self.db) —
+        and with a transition-only reset nothing would clear it again for the
+        rest of that launch, sending the next break at a day-old .prev
+        snapshot instead of the newest one. See
+        TestTheLadderStillResetsOnTheStatusReading below for the other half.
+        """
         s = _Stub()
         s._recovery_generation = 2
 
         s._set_wa_connected(True, "status-session CONNECTED")
 
-        assert s._recovery_generation == 0
+        assert s._recovery_generation == 2
+        # ...while the two that DID move still fire on this same event.
+        assert s._profile_recovery_attempted is False
+        assert s._unattended_qr_events == 0
+
+    def test_a_broken_generation_read_cannot_take_the_connection_offline(self):
+        """The block is wrapped because its old home was wrapped twice — a bug
+        in a diagnostic must never change the connection verdict. Here it
+        would: this runs inside check_wa_connection_http()'s try, whose
+        handler ends in _set_wa_connected(False, ...)."""
+        s = _Stub()
+
+        s._profile_recovery_attempted = _BoomOnBool()
+
+        s._set_wa_connected(True, "status-session CONNECTED")
+
+        # Reached the rest of the branch regardless.
+        assert s._unattended_qr_events == 0
+        assert s._wa_connected is True
+
 
     def test_a_disagreeing_probe_then_a_later_agreeing_one_only_rearms_once_it_agrees(self):
         """The realistic sequence: the flood carries on across a couple of
@@ -209,3 +253,93 @@ class TestTheRearmAndTheCounterResetTogether:
         s._set_wa_connected(True, "status-session CONNECTED (re-poll)")
 
         assert s._unattended_qr_events == 5  # untouched: early return, not a reset
+
+
+class TestTheLadderStillResetsOnTheStatusReading:
+    """The other half of the split: the generation ladder stays in
+    _note_status_for_profile_health(), re-asserted on every CONNECTED poll.
+
+    Moving it into _set_wa_connected() alongside the budget looks tidier and
+    is wrong. That block sits below a no-change early return, so it only runs
+    on a real False->True transition — and the one transition every manual
+    re-pair goes through happens inside Connect.show_connection_dial(), which
+    MainWindow.__init__ calls BEFORE prepare_sync() opens the database. The
+    write would find no self.db, no-op silently, and never be attempted again
+    for the rest of that launch: a stale ladder then sends the next break at
+    the .prev snapshot — up to a day older — instead of the newest one.
+    """
+
+    class _HealthStub:
+        def __init__(self, generation=0, db=object()):
+            from main import MainWindow
+            self._note_status_for_profile_health = (
+                MainWindow._note_status_for_profile_health.__get__(self))
+            self.settings = {"privateinfo": {"paired": True}}
+            self.db = db
+            self._generation = generation
+            self.generation_writes = []
+            self.recover_calls = 0
+
+        def _profile_recovery_generation(self):
+            # The real one answers 0 when there is no database to read.
+            return self._generation if self.db is not None else 0
+
+        def _set_profile_recovery_generation(self, value):
+            # The real one is a no-op without a database — that is the whole
+            # point of this test.
+            if self.db is None:
+                return
+            self._generation = value
+            self.generation_writes.append(value)
+
+        def _recover_suspect_profile(self, *a, **kw):
+            self.recover_calls += 1
+            return True
+
+    def test_a_connected_reading_clears_a_stale_ladder(self):
+        s = self._HealthStub(generation=2)
+
+        s._note_status_for_profile_health("CONNECTED")
+
+        assert s._generation == 0
+        assert s.generation_writes == [0]
+
+    def test_every_poll_re_asserts_it_not_just_the_first(self):
+        """The property a transition-only reset would lose."""
+        s = self._HealthStub(generation=1)
+
+        s._note_status_for_profile_health("CONNECTED")
+        s._generation = 1          # something armed it again mid-launch
+        s._note_status_for_profile_health("CONNECTED")
+
+        assert s._generation == 0
+        assert s.generation_writes == [0, 0]
+
+    def test_a_ladder_already_at_zero_is_not_rewritten(self):
+        s = self._HealthStub(generation=0)
+
+        s._note_status_for_profile_health("CONNECTED")
+
+        assert s.generation_writes == []
+
+    def test_a_non_connected_reading_leaves_it_alone(self):
+        s = self._HealthStub(generation=2)
+
+        s._note_status_for_profile_health("CLOSED")
+
+        assert s._generation == 2
+
+    def test_the_pairing_launch_that_has_no_database_yet_recovers_next_poll(self):
+        """The failure a transition-only reset would make permanent: pairing
+        completes before prepare_sync(), so this write cannot land — and
+        because this path runs on EVERY poll, the one after the database
+        opens finishes the job."""
+        s = self._HealthStub(generation=2, db=None)
+
+        s._note_status_for_profile_health("CONNECTED")
+        assert s._generation == 2          # nothing could be written yet
+
+        s.db = object()                    # prepare_sync() has now run
+        s._note_status_for_profile_health("CONNECTED")
+
+        assert s._generation == 0

--- a/tests/test_qr_flood_rearm_counter.py
+++ b/tests/test_qr_flood_rearm_counter.py
@@ -1,0 +1,211 @@
+"""issue #202: the profile-recovery re-arm and the QR-flood counter reset
+must happen as one atomic event, not two that can drift apart.
+
+`_recover_suspect_profile()` runs at most once per launch behind
+`_profile_recovery_attempted`, cleared only once a session reports CONNECTED.
+That re-arm used to live in `_note_status_for_profile_health()`, keyed on the
+bare status string alone — but `createSessionUtil.start()` can promote a
+session to CONNECTED off its own state listener before the live
+`isConnected()` probe ever agrees ("the event wins"), and
+`check_wa_connection_http()` calls `_note_status_for_profile_health()`
+*before* it confirms that probe. So a CONNECTED the probe was about to refuse
+could re-arm recovery without resetting `_unattended_qr_events`, which only
+zeroes once the probe agrees, inside `_set_wa_connected()`. A second recovery
+could then start mid QR-flood on an event the counter had already counted,
+and `on_qrcode_update()` returns as soon as recovery starts — landing on the
+exact event where `seen == _UNATTENDED_QR_LIMIT` stops the halt from ever
+being evaluated for the rest of that flood.
+
+The fix moves the re-arm into `_set_wa_connected()`'s own "connection just
+came back up" branch, right beside the counter reset, so both only ever fire
+together, on the one event that branch already treats as the real online
+transition.
+
+MainWindow is a wx.Frame and cannot be instantiated without a running wx.App,
+so `_set_wa_connected()` is exercised as a plain function against a stub —
+same approach as tests/test_disconnect_ignores_stale_connected.py.
+"""
+
+import time
+
+import pytest
+
+
+class _Recorder:
+    def __init__(self):
+        self.played = 0
+
+    def play(self):
+        self.played += 1
+
+
+class _I18n:
+    @staticmethod
+    def t(key):
+        return key
+
+
+class _Stub:
+    # The first confirmed connection of a session also kicks off the
+    # send-capabilities probe on a background thread — real HTTP, and not
+    # what any test here is about. Record it instead.
+    def _check_send_capabilities(self):
+        self.capability_probes = getattr(self, "capability_probes", 0) + 1
+
+    def __init__(self, token="tok"):
+        from main import MainWindow
+        self._set_wa_connected = MainWindow._set_wa_connected.__get__(self)
+        self._set_preparing_status_if_idle = (
+            MainWindow._set_preparing_status_if_idle.__get__(self))
+        self._reset_startup_probe = MainWindow._reset_startup_probe.__get__(self)
+        self._announce_sync_events_enabled = MainWindow._announce_sync_events_enabled.__get__(self)
+        self._self_inflicted_teardown_expected = (
+            MainWindow._self_inflicted_teardown_expected.__get__(self))
+        self._WA_STARTUP_GRACE_SECONDS = MainWindow._WA_STARTUP_GRACE_SECONDS
+
+        self.settings = {}
+        self.token = token
+
+        self._shutting_down = False
+        self._wpp_updating = False
+        self._wa_connected = False
+        self._auto_offline = False
+        self._wa_connect_announced = False
+        self._send_capabilities_checked = False
+        self._wa_offline_strikes = 0
+        self._dead_browser_strikes = 0
+        self._auto_repair_dialog_shown = False
+        self._wa_startup_time = time.time()
+        self.background_mode = False
+        self.i18n = _I18n()
+        self.offline_mode_sound = _Recorder()
+        self.connected_sound = _Recorder()
+        self.statuses = []
+        self.spoken = []
+        self._tray_status = "tray_connecting"
+        self.ws = None
+        self._sync_completed = False
+        self._initial_sync_running = False
+        self._last_sync_attempt_ts = 0
+        self._sync_retry_count = 0
+        self.sync_triggered = 0
+        self.reconnect_threads_started = 0
+
+        # What the QR-flood halt guards, and what this file is actually
+        # about: pre-arm both as a broken/mid-flood session would carry them.
+        self._unattended_qr_events = 3
+        self._qr_flood_halted = False
+        self._profile_recovery_attempted = True
+        self._recovery_generation = 0
+
+    def _profile_recovery_generation(self):
+        return self._recovery_generation
+
+    def _set_profile_recovery_generation(self, value):
+        self._recovery_generation = value
+
+    def _apply_offline_state(self):
+        pass
+
+    def trigger_sync_if_needed(self):
+        self.sync_triggered += 1
+
+    def _set_status(self, text):
+        self.statuses.append(text)
+
+    def output(self, text, interrupt=False):
+        self.spoken.append(text)
+
+    def _startup_offline_confirmed(self):
+        return False
+
+    def _reconnect_websocket_now(self):
+        self.reconnect_threads_started += 1
+
+
+@pytest.fixture(autouse=True)
+def _no_wx(monkeypatch):
+    monkeypatch.setattr("main.wx.CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+
+
+@pytest.fixture(autouse=True)
+def _no_threads(monkeypatch):
+    class _InlineThread:
+        def __init__(self, target=None, args=(), kwargs=None, daemon=None, name=None):
+            self._target = target
+            self._args = args
+            self._kwargs = kwargs or {}
+
+        def start(self):
+            self._target(*self._args, **self._kwargs)
+
+    monkeypatch.setattr("main.threading.Thread", _InlineThread)
+
+
+class TestTheRearmAndTheCounterResetTogether:
+    def test_a_probe_that_disagrees_leaves_both_untouched(self):
+        """The exact gap issue #202 describes: CONNECTED promoted by the
+        state listener, but isConnected() refuses it. Neither the counter
+        nor the recovery latch may move."""
+        s = _Stub()
+
+        s._set_wa_connected(False, "status-session CONNECTED but isConnected() false")
+
+        assert s._unattended_qr_events == 3
+        assert s._profile_recovery_attempted is True
+
+    def test_a_probe_that_agrees_resets_both_in_the_same_call(self):
+        s = _Stub()
+
+        s._set_wa_connected(True, "status-session CONNECTED")
+
+        assert s._unattended_qr_events == 0
+        assert s._profile_recovery_attempted is False
+
+    def test_the_generation_ladder_resets_alongside_them_too(self):
+        s = _Stub()
+        s._recovery_generation = 2
+
+        s._set_wa_connected(True, "status-session CONNECTED")
+
+        assert s._recovery_generation == 0
+
+    def test_a_disagreeing_probe_then_a_later_agreeing_one_only_rearms_once_it_agrees(self):
+        """The realistic sequence: the flood carries on across a couple of
+        refused CONNECTEDs before the probe finally agrees."""
+        s = _Stub()
+
+        s._set_wa_connected(False, "status-session CONNECTED but isConnected() false")
+        s._set_wa_connected(False, "status-session CONNECTED but isConnected() false")
+        assert s._profile_recovery_attempted is True
+        assert s._unattended_qr_events == 3
+
+        s._set_wa_connected(True, "status-session CONNECTED")
+        assert s._profile_recovery_attempted is False
+        assert s._unattended_qr_events == 0
+
+    def test_a_stale_connected_report_with_no_token_touches_neither(self):
+        """Regression guard against the neighbouring fix in this same
+        method (test_disconnect_ignores_stale_connected.py): the no-token
+        early return must not accidentally reach the re-arm/reset lines
+        either."""
+        s = _Stub(token="")
+
+        s._set_wa_connected(True, "status-session CONNECTED")
+
+        assert s._unattended_qr_events == 3
+        assert s._profile_recovery_attempted is True
+
+    def test_already_connected_reconfirmation_does_not_repeat_the_reset(self):
+        """A repeat CONNECTED while nothing changed must hit the method's
+        own early return, not re-run the reset every health-check tick —
+        harmless either way here since the values are idempotent, but this
+        pins that the early return still fires before reaching them."""
+        s = _Stub()
+        s._set_wa_connected(True, "status-session CONNECTED")
+        assert s._unattended_qr_events == 0  # the first connect's own reset
+
+        s._unattended_qr_events = 5  # simulate a fresh QR seen after connecting
+        s._set_wa_connected(True, "status-session CONNECTED (re-poll)")
+
+        assert s._unattended_qr_events == 5  # untouched: early return, not a reset

--- a/tests/test_startup_grace.py
+++ b/tests/test_startup_grace.py
@@ -64,6 +64,11 @@ class _Stub:
     _announce_sync_events_enabled = MainWindow._announce_sync_events_enabled
     _self_inflicted_teardown_expected = MainWindow._self_inflicted_teardown_expected
     _WA_STARTUP_GRACE_SECONDS = MainWindow._WA_STARTUP_GRACE_SECONDS
+    # Not what this file is testing — a real connect just needs these two to
+    # exist so _set_wa_connected()'s own profile-recovery re-arm (issue #202,
+    # see tests/test_qr_flood_rearm_counter.py) doesn't AttributeError here.
+    _profile_recovery_generation = lambda self: 0
+    _set_profile_recovery_generation = lambda self, value: None
 
     # Overridden per-test; the default keeps the grace intact.
     def _startup_offline_confirmed(self):

--- a/tests/test_status_synced_with_connected_sound.py
+++ b/tests/test_status_synced_with_connected_sound.py
@@ -53,6 +53,12 @@ class _Stub:
         self._self_inflicted_teardown_expected = (
             MainWindow._self_inflicted_teardown_expected.__get__(self))
         self._WA_STARTUP_GRACE_SECONDS = MainWindow._WA_STARTUP_GRACE_SECONDS
+        # Not what this file is testing — a real connect just needs these two
+        # to exist so _set_wa_connected()'s own profile-recovery re-arm
+        # (issue #202, see tests/test_qr_flood_rearm_counter.py) doesn't
+        # AttributeError here.
+        self._profile_recovery_generation = lambda: 0
+        self._set_profile_recovery_generation = lambda value: None
 
         self.settings = {}
         self.token = "tok"


### PR DESCRIPTION
Fixes #202.

the profile-recovery re-arm used to fire on the bare CONNECTED status string, before the live isConnected() probe is checked, while the QR-flood counter only resets once that probe agrees — so a CONNECTED the probe later refuses could re-arm recovery without resetting the counter, letting a second recovery start mid-flood on an event already counted and skip the halt's exact `seen == limit` check for the rest of that flood. Moved the re-arm into _set_wa_connected()'s probe-agreeing branch, right beside the counter reset, so both now only ever fire together.