### PR TITLE
Attempt profile repair before the startup-grace window, not after

### DIFF
--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -872,6 +872,15 @@ class WebSocketClient:
         unlink-confirming path in this codebase accepts either — see
         _REPAIR_DIALOG_CONFIRM_EVENTS, which requires this one too.
 
+        The profile *repair* attempt (_recover_suspect_profile(), inside the
+        block below) is deliberately NOT behind either of those two gates —
+        only the dialog is. A code already proves what the gates exist to
+        rule out for the dialog's own harsher conclusion, so making repair
+        wait for them too used to mean a flood confined entirely to the
+        startup grace window ran its whole budget out and hit the halt with
+        a good profile snapshot on disk nothing had ever looked at (issue
+        #203).
+
         Stopping the churn is the part whose absence got an account banned.
         `autoClose`/`deviceSyncTimeout` are pinned to 0 (client/api_patches/
         src/config.ts) so WPPConnect never closes a code-producing session on
@@ -902,8 +911,6 @@ class WebSocketClient:
         if (
             mw.settings.get("privateinfo", {}).get("paired")
             and not getattr(mw, "_auto_repair_dialog_shown", False)
-            and not self._qr_within_startup_grace()
-            and seen >= self._REPAIR_DIALOG_CONFIRM_EVENTS
         ):
             # Try to repair the profile before sending the user off to pair by
             # hand. This event is the *earliest and strongest* evidence that
@@ -929,13 +936,67 @@ class WebSocketClient:
             # _recover_suspect_profile() runs at most once per launch and calls
             # back when it gives up — against a re-pairing saved every time the
             # profile was the actual fault.
+            #
+            # Recover early, confirm late (issue #203): unlike the dialog just
+            # below, the repair attempt itself does NOT wait out
+            # _qr_within_startup_grace() or _REPAIR_DIALOG_CONFIRM_EVENTS. The
+            # grace window and the confirm-count exist to protect a
+            # user-visible, history-wiping conclusion ("you must pair again")
+            # from a single transient reading — they were never meant to gate
+            # the *observation* a code already settles on its own: wa-js only
+            # ever hands one back while unpaired and unauthenticated, so a code
+            # arriving even inside the grace window already proves the stored
+            # session could not be restored. Waiting for the two gates before
+            # even trying the repair used to mean a flood confined entirely to
+            # the grace window (a fresh boot, session gone) ran out its whole
+            # budget and hit the halt below with a good profile snapshot on
+            # disk that nothing had ever looked at — and the halt latches, so
+            # a snapshot restored after that point would never be started
+            # either.
+            #
+            # _recover_suspect_profile() latches once-per-launch
+            # (_profile_recovery_attempted) and its bare boolean return
+            # cannot tell "already started, still in flight" apart from "just
+            # confirmed there is nothing to restore" on a later call — both
+            # come back False once latched. That ambiguity is fine for THIS
+            # call (a fresh False here genuinely means nothing was found, so
+            # falling through to the dialog gate below is correct), but not
+            # for a LATER event: without remembering that an earlier call
+            # already started a restore, a later event's latched False would
+            # wrongly fall through and send the user to pair by hand while a
+            # legitimate restore from a few seconds ago is still resolving or
+            # has already succeeded — on_give_up is what surfaces its actual
+            # failure, so there is nothing for this method to add. Tracked
+            # separately on _profile_repair_started rather than trusting the
+            # latch's own reset (_note_status_for_profile_health() clears
+            # _profile_recovery_attempted once a restored profile reaches
+            # CONNECTED, on purpose, to allow a second recovery if it breaks
+            # again — checking that flag too here means this skip only holds
+            # while that first attempt has neither resolved nor been
+            # forgiven). "Resolved" also covers a restore that lands at the
+            # file level but never reaches CONNECTED — _restore() (main.py)
+            # resets _profile_repair_started itself the moment the file copy
+            # succeeds, precisely so this skip does not hold past that point
+            # with nothing left to clear it.
+            if (getattr(mw, "_profile_repair_started", False)
+                    and getattr(mw, "_profile_recovery_attempted", False)):
+                return
             if mw._recover_suspect_profile(
                     reason="WPPConnect minted a pairing code for a paired "
                            "install — the stored session could not be restored",
                     on_give_up=self._show_repair_dialog):
+                mw._profile_repair_started = True
                 return
-            self._show_repair_dialog()
-            return
+            # The dialog is the user-visible conclusion, so it still keeps
+            # both gates: outside the startup grace window (still settling
+            # from a normal slow boot is not the same as confirmed lost) and
+            # confirmed by _REPAIR_DIALOG_CONFIRM_EVENTS consecutive readings,
+            # not a single one — same reasoning as every other unlink-confirming
+            # path in this codebase.
+            if (not self._qr_within_startup_grace()
+                    and seen >= self._REPAIR_DIALOG_CONFIRM_EVENTS):
+                self._show_repair_dialog()
+                return
         if seen == self._UNATTENDED_QR_LIMIT:
             # Never paired, or the dialog was already offered and is no longer
             # up: nobody is going to scan these. Reached on the same event

--- a/client/main.py
+++ b/client/main.py
@@ -8947,6 +8947,23 @@ class MainWindow(wx.Frame):
                     # profile now moved aside; counting it against the flood
                     # ceiling would halt a session that is about to be fine.
                     self._unattended_qr_events = 0
+                    # issue #203 review: a restore that lands at the file
+                    # level does not guarantee the profile ever reaches
+                    # CONNECTED (see the generation-climbing comment above —
+                    # this same snapshot can itself be one that doesn't hold).
+                    # _profile_repair_started has no other reset — it is not
+                    # cleared by CONNECTED the way _profile_recovery_attempted
+                    # is — so leaving it set here would silently swallow every
+                    # later unattended-QR event for the rest of the launch
+                    # (neither the repair dialog nor the flood halt would ever
+                    # run again, against this codebase's own "a code stream
+                    # nobody is watching is a ban" rule). Resetting it here is
+                    # safe exactly because the ambiguity it exists to prevent
+                    # is gone the moment this branch runs: the restore is no
+                    # longer "still in flight," so a later event can only be a
+                    # genuinely new flood, which the ordinary grace/confirm/
+                    # halt path below is built to handle on its own.
+                    self._profile_repair_started = False
                     wx.CallAfter(self._announce_profile_restored)
                 else:
                     wx.CallAfter(self._announce_profile_beyond_repair)

--- a/tests/test_profile_recovery_wiring.py
+++ b/tests/test_profile_recovery_wiring.py
@@ -67,6 +67,12 @@ class _Stub:
     def output(self, text, interrupt=False):
         self.announced.append(text)
 
+    def wait_for_profile_release(self, session_name, timeout=20.0):
+        # Real implementation polls win32 process handles for up to
+        # `timeout` seconds -- not appropriate off the real profile paths a
+        # unit test stub has none of.
+        return True
+
     def _recover_suspect_profile(self):
         self.recovered += 1
 
@@ -360,3 +366,62 @@ class TestARestoreThatConnectedEarnsAnotherChance:
         for _ in range(5):
             _note(stub, "CLOSED")
             assert MainWindow._recover_suspect_profile(stub) is False
+
+
+class TestASuccessfulFileLevelRestoreResetsTheQrRepairLatch:
+    """issue #203 review finding: _profile_repair_started (set by
+    core/websocket_client.py's _handle_unattended_qr(), tracked separately
+    from _profile_recovery_attempted so a QR event arriving mid-restore
+    cannot mistake "still in flight" for "confirmed nothing to restore") has
+    no reset of its own anywhere else -- unlike _profile_recovery_attempted,
+    which _note_status_for_profile_health() clears on a CONNECTED reading.
+
+    A snapshot restore can succeed at the file level and still not reach
+    CONNECTED (this same method's own generation-climbing branch above exists
+    because a restored snapshot sometimes does not hold). Left unreset,
+    _profile_repair_started would silently swallow every later unattended-QR
+    event for the rest of the launch -- no repair dialog, and, worse, no
+    flood halt either, since _handle_unattended_qr()'s early return on this
+    flag skips past the halt check too. So the success branch of _restore()
+    resets it alongside _unattended_qr_events: the ambiguity the flag exists
+    to prevent is over the moment this branch runs (the restore is no longer
+    "in flight"), so a later event can only be a genuinely new flood, which
+    the ordinary grace/confirm/halt path is built to handle on its own.
+    """
+
+    @pytest.fixture
+    def stub(self, monkeypatch):
+        s = _Stub()
+        s._unattended_qr_events = 4
+        s._profile_repair_started = True
+        monkeypatch.setattr(
+            "main.threading.Thread",
+            lambda target=None, **kw: types.SimpleNamespace(
+                start=lambda: target and target()))
+        monkeypatch.setattr("main.wx.CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+        monkeypatch.setattr("main.api_post", lambda *a, **kw: None)
+        monkeypatch.setattr("core.profile_recovery.has_snapshot", lambda *a, **kw: True)
+        return s
+
+    def test_a_successful_restore_clears_the_latch(self, stub, monkeypatch):
+        monkeypatch.setattr("core.profile_recovery.restore_snapshot",
+                            lambda *a, **kw: True)
+
+        MainWindow._recover_suspect_profile(stub)
+
+        assert stub._profile_repair_started is False
+        assert stub._unattended_qr_events == 0
+
+    def test_a_failed_restore_leaves_the_latch_alone(self, stub, monkeypatch):
+        """on_give_up already surfaces the failure and _auto_repair_dialog_shown
+        (set by the caller) takes over routing every later event straight to
+        the halt check -- nothing needs _profile_repair_started reset here,
+        and this pins that the fix above did not widen to this branch too."""
+        monkeypatch.setattr("core.profile_recovery.restore_snapshot",
+                            lambda *a, **kw: False)
+        gave_up = []
+
+        MainWindow._recover_suspect_profile(stub, on_give_up=lambda: gave_up.append(1))
+
+        assert gave_up == [1]
+        assert stub._profile_repair_started is True

--- a/tests/test_qrcode_auto_repair_dialog.py
+++ b/tests/test_qrcode_auto_repair_dialog.py
@@ -334,21 +334,23 @@ class TestTheProfileIsRepairedBeforeAskingTheUserToPair:
         assert len(mw.recover_calls) == 1
         assert connect.show_connection_dial_calls == 0
 
-        # KNOWN GAP (not introduced by this branch — see PR #183, already on
-        # upstream/main): a THIRD event, arriving while the restore from the
-        # second is still unresolved, calls _recover_suspect_profile() again.
-        # Its latch correctly refuses to start a second restore and returns
-        # False — but _handle_unattended_qr() treats every False the same
-        # way ("nothing was started, send the user to pair by hand") and
-        # falls through to _show_repair_dialog() anyway, even though a
-        # restore it started one event ago may still be in flight or may
-        # have already quietly succeeded. The bare boolean return of
-        # _recover_suspect_profile() cannot currently tell those two "False"
-        # cases apart. Documented here rather than silently asserted around,
-        # since a passing assert on this line would hide a real interaction
-        # this test suite does not otherwise cover.
+        # GAP CLOSED (issue #203): a THIRD event, arriving while the restore
+        # from the second is still unresolved, used to call
+        # _recover_suspect_profile() again, get back a latched False (the
+        # bare boolean cannot tell "already started, still in flight" apart
+        # from "just confirmed nothing to restore"), and fall through to
+        # _show_repair_dialog() anyway — sending the user to pair by hand
+        # over a restore that may already have quietly succeeded. Moving the
+        # repair attempt ahead of the startup-grace/confirm-events gates
+        # (this same change) required tracking "already started" on its own
+        # flag (_profile_repair_started) rather than trusting the latch's
+        # bare return, which incidentally closes this gap too: a third (or
+        # later) event while the first attempt is still unresolved is now a
+        # no-op here, exactly as it should be — on_give_up is what surfaces
+        # an eventual failure.
         s.on_qrcode_update(QR_EVENT)
-        assert connect.show_connection_dial_calls == 1
+        assert connect.show_connection_dial_calls == 0
+        assert len(mw.recover_calls) == 1
 
 
 class TestStartupGraceWindow:
@@ -419,3 +421,76 @@ class TestStartupGraceWindow:
         s.on_qrcode_update(QR_EVENT)
 
         assert connect.show_connection_dial_calls == 1
+
+
+class TestRepairIsAttemptedInsideTheGraceWindow:
+    """Issue #203: recover early, confirm late. A flood confined entirely to
+    the startup grace window used to let every _UNATTENDED_QR_LIMIT code pass
+    through _handle_unattended_qr() without ever trying the profile repair —
+    the repair attempt sat behind the exact same two gates as the dialog. A
+    code already proves what those gates exist to rule out for the DIALOG's
+    own harsher, history-wiping conclusion ("you must pair again"); it does
+    not need to wait for them itself. The halt still fires at exactly
+    _UNATTENDED_QR_LIMIT regardless — this must not delay it."""
+
+    def test_the_very_first_code_inside_the_grace_window_still_attempts_repair(self):
+        mw = _FakeMainWindow(
+            paired=True, pairing_dialog_active=False,
+            wa_connect_announced=False, wa_startup_time=time.time(),
+        )
+        mw.profile_restore_available = True
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        s.on_qrcode_update(QR_EVENT)
+
+        assert len(mw.recover_calls) == 1
+        # The repair attempt is not the dialog: still inside the grace
+        # window and short of _REPAIR_DIALOG_CONFIRM_EVENTS, so the
+        # user-visible conclusion is correctly withheld either way.
+        assert connect.show_connection_dial_calls == 0
+
+    def test_a_flood_entirely_inside_the_grace_window_still_repairs_before_halting(self):
+        """The exact shape the issue describes: every event of the flood
+        lands inside the startup grace window, so the dialog gate never
+        clears at all before the halt. Repair must still have been tried."""
+        mw = _FakeMainWindow(
+            paired=True, pairing_dialog_active=False,
+            wa_connect_announced=False, wa_startup_time=time.time(),
+        )
+        mw.profile_restore_available = False
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        for _ in range(WebSocketClient._UNATTENDED_QR_LIMIT):
+            s.on_qrcode_update(QR_EVENT)
+
+        assert len(mw.recover_calls) == 1
+        # The halt is not delayed by any of this — still exactly at the
+        # limit, no new condition in front of it.
+        assert mw.halt_calls == 1
+        # Nothing to restore, so the dialog never opens here either — this
+        # install falls through to the halt's own "never offered a way
+        # back" branch instead (covered by test_qrcode_unattended_session.py).
+        assert connect.show_connection_dial_calls == 1
+
+    def test_a_restorable_profile_inside_the_grace_window_never_reaches_the_halt(self):
+        """With something to restore, the repair started on the first event
+        suppresses the dialog AND the halt for as long as it is unresolved —
+        matching TestTheProfileIsRepairedBeforeAskingTheUserToPair's
+        behaviour once a restore is in flight, just reached one gate
+        earlier."""
+        mw = _FakeMainWindow(
+            paired=True, pairing_dialog_active=False,
+            wa_connect_announced=False, wa_startup_time=time.time(),
+        )
+        mw.profile_restore_available = True
+        connect = _FakeConnect(mw)
+        s = _Stub(mw, connect)
+
+        for _ in range(WebSocketClient._UNATTENDED_QR_LIMIT * 2):
+            s.on_qrcode_update(QR_EVENT)
+
+        assert len(mw.recover_calls) == 1
+        assert mw.halt_calls == 0
+        assert connect.show_connection_dial_calls == 0


### PR DESCRIPTION
Fixes #203.

`_handle_unattended_qr()` only attempted profile repair after both the startup-grace window and the confirm-events count, so a QR flood confined entirely to the grace window (fresh boot, session already gone) burned its whole budget and hit the flood halt with a good, restorable snapshot on disk that nothing had ever looked at. Repair now runs before both gates — they still guard only the user-visible dialog — and a review pass surfaced a related gap this same change had to close: a restore that lands at the file level without ever reaching CONNECTED now clears its own latch, so it can't silently suppress the flood halt for the rest of the launch.