### PR TITLE
Detect a node_modules wppconnect that drifted from the pin

### DIFF
--- a/client/core/wpp_runtime.py
+++ b/client/core/wpp_runtime.py
@@ -45,3 +45,102 @@ def homologated_wpp_tag(path: str) -> str:
     """
     version = read_homologated_wpp_version(path)
     return f"v{version.lstrip('vV')}" if version else ""
+
+
+#: The npm package whose compiled output WinZapp patches in place (see
+#: core/wppconnect_*_patch.py). Its version is pinned exactly by
+#: api/package.json, and the patches are search-and-replace against that exact
+#: version's source text.
+WPPCONNECT_PACKAGE = "@wppconnect-team/wppconnect"
+
+
+def _read_json(path: str) -> dict:
+    """Parse a JSON file, or {} when it cannot be read at all.
+
+    Same swallow-everything contract as read_homologated_wpp_version() above,
+    and for the same reason: these run on the startup path, outside any local
+    try block, and an exception here would skip the Node server coming up at
+    all.
+    """
+    try:
+        import json
+        with open(path, encoding="utf-8-sig") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def installed_wppconnect_version(api_dir: str) -> str:
+    """The wppconnect library version actually present in node_modules, or "".
+
+    Deliberately NOT api/package.json's own "version" field, which is the
+    WPPConnect *Server* version — a different number, and one that ships
+    inside the release ZIP, so an update always rewrites it.
+    """
+    path = _join(api_dir, "node_modules", *WPPCONNECT_PACKAGE.split("/"),
+                 "package.json")
+    version = _read_json(path).get("version")
+    return version.strip() if isinstance(version, str) else ""
+
+
+def required_wppconnect_version(api_dir: str) -> str:
+    """The exact version api/package.json pins, or "" when it is not exact.
+
+    A range ("^2.3.3", "~2.3.3", "*", a git URL) answers "" on purpose:
+    deciding whether an installed version satisfies a range needs a semver
+    resolver this module cannot have (stdlib-only — setup_api.py imports it
+    before any dependency is installed), and guessing wrong here would either
+    miss a real drift or force a multi-minute reinstall on a healthy install.
+    WinZapp pins exactly; anything else is somebody's local edit, and the
+    honest answer to it is "I cannot tell".
+    """
+    deps = _read_json(_join(api_dir, "package.json")).get("dependencies")
+    pin = deps.get(WPPCONNECT_PACKAGE) if isinstance(deps, dict) else None
+    if not isinstance(pin, str):
+        return ""
+    pin = pin.strip()
+    # An exact pin is digits and dots, optionally with a pre-release suffix.
+    if not pin or not pin[0].isdigit():
+        return ""
+    return pin
+
+
+def wppconnect_library_drift(api_dir: str):
+    """(installed, required) when node_modules holds a different wppconnect
+    than api/package.json pins; None when they agree or either is unreadable.
+
+    This is the mismatch nothing checked, and the one that actually breaks
+    people. The release ZIP excludes node_modules (build.py's
+    API_EXCLUDE_DIRS), so an update ships a new dist/server.js and a new
+    package.json over whatever wppconnect the machine already had. The
+    startup gate could never catch it: it compares api/package.json's server
+    version against wpp_minimum_version.txt, and BOTH of those files come out
+    of the same ZIP, so after an update they always agree.
+
+    What breaks is the patching. core/wppconnect_*_patch.py rewrites the
+    library's compiled output by searching for exact source text, so against
+    an unexpected version the patch does not fail — it is silently skipped
+    ("DID NOT MATCH ... left untouched"). Observed live on a user's install
+    whose host.layer.js checkQrCode and loginByCode patches were both skipped:
+    the pairing-code path went unpatched and the session cycled
+    CLOSED/INITIALIZING without ever reaching CONNECTED.
+
+    Any difference counts, not just an older one — the patches target one
+    exact version's source, so a newer library misses them just as an older
+    one does.
+
+    Returns None on anything unreadable rather than guessing: the caller's
+    response to drift is a full re-download and rebuild of the server, which
+    is far too expensive to trigger on a file this could not parse.
+    """
+    installed = installed_wppconnect_version(api_dir)
+    required = required_wppconnect_version(api_dir)
+    if not installed or not required or installed == required:
+        return None
+    return (installed, required)
+
+
+def _join(*parts: str) -> str:
+    import os
+    return os.path.join(*parts)

--- a/client/main.py
+++ b/client/main.py
@@ -59,7 +59,9 @@ from core.incremental_sync import (
 from core.websocket_client import WebSocketClient
 from core.api_client import api_get, api_post, redact_credentials
 from core.send_contract import accepted_message_id
-from core.wpp_runtime import read_homologated_wpp_version
+from core.wpp_runtime import (
+    read_homologated_wpp_version, wppconnect_library_drift, WPPCONNECT_PACKAGE,
+)
 from core.utils import reaction_targets_status, encrypt, decrypt, encrypt_json, decrypt_json, generate_and_save_key, retrieve_key, format_number, is_phone_like, looks_like_binary_blob, prune_message_record, prune_chats_messages, effective_unread_count, mute_response_accepted, normalize_for_search, search_normalization_mode, parse_bool_flag as _parse_bool_flag, group_setting_notif_value, DEFAULT_SETTINGS, append_selected_marker, is_message_forwarded, plan_row_updates, display_page_fetch_limit, carry_over_video_durations, video_seconds, MEASURED_SECONDS_KEY, is_voice_message, backfill_missing_defaults, auto_download_allows, migrate_voice_messages_media_types, migrate_voice_message_mode_default
 from core.locale_format import get_date_format, get_time_format, get_datetime_format
 from core.quiet_hours import is_quiet_hours_active
@@ -7688,6 +7690,39 @@ class MainWindow(wx.Frame):
             return ""
 
 
+    def _server_version_below_minimum(self):
+        """(installed, minimum) when the WPPConnect Server itself is too old,
+        else None.
+
+        Worth knowing what this can and cannot see: both numbers come out of
+        the release ZIP — api/package.json's own "version" field and
+        wpp_minimum_version.txt — so an update rewrites the two together and
+        they agree by construction afterwards. This catches an install that
+        has NOT been updated (a server left behind by an older WinZapp, a
+        hand-built api/), never a drift the update itself introduced. That
+        second case is _wppconnect_library_drift()'s, and it is the one that
+        was going unnoticed.
+        """
+        minimum = self._read_wpp_minimum_version()
+        installed = self._get_installed_wpp_version() if minimum else ""
+        if not minimum or not installed:
+            return None  # Nothing pinned, or unreadable — skip silently
+        return (installed, minimum) if self._version_is_below(installed, minimum) else None
+
+    def _wppconnect_library_drift(self):
+        """(installed, pinned) when node_modules holds a wppconnect other than
+        the one api/package.json pins, else None.
+
+        The whole reasoning lives in core/wpp_runtime.wppconnect_library_drift()
+        — this only supplies the api/ path and never lets a failure here stop
+        the server from starting.
+        """
+        try:
+            return wppconnect_library_drift(resource_path("api"))
+        except Exception:
+            logging.exception("[ensure_wpp_version] library drift check failed")
+            return None
+
     @staticmethod
     def _version_is_below(installed: str, minimum: str) -> bool:
         """
@@ -7706,8 +7741,15 @@ class MainWindow(wx.Frame):
 
     def ensure_wpp_version(self):
         """
-        Compare the installed WPPConnect version against the minimum required
-        by this WinZapp build (see _read_wpp_minimum_version()).
+        Two independent checks, either of which offers the same repair:
+
+        * the WPPConnect Server itself older than this build's minimum
+          (_server_version_below_minimum());
+        * node_modules holding a wppconnect other than the one
+          api/package.json pins (_wppconnect_library_drift()) — the drift an
+          update introduces on its own, because the release ZIP ships
+          dist/server.js and package.json but NOT node_modules, and which
+          silently un-patches the pairing-code path.
 
         If the installed version is older the user is prompted to:
           • Update now   — re-download + rebuild via ApiSetupDialog, then continue
@@ -7738,18 +7780,27 @@ class MainWindow(wx.Frame):
         if not os.path.isfile(dist_server):
             return  # API not installed yet — setup dialog will handle it
 
-        minimum  = self._read_wpp_minimum_version()
-        if not minimum:
-            return  # No minimum defined — nothing to check
+        outdated = self._server_version_below_minimum()
+        drifted = self._wppconnect_library_drift()
 
-        installed = self._get_installed_wpp_version()
-        if not installed:
-            return  # Could not determine installed version — skip silently
+        if outdated:
+            installed, minimum = outdated
+        elif drifted:
+            # The server itself is fine; what is wrong is the library it runs
+            # on. Same prompt, same repair — the reinstall runs npm install,
+            # which brings node_modules to the pinned version, and re-applies
+            # the node_modules patches against source they will now match.
+            installed, minimum = drifted
+            logging.warning(
+                "[ensure_wpp_version] node_modules holds %s %s but "
+                "api/package.json pins %s — the compiled-output patches are "
+                "matched against the pinned version's source, so offering the "
+                "reinstall.", WPPCONNECT_PACKAGE, installed, minimum,
+            )
+        else:
+            return  # Server and library both as expected — nothing to do
 
-        if not self._version_is_below(installed, minimum):
-            return  # Installed version meets (or exceeds) the minimum — all good
-
-        # ── Installed version is older than the minimum ───────────────────────
+        # ── Something is older/other than what this build expects ─────────────
         from ui.dialogs.api_version_check import (
             ApiVersionOutdatedDialog,
             RESULT_UPDATE, RESULT_EXIT, RESULT_CONTINUE,
@@ -7782,11 +7833,20 @@ class MainWindow(wx.Frame):
         from core.wpp_runtime import homologated_wpp_tag
         from ui.dialogs.api_setup import ApiSetupDialog
         minimum_tag = homologated_wpp_tag(resource_path("wpp_minimum_version.txt"))
+        if not minimum_tag and outdated:
+            # Only the server branch may fall back to `minimum` here: it IS a
+            # server version. The library branch's is a wppconnect version
+            # ("2.3.3"), and there is no wppconnect-server release tagged
+            # v2.3.3 — passing it would build a 404 archive URL, the same
+            # failure the comment above describes. With no tag at all,
+            # ApiSetupDialog resolves the latest release itself, which is the
+            # right answer when we cannot name a better one.
+            minimum_tag = f"v{minimum.lstrip('vV')}"
         def _show_update_dlg():
             update_dlg = ApiSetupDialog(
                 self,
                 title_override=self.i18n.t("api_update_dialog_title"),
-                forced_tag=minimum_tag or f"v{minimum.lstrip('vV')}",
+                forced_tag=minimum_tag,
             )
             res = update_dlg.ShowModal()
             update_dlg.Destroy()

--- a/tests/test_wppconnect_library_drift.py
+++ b/tests/test_wppconnect_library_drift.py
@@ -1,0 +1,240 @@
+"""Tests for detecting that node_modules holds a different wppconnect than
+api/package.json pins — core/wpp_runtime.wppconnect_library_drift().
+
+The mismatch nothing checked, and the one that actually disconnects people.
+`build.py`'s API_EXCLUDE_DIRS keeps node_modules OUT of the release ZIP, so an
+update ships a new dist/server.js and a new package.json over whatever
+wppconnect the machine already had. The startup gate could never see it: it
+compares api/package.json's *server* version against wpp_minimum_version.txt,
+and both of those files come out of the same ZIP, so after an update they
+agree by construction.
+
+What breaks is the patching. core/wppconnect_*_patch.py rewrites the library's
+compiled output by searching for exact source text, so against an unexpected
+version a patch does not fail — it is silently skipped. Measured on a real
+install (issue #164): host.layer.js's checkQrCode and loginByCode both logged
+"DID NOT MATCH ... left untouched", the pairing-code path ran unpatched, and
+the session cycled CLOSED/INITIALIZING for minutes without ever reaching
+CONNECTED. A second install, checked directly, held wppconnect 2.3.1 under an
+api/package.json pinning 2.3.3.
+
+Pure and stdlib-only (setup_api.py imports this module before any dependency
+is installed), so these run against real files in tmp_path rather than mocks.
+"""
+
+import inspect
+import json
+
+import main
+from core.wpp_runtime import (
+    WPPCONNECT_PACKAGE,
+    installed_wppconnect_version,
+    required_wppconnect_version,
+    wppconnect_library_drift,
+)
+
+
+def _api_dir(tmp_path, installed=None, pinned=None, pkg_extra=None):
+    """A minimal api/ tree. `installed` None means node_modules is absent,
+    `pinned` None means api/package.json declares no such dependency."""
+    api = tmp_path / "api"
+    api.mkdir(exist_ok=True)
+
+    pkg = {"name": "@wppconnect/server", "version": "2.10.18"}
+    if pinned is not None:
+        pkg["dependencies"] = {WPPCONNECT_PACKAGE: pinned}
+    if pkg_extra is not None:
+        pkg.update(pkg_extra)
+    (api / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+
+    if installed is not None:
+        lib = api / "node_modules"
+        for part in WPPCONNECT_PACKAGE.split("/"):
+            lib = lib / part
+        lib.mkdir(parents=True, exist_ok=True)
+        (lib / "package.json").write_text(
+            json.dumps({"name": WPPCONNECT_PACKAGE, "version": installed}),
+            encoding="utf-8",
+        )
+    return str(api)
+
+
+class TestReadingTheTwoVersions:
+    def test_the_installed_version_comes_from_node_modules(self, tmp_path):
+        api = _api_dir(tmp_path, installed="2.3.1", pinned="2.3.3")
+        assert installed_wppconnect_version(api) == "2.3.1"
+
+    def test_it_is_not_api_package_jsons_own_version(self, tmp_path):
+        """api/package.json's "version" is the WPPConnect *Server* number
+        (2.10.18 here) — a different thing entirely, and the one the old gate
+        was reading."""
+        api = _api_dir(tmp_path, installed="2.3.1", pinned="2.3.3")
+        assert installed_wppconnect_version(api) != "2.10.18"
+
+    def test_the_required_version_comes_from_the_pin(self, tmp_path):
+        api = _api_dir(tmp_path, installed="2.3.1", pinned="2.3.3")
+        assert required_wppconnect_version(api) == "2.3.3"
+
+    def test_a_missing_node_modules_reads_as_unknown(self, tmp_path):
+        api = _api_dir(tmp_path, installed=None, pinned="2.3.3")
+        assert installed_wppconnect_version(api) == ""
+
+    def test_an_unparseable_file_reads_as_unknown(self, tmp_path):
+        api = _api_dir(tmp_path, installed="2.3.1", pinned="2.3.3")
+        broken = tmp_path / "api" / "package.json"
+        broken.write_text("{ not json", encoding="utf-8")
+        assert required_wppconnect_version(api) == ""
+
+
+class TestOnlyAnExactPinIsActedOn:
+    """Deciding whether an installed version satisfies a RANGE needs a semver
+    resolver this module cannot have — it is stdlib-only because setup_api.py
+    imports it before any dependency exists. Answering "I cannot tell" is the
+    safe direction: the caller's response to drift is a multi-minute
+    re-download and rebuild."""
+
+    def test_a_caret_range_is_not_an_exact_pin(self, tmp_path):
+        api = _api_dir(tmp_path, installed="2.3.1", pinned="^2.3.3")
+        assert required_wppconnect_version(api) == ""
+        assert wppconnect_library_drift(api) is None
+
+    def test_a_tilde_range_is_not_an_exact_pin(self, tmp_path):
+        api = _api_dir(tmp_path, installed="2.3.1", pinned="~2.3.3")
+        assert wppconnect_library_drift(api) is None
+
+    def test_a_wildcard_is_not_an_exact_pin(self, tmp_path):
+        api = _api_dir(tmp_path, installed="2.3.1", pinned="*")
+        assert wppconnect_library_drift(api) is None
+
+    def test_a_git_url_is_not_an_exact_pin(self, tmp_path):
+        api = _api_dir(tmp_path, installed="2.3.1",
+                       pinned="github:wppconnect-team/wppconnect#main")
+        assert wppconnect_library_drift(api) is None
+
+    def test_a_prerelease_pin_is_still_exact(self, tmp_path):
+        api = _api_dir(tmp_path, installed="2.4.0-rc1", pinned="2.4.0-rc2")
+        assert required_wppconnect_version(api) == "2.4.0-rc2"
+        assert wppconnect_library_drift(api) == ("2.4.0-rc1", "2.4.0-rc2")
+
+
+class TestTheDrift:
+    def test_the_real_reported_mismatch_is_detected(self, tmp_path):
+        """The exact pair found on a live install."""
+        api = _api_dir(tmp_path, installed="2.3.1", pinned="2.3.3")
+        assert wppconnect_library_drift(api) == ("2.3.1", "2.3.3")
+
+    def test_agreeing_versions_are_not_drift(self, tmp_path):
+        api = _api_dir(tmp_path, installed="2.3.3", pinned="2.3.3")
+        assert wppconnect_library_drift(api) is None
+
+    def test_a_newer_library_is_drift_too(self, tmp_path):
+        """Not a "below the minimum" test: the patches search for one exact
+        version's source text, so a newer library misses them just as an
+        older one does."""
+        api = _api_dir(tmp_path, installed="2.4.0", pinned="2.3.3")
+        assert wppconnect_library_drift(api) == ("2.4.0", "2.3.3")
+
+    def test_whitespace_around_a_version_does_not_invent_drift(self, tmp_path):
+        api = _api_dir(tmp_path, installed=" 2.3.3 ", pinned=" 2.3.3 ")
+        assert wppconnect_library_drift(api) is None
+
+    def test_nothing_readable_is_never_reported_as_drift(self, tmp_path):
+        """Every unknown answers None: the response to drift is a full
+        rebuild, far too expensive to trigger on a file that could not be
+        parsed."""
+        assert wppconnect_library_drift(str(tmp_path / "nope")) is None
+        assert wppconnect_library_drift(
+            _api_dir(tmp_path, installed=None, pinned="2.3.3")) is None
+        assert wppconnect_library_drift(
+            _api_dir(tmp_path, installed="2.3.1", pinned=None)) is None
+
+    def test_a_non_dict_dependencies_block_is_survived(self, tmp_path):
+        api = _api_dir(tmp_path, installed="2.3.1", pinned=None,
+                       pkg_extra={"dependencies": "not-an-object"})
+        assert wppconnect_library_drift(api) is None
+
+
+# ── The gate that consumes it ────────────────────────────────────────────────
+
+
+class _Gate:
+    """MainWindow's two version questions, unbound against a stub.
+
+    MainWindow is a wx.Frame and cannot be built without a running wx.App;
+    these two methods touch nothing but the helpers below them.
+    """
+
+    _server_version_below_minimum = main.MainWindow._server_version_below_minimum
+    _wppconnect_library_drift     = main.MainWindow._wppconnect_library_drift
+    # staticmethod(), or binding it as a plain class attribute would make it
+    # an instance method and pass `self` as the first version.
+    _version_is_below = staticmethod(main.MainWindow._version_is_below)
+
+    def __init__(self, installed="2.10.18", minimum="2.10.18", drift=None):
+        self._installed = installed
+        self._minimum = minimum
+        self._drift = drift
+
+    def _read_wpp_minimum_version(self):
+        return self._minimum
+
+    def _get_installed_wpp_version(self):
+        return self._installed
+
+
+class TestTheServerCheckCannotSeeAnUpdateIntroducedDrift:
+    """Why the library check had to be added rather than the server one
+    tightened: both of the server check's inputs — api/package.json's own
+    "version" and wpp_minimum_version.txt — ship inside the release ZIP, so
+    an update rewrites them together and they agree afterwards no matter what
+    happened to node_modules."""
+
+    def test_matching_versions_report_nothing(self):
+        assert _Gate(installed="2.10.18", minimum="2.10.18")._server_version_below_minimum() is None
+
+    def test_an_older_server_is_still_caught(self):
+        """The case it CAN see: an install never updated at all."""
+        gate = _Gate(installed="2.10.16", minimum="2.10.18")
+        assert gate._server_version_below_minimum() == ("2.10.16", "2.10.18")
+
+    def test_a_newer_server_is_not_a_problem(self):
+        assert _Gate(installed="2.11.0", minimum="2.10.18")._server_version_below_minimum() is None
+
+    def test_unreadable_inputs_report_nothing(self):
+        assert _Gate(installed="", minimum="2.10.18")._server_version_below_minimum() is None
+        assert _Gate(installed="2.10.16", minimum="")._server_version_below_minimum() is None
+
+
+class TestTheLibraryCheckNeverBlocksStartup:
+    def test_an_exception_is_swallowed_rather_than_raised(self, monkeypatch):
+        """It runs on the startup path, before the Node server is brought up
+        — an exception escaping here would leave the app open with no server
+        behind it."""
+        def _boom(_api_dir):
+            raise RuntimeError("unreadable")
+        monkeypatch.setattr(main, "wppconnect_library_drift", _boom)
+        monkeypatch.setattr(main, "resource_path", lambda *p: "/nope")
+
+        assert _Gate()._wppconnect_library_drift() is None
+
+    def test_a_drift_is_passed_through(self, monkeypatch):
+        monkeypatch.setattr(main, "wppconnect_library_drift",
+                            lambda _api_dir: ("2.3.1", "2.3.3"))
+        monkeypatch.setattr(main, "resource_path", lambda *p: "/api")
+
+        assert _Gate()._wppconnect_library_drift() == ("2.3.1", "2.3.3")
+
+
+class TestTheReinstallTagIsNeverBuiltFromALibraryVersion:
+    """The library branch's version is a wppconnect number ("2.3.3"), and no
+    wppconnect-SERVER release is tagged v2.3.3 — feeding it to
+    ApiSetupDialog's forced_tag would build a 404 archive URL, the same
+    failure the bare-version bug had. Only the server branch may fall back to
+    its own number; the library branch passes no tag and lets the dialog
+    resolve the latest release itself."""
+
+    def test_the_fallback_is_gated_on_the_server_branch(self):
+        src = inspect.getsource(main.MainWindow.ensure_wpp_version)
+        assert "if not minimum_tag and outdated:" in src
+        # and the tag is handed over as-is, never re-derived at the call site
+        assert "forced_tag=minimum_tag," in src


### PR DESCRIPTION
Investigated from the reports of "I updated WinZapp and it disconnected me". This is the mechanism, and nothing was checking for it.

## What happens

`build.py`'s `API_EXCLUDE_DIRS` keeps `node_modules` **out** of the release ZIP. So an update ships a new `api/dist/server.js` and a new `api/package.json` over whatever wppconnect the machine already had installed.

What breaks is the patching. `core/wppconnect_*_patch.py` rewrites the library's *compiled* output by searching for exact source text, so against an unexpected version a patch does not fail — it is **silently skipped**.

Measured, not theorised:

- [#164](https://github.com/gabrielhhaber/WinZapp_Python/issues/164)'s attached log has `host.layer.js — checkQrCode: DID NOT MATCH any known source text — left untouched` and the same for `loginByCode`. Those two are the pairing-code path. That session then cycled `CLOSED → INITIALIZING → CLOSED` for three minutes and never reached `CONNECTED`.
- A second install, inspected directly: `api/node_modules/@wppconnect-team/wppconnect` at **2.3.1** under an `api/package.json` pinning **2.3.3**. Its patches still applied — 2.3.1's source happens to still match — which is why this hits some people and not others: it depends on which stale version you are stuck at.

## Why the existing gate could never see it

`ensure_wpp_version()` compared `api/package.json`'s own `"version"` field (the WPPConnect **Server** number) against `wpp_minimum_version.txt`. **Both files ship inside the release ZIP**, so an update rewrites the two together and they agree by construction afterwards. The gate can only catch an install that was never updated — never a drift the update itself introduced.

That gate also spent its whole life as dead code (it guarded on `dist/main.js`, which WPPConnect Server never builds) and was only made live two days ago, so this blind spot has never been exercised in the field until now.

## The change

`wppconnect_library_drift()` in `core/wpp_runtime.py` reads the version actually present in `node_modules` and the version `api/package.json` pins, and reports the pair when they differ. Pure and stdlib-only, because `setup_api.py` imports that module before any dependency exists.

Two deliberate choices:

- **Any difference counts, not just an older one.** The patches target one exact version's source text, so a newer library misses them exactly as an older one does.
- **A non-exact pin (`^`, `~`, `*`, a git URL) answers "I cannot tell".** Deciding whether an installed version satisfies a range needs a semver resolver this module cannot have, and the caller's response to drift is a multi-minute re-download and rebuild — far too expensive to trigger on a guess. Every unreadable input answers the same way.

`ensure_wpp_version()` now offers the same existing repair for either problem, reusing the dialog and strings already there — **no new locale keys**. The reinstall runs `npm install`, which brings `node_modules` to the pin, and re-applies the patches against source they will now match.

One thing that had to be gated: only the server branch may fall back to building a tag from its own number. The library branch's number is a wppconnect version, and there is no wppconnect-**server** release tagged `v2.3.3` — passing it would build a 404 archive URL, the same defect the bare-version bug had. The library branch passes no tag and lets `ApiSetupDialog` resolve the latest release itself.

## Tests

`tests/test_wppconnect_library_drift.py`, 23 tests against real files in `tmp_path` rather than mocks (the code is pure): both version reads, the exact-pin rule across `^`/`~`/`*`/git-URL/pre-release, the real reported 2.3.1-vs-2.3.3 pair, a newer library, every unreadable path, plus the gate itself — including that the server check cannot see an update-introduced drift, that a failure in the library check never blocks startup, and that the tag fallback stays gated on the server branch.

Full suite: 6617 passed. The 18 failures on my machine are all `client/api` ↔ `client/api_patches` drift (git-ignored, stale locally); this diff touches no Node file.

## Not in this PR

The same investigation found a second, independent problem: a `shutdown_audit.log` shows an update proceeding over a run that never wrote a single teardown line, and the generated `.bat` does `taskkill /F` on the port two seconds after the PID disappears without verifying the flush happened, and never touches an orphaned `chrome.exe` (which listens on no port). Worth its own change.