### PR TITLE
Two settings/backfill fixes found reviewing the new work

### DIFF
--- a/client/core/utils.py
+++ b/client/core/utils.py
@@ -552,6 +552,54 @@ def migrate_voice_message_mode_default(settings) -> bool:
     return True
 
 
+# Marks that the one-shot spell_check_enabled -> spell_check_mode conversion
+# has already run. Its own flag, like the two above, for the same reason.
+SPELL_CHECK_MODE_MIGRATION_FLAG = "spell_check_mode_migrated"
+
+
+def migrate_spell_check_mode(settings) -> bool:
+    """Carry a legacy ``spell_check_enabled`` bool onto ``spell_check_mode``.
+
+    core/spell_checker.py's spell_check_mode() already knows how to read the
+    old bool, but that fallback is unreachable on a real install:
+    backfill_missing_defaults() inserts the new key (it is in DEFAULT_SETTINGS)
+    on the first launch after the update, before anything has read the setting,
+    so every later call finds a recognised mode and never looks at the legacy
+    value. A user who had turned spell checking off got it back on, while their
+    settings.json still said ``spell_check_enabled: false`` — the setting
+    looking honoured is what makes that hard to notice.
+
+    Hence a migration rather than a read-time fallback, run from
+    _migrate_settings() and therefore BEFORE the backfill that would otherwise
+    invent the value this reads.
+
+    Only an explicit False is carried across, matching what spell_check_mode()
+    already decided: True was the default nobody chose, so it means "expressed
+    no preference" and lands on the new default instead of being frozen into an
+    override that would ignore Windows forever. An already-present
+    ``spell_check_mode`` is never overwritten — that is a choice made under the
+    new setting and outranks the old one.
+
+    The flag is what keeps this one-shot: without it, a user who deliberately
+    goes back to "follow Windows" would find it reverted to "off" on the next
+    launch, and that is exactly the user who cares. Returns True whenever
+    *settings* changed, the flag included — an unwritten flag is no flag.
+    """
+    if not isinstance(settings, dict):
+        return False
+    general = settings.get("general")
+    if not isinstance(general, dict):
+        general = {}
+        settings["general"] = general
+    if general.get(SPELL_CHECK_MODE_MIGRATION_FLAG):
+        return False
+    if ("spell_check_mode" not in general
+            and general.get("spell_check_enabled") is False):
+        general["spell_check_mode"] = "off"
+    general[SPELL_CHECK_MODE_MIGRATION_FLAG] = True
+    return True
+
+
 def auto_download_allows(settings, msg) -> bool:
     """Whether the background auto-download may fetch *msg*'s media.
 

--- a/client/main.py
+++ b/client/main.py
@@ -62,7 +62,7 @@ from core.send_contract import accepted_message_id
 from core.wpp_runtime import (
     read_homologated_wpp_version, wppconnect_library_drift, WPPCONNECT_PACKAGE,
 )
-from core.utils import reaction_targets_status, encrypt, decrypt, encrypt_json, decrypt_json, generate_and_save_key, retrieve_key, format_number, is_phone_like, looks_like_binary_blob, prune_message_record, prune_chats_messages, effective_unread_count, mute_response_accepted, normalize_for_search, search_normalization_mode, parse_bool_flag as _parse_bool_flag, group_setting_notif_value, DEFAULT_SETTINGS, append_selected_marker, is_message_forwarded, plan_row_updates, display_page_fetch_limit, carry_over_video_durations, video_seconds, MEASURED_SECONDS_KEY, is_voice_message, backfill_missing_defaults, auto_download_allows, migrate_voice_messages_media_types, migrate_voice_message_mode_default
+from core.utils import reaction_targets_status, encrypt, decrypt, encrypt_json, decrypt_json, generate_and_save_key, retrieve_key, format_number, is_phone_like, looks_like_binary_blob, prune_message_record, prune_chats_messages, effective_unread_count, mute_response_accepted, normalize_for_search, search_normalization_mode, parse_bool_flag as _parse_bool_flag, group_setting_notif_value, DEFAULT_SETTINGS, append_selected_marker, is_message_forwarded, plan_row_updates, display_page_fetch_limit, carry_over_video_durations, video_seconds, MEASURED_SECONDS_KEY, is_voice_message, backfill_missing_defaults, auto_download_allows, migrate_voice_messages_media_types, migrate_voice_message_mode_default, migrate_spell_check_mode
 from core.locale_format import get_date_format, get_time_format, get_datetime_format
 from core.quiet_hours import is_quiet_hours_active
 from core.database_bridge import DatabaseBridge
@@ -10344,6 +10344,13 @@ class MainWindow(wx.Frame):
         # default only reaches anyone through a conversion. One shot, with
         # its own flag — see migrate_voice_message_mode_default().
         if migrate_voice_message_mode_default(self.settings):
+            changed = True
+        # spell_check_enabled (bool) -> spell_check_mode (three-valued).
+        # core/spell_checker.py's own read-time fallback cannot reach a real
+        # install: backfill_missing_defaults() below invents spell_check_mode
+        # before anything reads it. Must run here, ahead of that backfill —
+        # see migrate_spell_check_mode().
+        if migrate_spell_check_mode(self.settings):
             changed = True
         if changed:
             self.save_settings()

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -13683,6 +13683,17 @@ class ConversationsPanel(wx.Panel):
         jid = self.conversation.get("remoteJid", "")
         if not jid:
             return
+        # Before the cooldown is stamped, not after. Every request this pass
+        # would make bails on the same flag inside
+        # MainWindow.fetch_message_reactions(), so arming it while offline
+        # spends the whole 5 minutes on a pass that cannot fetch anything —
+        # and the pass that most often runs disconnected is the one right
+        # after a reconnection, which is the case this backfill exists for:
+        # the health poll can take ~30 s to confirm the connection, and a
+        # chat opened inside that window would then stay stale until the user
+        # left it and came back more than five minutes later.
+        if not getattr(self.main_window, "_wa_connected", False):
+            return
         if not self._reaction_backfill_is_due(jid):
             return
         records = (

--- a/tests/test_reaction_backfill.py
+++ b/tests/test_reaction_backfill.py
@@ -54,6 +54,10 @@ class _FakeMainWindow:
         self._lid_to_phone = dict(lid_to_phone or {})
         self.my_jid = ME
         self.my_lid = ""
+        # The real fetch_message_reactions() refuses to send anything while
+        # this is False, so the backfill refuses to spend its cooldown on a
+        # pass that could not fetch — see TestItDoesNotSpendItsCooldownOffline.
+        self._wa_connected = True
 
     def get_chat(self, jid):
         return self._chat
@@ -513,6 +517,50 @@ class TestTheCooldown:
         stub._backfill_reactions_for_open_conversation()
 
         assert stub.main_window.fetch_calls == ["m1", "m1"]
+
+
+class TestItDoesNotSpendItsCooldownOffline:
+    """The cooldown may only be spent on a pass that could actually fetch.
+
+    Every request this makes bails on `_wa_connected` inside
+    MainWindow.fetch_message_reactions(), so a pass armed while disconnected
+    fetches nothing and still locks the chat out for five minutes. The pass
+    most likely to run disconnected is the one right after a reconnection —
+    the health poll can take ~30 s to confirm it — which is exactly the case
+    this backfill exists for: reactions that arrived while WinZapp was away.
+    """
+
+    def test_a_disconnected_open_fetches_nothing(self, monkeypatch):
+        monkeypatch.setattr(
+            threading.Thread, "start",
+            lambda self: self._target(*self._args, **self._kwargs),
+        )
+        stub = _Stub(JID, records=[_msg("m1", 100)])
+        stub.main_window._wa_connected = False
+
+        stub._backfill_reactions_for_open_conversation()
+
+        assert stub.main_window.fetch_calls == []
+
+    def test_and_leaves_the_cooldown_unspent(self, monkeypatch):
+        """The point of the fix: the open that follows, once the connection is
+        up, still does the work instead of waiting out five minutes."""
+        monkeypatch.setattr(
+            threading.Thread, "start",
+            lambda self: self._target(*self._args, **self._kwargs),
+        )
+        stub = _Stub(JID, records=[_msg("m1", 100)])
+        stub.main_window._wa_connected = False
+
+        stub._backfill_reactions_for_open_conversation()
+        assert stub._reaction_backfill_last == {}, (
+            "the cooldown was stamped by a pass that could not fetch"
+        )
+
+        stub.main_window._wa_connected = True
+        stub._backfill_reactions_for_open_conversation()
+
+        assert stub.main_window.fetch_calls == ["m1"]
 
 
 class TestGenerationGuard:

--- a/tests/test_sound_events_migration.py
+++ b/tests/test_sound_events_migration.py
@@ -18,7 +18,8 @@ tests/test_reported_bugfixes.py.
 
 from main import MainWindow
 from core.sound_system import DEFAULT_PACK_ID
-from core.utils import (VOICE_MEDIA_TYPE_MIGRATION_FLAG,
+from core.utils import (SPELL_CHECK_MODE_MIGRATION_FLAG,
+                        VOICE_MEDIA_TYPE_MIGRATION_FLAG,
                         VOICE_MESSAGE_MODE_MIGRATION_FLAG)
 
 
@@ -35,6 +36,7 @@ class _MainWindowStub:
         self.settings.setdefault("general", {}).update({
             VOICE_MEDIA_TYPE_MIGRATION_FLAG: True,
             VOICE_MESSAGE_MODE_MIGRATION_FLAG: True,
+            SPELL_CHECK_MODE_MIGRATION_FLAG: True,
         })
         self.save_calls = 0
 

--- a/tests/test_spell_check_setting.py
+++ b/tests/test_spell_check_setting.py
@@ -31,6 +31,10 @@ from ui.conversations import ConversationsPanel
 from core.spell_checker import (
     SPELL_CHECK_MODES, spell_check_active, spell_check_mode,
 )
+from core.utils import (
+    DEFAULT_SETTINGS, SPELL_CHECK_MODE_MIGRATION_FLAG,
+    backfill_missing_defaults, migrate_spell_check_mode,
+)
 
 
 _CLIENT = pathlib.Path(__file__).resolve().parents[1] / "client"
@@ -112,6 +116,68 @@ class TestTheLegacyBoolIsMigrated:
         assert spell_check_mode(
             {"spell_check_mode": "on", "spell_check_enabled": False}
         ) == "on"
+
+
+class TestTheMigrationSurvivesTheBackfill:
+    """The read-time fallback above is correct and, on its own, unreachable.
+
+    `spell_check_mode` is in DEFAULT_SETTINGS, so backfill_missing_defaults()
+    inserts it on the first launch after the update — before anything has read
+    the setting. Every later call then finds a recognised mode and never looks
+    at the legacy bool, so a user who had turned checking off got it back on
+    while their settings.json still said `spell_check_enabled: false`.
+    Confirmed against a real install, whose settings.json came out of the
+    update carrying both keys.
+
+    These drive the two functions in the order MainWindow.load_settings() runs
+    them, because testing the fallback against a dict holding only the legacy
+    key — which is what the class above does — passes either way.
+    """
+
+    def _loaded(self, general):
+        """settings as load_settings() leaves them: migrate, then backfill."""
+        settings = {"general": dict(general)}
+        migrate_spell_check_mode(settings)
+        backfill_missing_defaults(settings, DEFAULT_SETTINGS)
+        return settings["general"]
+
+    def test_an_explicit_false_survives_the_backfill(self):
+        assert spell_check_mode(
+            self._loaded({"spell_check_enabled": False})) == "off"
+
+    def test_it_stays_off_on_the_next_launch_too(self):
+        settings = {"general": {"spell_check_enabled": False}}
+        migrate_spell_check_mode(settings)
+        backfill_missing_defaults(settings, DEFAULT_SETTINGS)
+        migrate_spell_check_mode(settings)  # second launch
+        assert spell_check_mode(settings["general"]) == "off"
+
+    def test_a_legacy_true_still_lands_on_the_new_default(self):
+        assert spell_check_mode(
+            self._loaded({"spell_check_enabled": True})) == "windows"
+
+    def test_a_fresh_install_is_untouched(self):
+        assert spell_check_mode(self._loaded({})) == "windows"
+
+    def test_a_choice_made_under_the_new_setting_outranks_the_old_bool(self):
+        assert spell_check_mode(self._loaded(
+            {"spell_check_mode": "on", "spell_check_enabled": False})) == "on"
+
+    def test_the_flag_makes_it_one_shot(self):
+        """Without it, a user who goes back to "follow Windows" finds it
+        reverted to "off" on the next launch — and that is the user who
+        cares."""
+        settings = {"general": {"spell_check_enabled": False}}
+        migrate_spell_check_mode(settings)
+        settings["general"]["spell_check_mode"] = "windows"  # user re-chooses
+        assert migrate_spell_check_mode(settings) is False
+        assert settings["general"]["spell_check_mode"] == "windows"
+
+    def test_the_flag_is_written_even_when_nothing_was_converted(self):
+        """An unwritten flag is the same as no flag."""
+        settings = {"general": {}}
+        assert migrate_spell_check_mode(settings) is True
+        assert settings["general"][SPELL_CHECK_MODE_MIGRATION_FLAG] is True
 
 
 class TestTheDecision:


### PR DESCRIPTION
Dois achados da revisão do trabalho novo que entrou no `main`.

---

## 1. O bool legado `spell_check_enabled` nunca chegava à sua migração

O `spell_check_mode()` sabe ler o bool antigo, mas esse fallback é **inalcançável** num install real: `spell_check_mode` está em `DEFAULT_SETTINGS`, então o `backfill_missing_defaults()` insere a chave no primeiro launch após a atualização — **antes de qualquer leitura** — e a partir daí toda chamada encontra um modo reconhecido e nunca olha para o valor legado.

Quem tinha desligado a verificação ortográfica de propósito ficava com ela **ligada de volta**, enquanto o settings.json continuava dizendo `spell_check_enabled: false`. O ajuste parecer respeitado é o que torna isso difícil de perceber.

Confirmado num install real (o settings.json saiu da atualização carregando as duas chaves) e rodando as duas funções na ordem em que o `load_settings()` as executa: `spell_check_mode()` responde `"off"` antes do backfill e `"windows"` depois.

A correção é uma migração one-shot, no formato que o CLAUDE.md prescreve e que as duas já existentes usam: flag própria, chamada do `_migrate_settings()` — que já está ordenado à frente do backfill exatamente por isso. Só um `False` explícito é convertido (o `True` era o default que ninguém escolheu, então lê como "não expressou preferência"), e um `spell_check_mode` já presente nunca é sobrescrito, porque é uma escolha feita sob o ajuste novo.

O fallback de leitura em `spell_checker.py` fica onde está: está correto, e agora é redundante em vez de errado.

O `tests/test_spell_check_setting.py` exercitava a migração contra um dict só com a chave legada, o que passa de qualquer jeito — por isso escapou. A classe nova dirige migração + backfill na ordem do próprio `load_settings()`.

---

## 2. O backfill de reações gastava o cooldown em passadas que não podiam buscar

Toda requisição do `_backfill_reactions_for_open_conversation()` sai pelo guard de `_wa_connected` dentro do `MainWindow.fetch_message_reactions()`, mas o cooldown de 5 minutos era carimbado **antes** de qualquer tentativa.

Abra uma conversa enquanto a reconexão ainda está sendo confirmada — o poll de saúde pode levar ~30s — e a passada não busca nada e ainda tranca aquele chat por cinco minutos. Que é justamente o caso para o qual esse backfill existe: reações que chegaram enquanto o WinZapp estava fora.

A checagem de conectividade passa para antes do `_reaction_backfill_is_due()`. Menor corte que fecha o problema: desmarcar depois exigiria a thread de fundo voltar no mapa de cooldown, correndo com outra conversa sendo aberta.

---

## Duas notas do lado dos testes, nenhuma é regressão

- O stub de `test_sound_events_migration.py` pré-marca todas as outras migrações one-shot como já feitas, para que `save_calls` responda só pela migração que aquele arquivo testa — o comentário dele diz isso. A flag nova entra nesse conjunto.
- O fake `MainWindow` de `test_reaction_backfill.py` não tinha `_wa_connected` nenhum, então sem defini-lo todos os testes de lá passariam a sair pelo guard novo sem exercitar nada.

Suíte completa: **6703 passed, 73 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)