### PR TITLE
Ask a recording device its own sample rate before the fixed list

### DIFF
--- a/client/core/audio_devices.py
+++ b/client/core/audio_devices.py
@@ -256,6 +256,77 @@ def fallback_input_device_indices(pa: "pyaudio.PyAudio | None" = None, exclude=(
 RECORDING_SAMPLE_CONFIGS = [(48000, 1), (48000, 2), (44100, 1), (44100, 2)]
 
 
+def recording_configs_for(device_index, pa=None) -> list:
+    """RECORDING_SAMPLE_CONFIGS with `device_index`'s own native rate first.
+
+    The fixed list above was written for WASAPI devices, whose native rate is
+    48000 on everything tested, and it leaves out the one family that never
+    offers either rate: a Bluetooth headset used as a *microphone*. Recording
+    takes it out of A2DP and into the Hands-Free Profile, whose SCO link is
+    mono at 8000 Hz (CVSD) or 16000 Hz (mSBC) — so every combination above is
+    refused and the device looks broken.
+
+    Reported from a real install on 2026-09-09, four times across two sessions:
+
+        [audio_devices] Input device test failed for every sample-rate/channel
+        combo (index=14)
+
+    (index 19 in the later session — a Bluetooth device's index is not stable,
+    which is why devices are stored by name.) Note the failure was never
+    confined to Settings validation: the constant above says it must mirror
+    _start_voice_recording()'s chain and does, so recording with that headset
+    could not have worked either. The dialog was telling the truth about a
+    limit that is WinZapp's, not the device's.
+
+    Asking the device rather than widening the list is what makes this general:
+    PortAudio already reports `defaultSampleRate`, which is the rate Windows
+    has the endpoint opened at, so this covers 8000 and 16000 without naming
+    them and covers whatever comes next for free. The fixed list stays as the
+    tail, because `defaultSampleRate` is a *default*, not the only rate a
+    device accepts, and a driver that reports one thing and accepts another
+    was the situation this whole chain exists for.
+
+    Never raises, and never returns an empty list: a device whose info cannot
+    be read falls back to exactly the previous behaviour.
+    """
+    if pyaudio is None:
+        return list(RECORDING_SAMPLE_CONFIGS)
+    owns_pa = pa is None
+    try:
+        if owns_pa:
+            pa = pyaudio.PyAudio()
+        info = pa.get_device_info_by_index(int(device_index))
+        native = int(round(float(info.get("defaultSampleRate") or 0)))
+        max_channels = int(info.get("maxInputChannels") or 0)
+    except Exception:
+        logging.info(
+            "[audio_devices] Could not read the native rate of input device %s "
+            "— falling back to the fixed combinations.", device_index,
+        )
+        return list(RECORDING_SAMPLE_CONFIGS)
+    finally:
+        if owns_pa and pa is not None:
+            try:
+                pa.terminate()
+            except Exception:
+                pass
+
+    configs = []
+    if native > 0:
+        # Mono first for the same reason the fixed list does it: WhatsApp voice
+        # messages are mono, and a stereo capture costs a downmix loop in pure
+        # Python. A device reporting a single input channel never gets asked
+        # for two — an HFP microphone is exactly that.
+        for channels in (1, 2):
+            if max_channels and channels > max_channels:
+                continue
+            configs.append((native, channels))
+    for combo in RECORDING_SAMPLE_CONFIGS:
+        if combo not in configs:
+            configs.append(combo)
+    return configs
+
+
 def test_input_device(device_index: int) -> bool:
     """Try to briefly open (without starting) an input stream on
     `device_index`, across every sample-rate/channel combo recording itself
@@ -266,7 +337,7 @@ def test_input_device(device_index: int) -> bool:
         return False
     pa = pyaudio.PyAudio()
     try:
-        for rate, channels in RECORDING_SAMPLE_CONFIGS:
+        for rate, channels in recording_configs_for(device_index, pa):
             try:
                 stream = pa.open(
                     rate=rate,

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -22,7 +22,8 @@ import wave
 import sound_lib.stream as sl_stream
 from sound_lib.effects import Tempo
 from core.audio_devices import (
-    find_input_device_index, fallback_input_device_indices, RECORDING_SAMPLE_CONFIGS,
+    find_input_device_index, fallback_input_device_indices,
+    recording_configs_for,
 )
 from core.audio_transcode import transcode_audio_to_wav
 from core.attachment_types import classify_attachment_media_type
@@ -3256,13 +3257,12 @@ class ConversationsPanel(wx.Panel):
             pa_cont = getattr(pyaudio, "paContinue", 0) if pyaudio is not None else 0
             return (None, pa_cont)
 
-        # Try each (rate, channels) combination in preference order (shared
-        # with core.audio_devices.test_input_device()'s Settings-dialog
-        # validation, so a device that validates there is guaranteed to open
-        # here too). WhatsApp voice messages are natively 48 kHz Mono.
-        # Prioritizing Mono avoids CPU-intensive downmixing loops in pure
-        # Python.
-        _configs = RECORDING_SAMPLE_CONFIGS
+        # The (rate, channels) combinations are resolved per device down in
+        # _try_open(), through the same recording_configs_for() that
+        # core.audio_devices.test_input_device() uses for the Settings-dialog
+        # validation — so a device that validates there is still guaranteed to
+        # open here. Mono stays first in both: WhatsApp voice messages are
+        # mono, and a stereo capture costs a downmix loop in pure Python.
         if self._recording_pa is None and pyaudio is not None:
             try:
                 self._recording_pa = pyaudio.PyAudio()
@@ -3309,7 +3309,11 @@ class ConversationsPanel(wx.Panel):
         pa = self._recording_pa
 
         def _try_open(device_index):
-            for rate, ch in _configs:
+            # Per device, not the shared list: a Bluetooth headset recording
+            # over HFP offers only its own 8/16 kHz mono link and refuses every
+            # fixed combination. See recording_configs_for(), which keeps the
+            # fixed list as the tail so nothing that worked before changes.
+            for rate, ch in recording_configs_for(device_index, pa):
                 try:
                     s = pa.open(
                         rate=rate,

--- a/tests/test_bluetooth_mic_native_rate.py
+++ b/tests/test_bluetooth_mic_native_rate.py
@@ -1,0 +1,141 @@
+"""A recording device is asked for its own sample rate before the fixed list.
+
+Reported from a real install on 2026-09-09 — selecting a Bluetooth headset as
+the recording device failed with "could not activate the selected recording
+device", four times across two sessions:
+
+    [audio_devices] Input device test failed for every sample-rate/channel
+    combo (index=14)      ... and index=19 in the later session
+
+PyAudio was present (that warning only exists on the branch where it loaded)
+and the device was enumerated and found. What failed is `pa.open()`, for every
+combination in RECORDING_SAMPLE_CONFIGS — 48000 and 44100.
+
+That list was written for WASAPI devices, whose native rate is 48000 on
+everything tested. A Bluetooth headset used as a *microphone* is the family it
+leaves out: recording takes the device out of A2DP and into the Hands-Free
+Profile, whose SCO link is mono at 8000 Hz (CVSD) or 16000 Hz (mSBC). Neither
+fixed rate is on offer, so the device looks broken and is not.
+
+The failure was never confined to Settings validation. RECORDING_SAMPLE_CONFIGS
+says it must mirror _start_voice_recording()'s chain and did, so recording with
+that headset could not have worked either — the dialog was reporting a limit
+that is WinZapp's.
+
+Asking the device is what makes the fix general: PortAudio already reports
+`defaultSampleRate`, so 8000 and 16000 are covered without being named, and so
+is whatever comes next. The fixed list stays as the tail, because a default is
+not the only rate a device accepts.
+"""
+
+import pytest
+
+import core.audio_devices as audio_devices
+from core.audio_devices import RECORDING_SAMPLE_CONFIGS, recording_configs_for
+
+
+class _FakePyAudio:
+    """Just the one call recording_configs_for() makes."""
+
+    def __init__(self, info=None, raises=False):
+        self._info = info or {}
+        self._raises = raises
+        self.terminated = 0
+
+    def get_device_info_by_index(self, index):
+        if self._raises:
+            raise OSError("device gone")
+        return self._info
+
+    def terminate(self):
+        self.terminated += 1
+
+
+@pytest.fixture(autouse=True)
+def _pyaudio_present(monkeypatch):
+    """The module degrades to the fixed list when PyAudio is absent; these
+    tests are about the branch where it is there."""
+    monkeypatch.setattr(audio_devices, "pyaudio", object())
+
+
+def _hfp(rate):
+    """What Windows reports for a Bluetooth headset's HFP microphone."""
+    return {"defaultSampleRate": float(rate), "maxInputChannels": 1}
+
+
+class TestTheDevicesOwnRateComesFirst:
+    @pytest.mark.parametrize("rate", [8000, 16000])
+    def test_a_bluetooth_headset_is_offered_its_own_link_rate(self, rate):
+        """The reported failure: neither 48000 nor 44100 is on offer, so every
+        combination was refused before this."""
+        configs = recording_configs_for(3, _FakePyAudio(_hfp(rate)))
+        assert configs[0] == (rate, 1)
+
+    def test_a_single_channel_device_is_never_asked_for_two(self):
+        """An HFP microphone is mono. Asking for stereo is one more refusal on
+        a path whose whole cost is refusals."""
+        configs = recording_configs_for(3, _FakePyAudio(_hfp(16000)))
+        assert (16000, 2) not in configs
+
+    def test_a_stereo_device_gets_mono_first_anyway(self):
+        """WhatsApp voice messages are mono, and a stereo capture costs a
+        downmix loop in pure Python — the reason the fixed list is ordered that
+        way too."""
+        info = {"defaultSampleRate": 32000.0, "maxInputChannels": 2}
+        configs = recording_configs_for(3, _FakePyAudio(info))
+        assert configs[:2] == [(32000, 1), (32000, 2)]
+
+    def test_the_fixed_list_still_follows(self):
+        """A default is not the only rate a device accepts, and a driver that
+        reports one thing and opens another is what this chain exists for."""
+        configs = recording_configs_for(3, _FakePyAudio(_hfp(16000)))
+        assert configs[-len(RECORDING_SAMPLE_CONFIGS):] == RECORDING_SAMPLE_CONFIGS
+
+    def test_a_native_rate_already_in_the_list_is_not_repeated(self):
+        info = {"defaultSampleRate": 48000.0, "maxInputChannels": 2}
+        configs = recording_configs_for(3, _FakePyAudio(info))
+        assert configs == RECORDING_SAMPLE_CONFIGS
+        assert len(configs) == len(set(configs))
+
+
+class TestItNeverMakesThingsWorse:
+    def test_an_unreadable_device_falls_back_to_the_old_behaviour(self):
+        configs = recording_configs_for(3, _FakePyAudio(raises=True))
+        assert configs == RECORDING_SAMPLE_CONFIGS
+
+    @pytest.mark.parametrize("value", [None, 0, "", "nonsense"])
+    def test_a_missing_or_junk_rate_is_ignored(self, value):
+        info = {"defaultSampleRate": value, "maxInputChannels": 1}
+        configs = recording_configs_for(3, _FakePyAudio(info))
+        assert configs == RECORDING_SAMPLE_CONFIGS
+
+    def test_without_pyaudio_it_answers_the_fixed_list(self, monkeypatch):
+        monkeypatch.setattr(audio_devices, "pyaudio", None)
+        assert recording_configs_for(3) == RECORDING_SAMPLE_CONFIGS
+
+    def test_a_borrowed_pyaudio_instance_is_not_terminated(self):
+        """Both callers pass their own live instance — test_input_device()
+        goes on using it for pa.open(), and _start_voice_recording() keeps it
+        for the whole recording."""
+        pa = _FakePyAudio(_hfp(16000))
+        recording_configs_for(3, pa)
+        assert pa.terminated == 0
+
+
+def test_both_call_sites_resolve_per_device():
+    """The constant's own comment requires the validation and the recording to
+    try the same combinations; two copies of that decision is how they would
+    drift apart."""
+    import ast
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1] / "client"
+    for rel in ("core/audio_devices.py", "ui/conversations.py"):
+        source = (root / rel).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        calls = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", None) == "recording_configs_for"
+        ]
+        assert calls, f"{rel} no longer resolves the combinations per device"


### PR DESCRIPTION
O microfone Bluetooth que falhava com "não foi possível ativar o dispositivo de gravação selecionado". Log de um install real, quatro vezes em duas sessões:

```
[audio_devices] Input device test failed for every sample-rate/channel combo (index=14)
[audio_devices] Input device test failed for every sample-rate/channel combo (index=19)
```

O PyAudio **está** presente (esse aviso só existe no ramo em que ele carregou) e o dispositivo é enumerado e encontrado. O que falha é o `pa.open()`, para **todas** as combinações de `RECORDING_SAMPLE_CONFIGS` — 48000 e 44100.

(O índice muda entre sessões, 14 → 19, o que é típico de Bluetooth e é por isso que os dispositivos são guardados por nome.)

## Por quê

Aquela lista foi escrita para dispositivos WASAPI, cuja taxa nativa é 48000 em tudo que foi testado — e o comentário logo acima dela descreve exatamente essa classe de falha ("most WASAPI devices only accept their own native rate... every non-default recording device used to fail Settings validation for exactly this reason").

Um fone Bluetooth usado **como microfone** é a família que ficou de fora: gravar tira o dispositivo do A2DP e o põe no Hands-Free Profile, cujo canal SCO é mono a **8000 Hz** (CVSD) ou **16000 Hz** (mSBC). Nenhuma das taxas fixas é oferecida, então o dispositivo parece quebrado e não está.

**Isso nunca foi só validação.** A constante diz que precisa espelhar a cadeia de `_start_voice_recording()` e espelhava — então gravar com aquele fone também não funcionaria. O diálogo estava relatando um limite que é do WinZapp, não do dispositivo. Os dois pontos agora resolvem as combinações por dispositivo, e um teste fixa que continuam compartilhando **uma** decisão em vez de criarem uma segunda cópia.

## A correção

`recording_configs_for()` pergunta o `defaultSampleRate` ao PortAudio em vez de aumentar a constante — é o que a torna geral: 8000 e 16000 ficam cobertos sem serem nomeados, e o que vier depois também. A lista fixa continua como cauda, porque um *default* não é a única taxa que um dispositivo aceita, e um driver que reporta uma coisa e abre outra é justamente o motivo de essa cadeia existir. Um dispositivo que informa um canal de entrada nunca é consultado por dois — um microfone HFP é exatamente isso, e cada recusa custa tempo num caminho cujo custo inteiro são recusas.

**Nada do que funcionava muda**: dispositivo ilegível, taxa ausente ou lixo, e ausência de PyAudio respondem exatamente a lista anterior. Uma instância passada pelo chamador nunca é terminada — os dois chamadores seguem usando a deles.

## Não corrigido aqui, e vale nomear

O `test_input_device()` roda isso **na thread da UI**, e o mesmo log pegou o watchdog acusando 3 s de interface congelada dentro do `_validate()` enquanto ele percorria as combinações.

## Testes

`tests/test_bluetooth_mic_native_rate.py` — 14 testes: as taxas HFP vindo primeiro, mono antes de estéreo, dispositivo mono nunca consultado por dois canais, a lista fixa seguindo como cauda sem duplicar, e cada caminho de degradação respondendo o comportamento anterior.

Suíte completa: **6735 passed, 73 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)