### PR TITLE
An ambiguous send failure must never be answered by sending again

### DIFF
--- a/client/core/send_contract.py
+++ b/client/core/send_contract.py
@@ -79,3 +79,43 @@ def accepted_message_id(body) -> str:
         raise SendContractError("success response has no message id")
     parts = message_id.split("_")
     return parts[2] if len(parts) > 2 else parts[-1]
+
+
+def send_failure_is_ambiguous(status_code) -> bool:
+    """Whether a failed send might nevertheless have reached WhatsApp.
+
+    A 5xx from a send endpoint is `returnError` on the Node side — an
+    exception raised somewhere inside the controller — and by then WPPConnect
+    has usually already handed the message to WhatsApp Web. Measured on a real
+    install on 2026-09-09, and the ordering is the whole point:
+
+        16:17:04.744  echo  id=3EB0B499A4020A9246C939  extendedTextMessage
+        16:17:04.754  POST /send-reply -> 500
+
+    The echo of the delivered reply arrived **ten milliseconds before** the
+    error response for the very request that sent it. Everything the caller
+    does after that 500 is acting on a message that is already on its way.
+
+    So a 5xx proves nothing, and no caller may answer it by sending again:
+    send_text_message()'s own fallbacks used to retry it without the quote,
+    which put a second copy in the conversation (the user's report: "the reply
+    shows up correctly and is then duplicated"). The shape to answer with is
+    the one _classify_send_exception() already uses for a timeout —
+    ``retry: False, ambiguous: True`` — so the queue drops the message rather
+    than resending it and the WebSocket echo resolves the pending row if and
+    when WhatsApp really delivers it.
+
+    4xx is the opposite: the controller rejected the request before doing
+    anything with it (a bad phone, a quoted message it cannot find), so a
+    fallback there is free. That is the distinction the fallbacks lost by
+    testing "not 200/201".
+
+    An unreadable status is treated as ambiguous, because the only cost of
+    being wrong that way is a message the user has to send again — against a
+    duplicate nobody can take back.
+    """
+    try:
+        code = int(status_code)
+    except (TypeError, ValueError):
+        return True
+    return code >= 500

--- a/client/main.py
+++ b/client/main.py
@@ -58,7 +58,7 @@ from core.incremental_sync import (
 )
 from core.websocket_client import WebSocketClient
 from core.api_client import api_get, api_post, redact_credentials
-from core.send_contract import accepted_message_id
+from core.send_contract import accepted_message_id, send_failure_is_ambiguous
 from core.wpp_runtime import (
     read_homologated_wpp_version, wppconnect_library_drift, WPPCONNECT_PACKAGE,
 )
@@ -22146,8 +22146,15 @@ class MainWindow(wx.Frame):
                 #    Skipped when the API reports the session as disconnected:
                 #    nothing was sent, and the message must stay queued as-is
                 #    instead of burning a retry (see MessageQueue).
+                #
+                #    A 5xx is excluded, and that is not a narrowing of "any
+                #    definite 4xx/5xx" — it is the word *definite* being
+                #    honoured. See send_failure_is_ambiguous(): the controller
+                #    threw after handing the message to WhatsApp Web, so a
+                #    second attempt here is a second message.
                 fb_phone = self._legacy_phone_for_send(remote_jid) if is_lid_target else ""
-                if fb_phone and not self._check_wa_connection_closed(response):
+                if (fb_phone and not self._check_wa_connection_closed(response)
+                        and not send_failure_is_ambiguous(response.status_code)):
                     logging.warning(
                         "[send_text_message] @lid destination %s refused (HTTP %s: %s) — retrying with legacy %s",
                         remote_jid, response.status_code, response.text[:200], fb_phone,
@@ -22187,7 +22194,19 @@ class MainWindow(wx.Frame):
                 #    never take this fallback: a plain DM is observably the
                 #    wrong operation, so report failure and let the user retry
                 #    instead of claiming that an unquoted reply succeeded.
-                if response.status_code not in (200, 201) and quoted_id and not is_status_reply:
+                #
+                #    Nor may it take it after an ambiguous failure. This is the
+                #    duplicate a user reported as "the reply shows up correctly
+                #    and is then duplicated": /send-reply answered 500, the
+                #    quote was stripped, the plain copy was sent — and the echo
+                #    of the ORIGINAL reply had already arrived 10 ms before that
+                #    500 (see send_failure_is_ambiguous() for the measurement).
+                #    Two messages on WhatsApp for one action, the second one
+                #    quietly missing the quote, which is what makes it read as
+                #    the same message sent twice.
+                if (response.status_code not in (200, 201) and quoted_id
+                        and not is_status_reply
+                        and not send_failure_is_ambiguous(response.status_code)):
                     logging.warning("[send_text_message] Quoted send failed (HTTP %s). Retrying without quote on %s...",
                                     response.status_code, active_dest)
                     url = f"{self.wpp_server}:{self.wpp_port}/api/{self.token}/send-message"
@@ -22212,8 +22231,24 @@ class MainWindow(wx.Frame):
                         # so it stays queued — but never retried in a loop while
                         # the connection is out (see MessageQueue).
                         return {"ok": False, "error": err, "retry": False, "disconnected": True}
+                    if send_failure_is_ambiguous(response.status_code):
+                        # Skipping the fallbacks above only moves the duplicate
+                        # if this hands the same send back to the queue as
+                        # retryable — MessageQueue would then resend a message
+                        # that may already be on its way, which is the failure
+                        # _classify_send_exception() exists to prevent for a
+                        # timeout. Same evidence, same answer: drop it here and
+                        # let the WebSocket echo resolve the pending row if
+                        # WhatsApp really delivered it.
+                        logging.warning(
+                            "[send_text_message] HTTP %s is ambiguous — the message "
+                            "may already be on its way, so it is NOT resent. Body: %s",
+                            response.status_code, response.text[:300],
+                        )
+                        return {"ok": False, "error": err, "retry": False,
+                                "ambiguous": True}
                     # If it's a transient error, mark retryable
-                    is_retryable = response.status_code in (408, 429, 500, 502, 503, 504)
+                    is_retryable = response.status_code in (408, 429)
                     return {"ok": False, "error": err, "retry": is_retryable}
 
 

--- a/tests/test_ambiguous_send_is_not_resent.py
+++ b/tests/test_ambiguous_send_is_not_resent.py
@@ -1,0 +1,225 @@
+"""A 5xx from a send endpoint must never be answered by sending again.
+
+Reported as "I reply to a message, it shows up correctly, and then it is
+duplicated". Measured on a real install on 2026-09-09, and the ordering is the
+whole diagnosis:
+
+    16:17:04.744  echo  id=3EB0B499A4020A9246C939  type=extendedTextMessage
+    16:17:04.754  POST /send-reply -> 500
+    16:17:04.754  [send_text_message] Quoted send failed (HTTP 500). Retrying
+                  without quote...
+    16:17:04.819  echo  id=3EB04F1F7AD701833157FC  type=conversation
+    16:17:04.992  POST /send-message -> 201
+
+The echo of the delivered reply arrived **ten milliseconds before** the error
+response for the request that sent it. Two WhatsApp message ids came out of one
+user action, and the second one is missing the quote — which is what makes the
+duplicate read as the same message sent twice.
+
+A 5xx is `returnError` on the Node side: an exception thrown somewhere inside
+the controller, by which point WPPConnect has usually already handed the
+message to WhatsApp Web. So it proves nothing about delivery, and the codebase
+already has the right answer for that class of outcome —
+_classify_send_exception()'s `retry: False, ambiguous: True`, written after
+users saw 30+ copies arrive at once when connectivity returned. This is the
+same failure reached through a status code instead of an exception.
+
+Three decision points had to change together, because fixing fewer just moves
+the duplicate: the two in-function fallbacks (legacy @lid address, quote
+stripping) and the verdict handed back to MessageQueue, which would otherwise
+resend the whole thing itself.
+
+MainWindow is a wx.Frame, so send_text_message() is bound onto a stub carrying
+only what it touches — the pattern tests/test_probe_timeout_is_not_offline.py
+uses for the same method.
+"""
+
+import json
+import types
+
+import pytest
+
+import main
+from main import MainWindow
+from core.send_contract import send_failure_is_ambiguous
+
+
+JID = "5511999999999@s.whatsapp.net"
+GROUP = "120363426331215016@g.us"
+QUOTED = {"key": {"id": "3EB0AAA", "remoteJid": GROUP, "fromMe": False}}
+
+
+class _Response:
+    def __init__(self, status_code, payload=None):
+        self._payload = payload if payload is not None else {
+            "status": "error", "message": "boom",
+        }
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self.text = json.dumps(self._payload)
+
+    def json(self):
+        return self._payload
+
+
+class _Stub:
+    send_text_message = MainWindow.send_text_message
+    _check_wa_connection_closed = MainWindow._check_wa_connection_closed
+    _serialize_quoted_id = MainWindow._serialize_quoted_id
+    _serialize_msg_id = MainWindow._serialize_msg_id
+    _is_self_jid = MainWindow._is_self_jid
+
+    def __init__(self):
+        self.wpp_server = "http://127.0.0.1"
+        self.wpp_port = 6300
+        self.token = "tok"
+        self.my_jid = "5500000000000@s.whatsapp.net"
+        self.my_lid = ""
+        self.connection_flags = []
+        # The quote-stripped fallback announces "reply_quote_lost" on its way
+        # out, so the success path needs a translator to reach.
+        self.i18n = types.SimpleNamespace(t=lambda key: key)
+
+    def _resolve_jid_for_send(self, jid):
+        return jid
+
+    def _build_link_preview_options(self, link_preview):
+        return {}
+
+    def _legacy_phone_for_send(self, jid):
+        return jid.replace("@lid", "@c.us")
+
+    # Bound from the real class: the outer `except` funnels through it, and a
+    # stub that swallowed exceptions would turn a genuine break into a pass.
+    _classify_send_exception = MainWindow._classify_send_exception
+
+    def output(self, text, interrupt=False):
+        pass
+
+    def _set_wa_connected(self, connected, reason="", **kwargs):
+        self.connection_flags.append(bool(connected))
+
+    def check_wa_connection_http(self):
+        pass
+
+
+def _answer(monkeypatch, *responses):
+    """Return each response in turn; record every request that was made."""
+    calls = []
+    queue = list(responses)
+
+    def _fake_api_post(url, **kwargs):
+        calls.append(url)
+        return queue.pop(0) if len(queue) > 1 else queue[0]
+
+    monkeypatch.setattr(main, "api_post", _fake_api_post)
+    return calls
+
+
+class TestTheClassifier:
+    @pytest.mark.parametrize("status", [500, 502, 503, 504, 599])
+    def test_a_server_error_is_ambiguous(self, status):
+        assert send_failure_is_ambiguous(status) is True
+
+    @pytest.mark.parametrize("status", [200, 201, 400, 404, 408, 429, 499])
+    def test_a_client_error_is_not(self, status):
+        """4xx means the controller rejected the request before doing anything
+        with it — a bad phone, a quoted message it cannot find — so a fallback
+        there is free."""
+        assert send_failure_is_ambiguous(status) is False
+
+    @pytest.mark.parametrize("status", [None, "", "nonsense", object()])
+    def test_an_unreadable_status_is_ambiguous(self, status):
+        """Being wrong this way costs a message the user sends again; being
+        wrong the other way costs a duplicate nobody can take back."""
+        assert send_failure_is_ambiguous(status) is True
+
+
+class TestAQuotedSendThatFailsAmbiguously:
+    def test_the_quote_is_not_stripped_and_resent(self, monkeypatch):
+        """The reported duplicate, end to end."""
+        calls = _answer(monkeypatch, _Response(500))
+        stub = _Stub()
+
+        result = stub.send_text_message(GROUP, "oi", quoted=QUOTED)
+
+        assert len(calls) == 1, (
+            f"a second send went out after an ambiguous failure: {calls}"
+        )
+        assert calls[0].endswith("/send-reply")
+        assert result["ok"] is False
+        assert result["ambiguous"] is True
+        assert result["retry"] is False, (
+            "handed back as retryable, so MessageQueue resends it instead — "
+            "the same duplicate, one layer down"
+        )
+
+    def test_a_definite_rejection_still_retries_without_the_quote(
+            self, monkeypatch, wx_app):
+        """The fallback keeps working where it was meant to: a 4xx is the
+        controller refusing the request, most often because it cannot find the
+        quoted message.
+
+        Needs the shared wx.App: this is the only branch that reaches
+        wx.CallAfter, to announce that the quote was lost."""
+        calls = _answer(monkeypatch, _Response(400), _Response(201, {
+            "status": "success", "response": {"id": "3EB0NEW"},
+        }))
+        stub = _Stub()
+
+        result = stub.send_text_message(GROUP, "oi", quoted=QUOTED)
+
+        assert [c.rsplit("/", 1)[-1] for c in calls] == ["send-reply", "send-message"]
+        assert result["ok"] is True
+        assert result["quote_lost"] is True
+
+
+class TestAPlainSendThatFailsAmbiguously:
+    def test_it_is_not_handed_back_as_retryable(self, monkeypatch):
+        """No quote involved, so only the third decision point applies — and on
+        its own it is what stops MessageQueue resending."""
+        calls = _answer(monkeypatch, _Response(500))
+        stub = _Stub()
+
+        result = stub.send_text_message(JID, "oi")
+
+        assert len(calls) == 1
+        assert result["ambiguous"] is True
+        assert result["retry"] is False
+
+    @pytest.mark.parametrize("status", [408, 429])
+    def test_a_transient_client_error_is_still_retryable(self, monkeypatch, status):
+        """Nothing reached WhatsApp, so resending cannot duplicate anything."""
+        _answer(monkeypatch, _Response(status))
+        stub = _Stub()
+
+        result = stub.send_text_message(JID, "oi")
+
+        assert result["retry"] is True
+        assert result.get("ambiguous") is not True
+
+
+class TestTheLidFallback:
+    def test_an_ambiguous_failure_does_not_try_the_legacy_address(
+            self, monkeypatch):
+        """"any definite 4xx/5xx is worth one legacy attempt" — the word that
+        was not being honoured is *definite*. A second attempt on a 5xx is a
+        second message."""
+        calls = _answer(monkeypatch, _Response(500))
+        stub = _Stub()
+
+        result = stub.send_text_message("123456@lid", "oi")
+
+        assert len(calls) == 1, f"a legacy retry went out anyway: {calls}"
+        assert result["ambiguous"] is True
+
+    def test_a_definite_refusal_still_falls_back(self, monkeypatch):
+        calls = _answer(monkeypatch, _Response(400), _Response(201, {
+            "status": "success", "response": {"id": "3EB0NEW"},
+        }))
+        stub = _Stub()
+
+        result = stub.send_text_message("123456@lid", "oi")
+
+        assert len(calls) == 2
+        assert result == "3EB0NEW"


### PR DESCRIPTION
A resposta duplicada relatada pelo usuário: "respondo uma mensagem, ela aparece certo, e depois é duplicada". O log dele resolve, e a **ordem** é o diagnóstico inteiro:

```
16:17:04.744  echo  id=3EB0B499A4020A9246C939  type=extendedTextMessage
16:17:04.754  POST /send-reply -> 500
16:17:04.754  [send_text_message] Quoted send failed (HTTP 500). Retrying without quote...
16:17:04.819  echo  id=3EB04F1F7AD701833157FC  type=conversation
16:17:04.992  POST /send-message -> 201
```

O eco da resposta **entregue** chegou **dez milissegundos antes** da resposta de erro da requisição que a enviou. Dois ids de mensagem no WhatsApp para uma ação só — e o segundo sem a citação, que é o que faz a duplicata ler como "a mesma mensagem duas vezes".

**Não é a guarda do ciphertext**, que era a suspeita: aquele log inteiro tem **um** evento ciphertext, `fromMe=False`, tratado corretamente.

## O que estava errado

Um 5xx de um endpoint de envio é o `returnError` do lado Node — uma exceção lançada dentro do controller, e a essa altura o WPPConnect normalmente já entregou a mensagem ao WhatsApp Web. Ele não prova nada sobre a entrega.

Os fallbacks testavam `not in (200, 201)`, o que apaga essa distinção. O fallback de `@lid` se documenta como disparando em "any definite 4xx/5xx" — e a palavra que não estava sendo honrada é **definite**.

## A correção

`send_failure_is_ambiguous()` traça a linha, e **três** pontos de decisão passam a consultá-la, porque corrigir menos só muda a duplicata de lugar:

1. o fallback de endereço legado `@lid`, que mandaria uma segunda cópia para outro endereço;
2. o fallback que remove a citação — o que o log pegou;
3. o veredito devolvido ao `MessageQueue`: um 500 era reportado como *retryable*, então pular os dois fallbacks acima deixaria a própria fila reenviando tudo, uma camada abaixo.

A resposta para um resultado ambíguo **já existia** e é reaproveitada em vez de reinventada: o `retry: False, ambiguous: True` do `_classify_send_exception()`, escrito depois de usuários verem 30+ cópias entregues de uma vez quando a conexão voltava. A fila descarta a mensagem e o eco do WebSocket resolve a linha pendente se o WhatsApp realmente entregou — que no caso relatado já tinha acontecido, 10 ms antes.

`408`/`429` continuam retryable: nada chegou ao WhatsApp, então reenviar não pode duplicar. Um status ilegível lê como ambíguo — errar nessa direção custa uma mensagem que o usuário reenvia, contra uma duplicata que ninguém desfaz.

A recusa agora **loga o corpo da resposta**. O corpo daquele 500 não está no log — o warning que ele tomou nunca incluía — então a próxima ocorrência fica diagnosticável.

## Testes

`tests/test_ambiguous_send_is_not_resent.py` — 23 testes: o classificador (5xx, 4xx, status ilegível), a duplicata relatada de ponta a ponta, o fallback de citação continuando a funcionar num 4xx legítimo, o fallback de `@lid` nos dois casos, e os transientes seguindo retryable. Usa o mesmo harness que `tests/test_probe_timeout_is_not_offline.py` já usa para esse método.

Suíte completa: **6744 passed, 73 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)