### PR TITLE
Announce the QR when it is on screen, and say so when it never arrives

### DIFF
--- a/client/core/websocket_client.py
+++ b/client/core/websocket_client.py
@@ -863,9 +863,18 @@ class WebSocketClient:
                 # unattended flood, whichever branch below ends up handling it.
                 self.main_window._unattended_qr_events = 0
             if dialog_open and self.connect.connection_mode == "qrcode" and base64_img:
-                # QR-CODE mode: update the image
-                self.main_window.pairing_code_updated_sound.play()
-                self.main_window.speak_output.output(self.i18n.t("qrcode_image_updated"))
+                # QR-CODE mode: update the image.
+                #
+                # "Updated" only once there is something to have updated. The
+                # first code a user ever sees arrives here too — the single
+                # status-session poll fires 71 ms after /start-session and
+                # measured 5.4 s before this event — and announcing it as a
+                # refresh is what made the QR seem to appear only on the second
+                # try. display_qrcode_image() owns the first one, where it can
+                # say the true thing at the moment it is actually on screen.
+                if getattr(self.connect, "_qr_displayed", False):
+                    self.main_window.pairing_code_updated_sound.play()
+                    self.main_window.speak_output.output(self.i18n.t("qrcode_image_updated"))
                 self.connect.display_qrcode_image(base64_img)
             elif dialog_open and self.connect.connection_mode == "phone" and pairing_code:
                 # Pairing code mode: update the text field only if it still exists.

--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -15,6 +15,8 @@
     "pairing_code_expired": "The pairing code has expired and will not be updated again. Cancel and try again to get a new code.",
     "qrcode_image_updated": "The QR code has been updated.",
     "qrcode_instructions": "Point your phone at the QR code displayed on the right side of the screen.",
+    "qrcode_generating": "Generating the QR code, please wait...",
+    "qrcode_not_generated": "The QR code could not be generated. Cancel and try again.",
     "connect_with_phone": "Connect with phone &number",
     "connect_with_qrcode": "Connect with &QR code",
     "cancel_pairing": "&Cancel pairing",

--- a/client/languages/es-ES.json
+++ b/client/languages/es-ES.json
@@ -15,6 +15,8 @@
     "pairing_code_expired": "El código de emparejamiento ha caducado y ya no se actualizará. Cancela e inténtalo de nuevo para recibir un código nuevo.",
     "qrcode_image_updated": "El código QR se ha actualizado.",
     "qrcode_instructions": "Apunta tu teléfono al código QR que se muestra en el lado derecho de la pantalla.",
+    "qrcode_generating": "Generando el código QR, espere...",
+    "qrcode_not_generated": "No se pudo generar el código QR. Cancele e inténtelo de nuevo.",
     "connect_with_phone": "Conectar con número de &teléfono",
     "connect_with_qrcode": "Conectar con código &QR",
     "cancel_pairing": "&Cancelar emparejamiento",

--- a/client/languages/pl.json
+++ b/client/languages/pl.json
@@ -15,6 +15,8 @@
     "pairing_code_expired": "Kod parowania wygasł i nie będzie już aktualizowany. Anuluj i spróbuj ponownie, aby otrzymać nowy kod.",
     "qrcode_image_updated": "Kod QR został zaktualizowany.",
     "qrcode_instructions": "Skieruj telefon na kod QR wyświetlony na ekranie.",
+    "qrcode_generating": "Generowanie kodu QR, proszę czekać...",
+    "qrcode_not_generated": "Nie udało się wygenerować kodu QR. Anuluj i spróbuj ponownie.",
     "connect_with_phone": "Połącz za pomocą &numeru telefonu",
     "connect_with_qrcode": "Połącz za pomocą kodu &QR",
     "cancel_pairing": "&Anuluj parowanie",

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -15,6 +15,8 @@
     "pairing_code_expired": "O código de pareamento expirou e não será mais atualizado. Cancele e tente novamente para receber um novo código.",
     "qrcode_image_updated": "O QR-CODE foi atualizado.",
     "qrcode_instructions": "Aponte seu celular para o QR-CODE exibido do lado direito da tela.",
+    "qrcode_generating": "Gerando o QR-code, aguarde...",
+    "qrcode_not_generated": "Não foi possível gerar o QR-code. Cancele e tente novamente.",
     "connect_with_phone": "Conectar com número de &telefone",
     "connect_with_qrcode": "Conectar com &QR-CODE",
     "cancel_pairing": "&Cancelar pareamento",

--- a/client/languages/pt-PT.json
+++ b/client/languages/pt-PT.json
@@ -15,6 +15,8 @@
     "pairing_code_expired": "O código de emparelhamento expirou e não será mais atualizado. Cancele e tente novamente para receber um novo código.",
     "qrcode_image_updated": "O código QR foi atualizado.",
     "qrcode_instructions": "Aponte o telemóvel para o código QR exibido do lado direito do ecrã.",
+    "qrcode_generating": "A gerar o QR-code, aguarde...",
+    "qrcode_not_generated": "Não foi possível gerar o QR-code. Cancele e tente novamente.",
     "connect_with_phone": "Ligar através do número de &telemóvel",
     "connect_with_qrcode": "Ligar-se através do código &QR",
     "cancel_pairing": "&Cancelar emparelhamento",

--- a/client/ui/dialogs/connect.py
+++ b/client/ui/dialogs/connect.py
@@ -892,8 +892,31 @@ class Connect:
         # Always start a fresh QR-CODE connection
         self.start_qrcode_connection(preserve_local_data=was_paired)
 
-        self.main_window.qrcode_loaded_sound.play()
-        self.main_window.output(self.i18n.t("qrcode_instructions"))
+        # NOT "the QR is ready" — it is not, and saying so is the bug this
+        # replaces. Measured on a real install:
+        #
+        #   21:47:13.174  POST /start-session -> 200
+        #   21:47:13.245  GET /status-session -> 200   (71 ms later: no qrcode)
+        #   21:47:13.245  "No QR in status-session yet — waiting for the event"
+        #   21:47:18.683  the QR finally arrives over the WebSocket
+        #
+        # start_qrcode_connection() returns as soon as /start-session is
+        # acknowledged, so this line used to play the "QR loaded" sound and
+        # read the instructions out over an empty box, five and a half seconds
+        # before there was anything to point a phone at. A sighted user sees
+        # the box fill in; a blind user was simply told a lie.
+        #
+        # The single status-session poll inside start_qrcode_connection() reads
+        # the right field — sessionController.ts answers `qrcode` at the top
+        # level, and display_qrcode_image() strips the data-URI prefix it
+        # carries. It is fired 71 ms after asking the session to start, so on a
+        # fresh session it cannot yet have one; it only ever pays off when an
+        # already-running session is reused. Keeping it costs nothing and this
+        # no longer depends on it.
+        self._qr_displayed = False
+        self._last_qr_payload = None
+        self.main_window.output(self.i18n.t("qrcode_generating"))
+        self._arm_qr_watchdog()
 
     def start_qrcode_connection(self, preserve_local_data=False):
         """Initiates QR-CODE connection without user interaction.
@@ -1143,12 +1166,74 @@ class Connect:
             # re-measure or the image is clipped to the old placeholder size.
             self.qrcode_panel.Layout()
 
-            self.main_window.pairing_code_updated_sound.play()
+            first = not getattr(self, "_qr_displayed", False)
+            self._qr_displayed = True
+            self._cancel_qr_watchdog()
+            if first:
+                # The honest moment for "here is your QR, point your phone at
+                # it" — the one the panel used to claim on open. Before this,
+                # the first code a user ever saw announced itself as an
+                # *update* (on_qrcode_update's refresh branch), which is what
+                # made the QR seem to appear only on the second try.
+                self.main_window.qrcode_loaded_sound.play()
+                self.main_window.output(self.i18n.t("qrcode_instructions"))
+            # No sound for a refresh: on_qrcode_update() already plays that one
+            # before calling here, and both firing left a single truncated blip
+            # rather than two cues — sound_lib restarts the stream (see
+            # CLAUDE.md on the focus_cloak work, same defect).
 
         except Exception:
             # Never silently: a QR that fails to render leaves the user staring
             # at an empty box with no idea why.
             logging.exception("[display_qrcode_image] Failed to render the QR code.")
+            self._announce_qr_failure("render failed")
+
+    # How long the dialog waits for a QR before saying it never arrived.
+    # Generously above the 5.4 s measured on the reporting install: this is the
+    # bound on a *silent* failure, and cutting a slow-but-working session short
+    # would replace one wrong announcement with another.
+    _QR_WATCHDOG_SECONDS = 25
+
+    def _arm_qr_watchdog(self):
+        """Say so if no QR ever reaches the screen.
+
+        The dialog's whole content is an image, so a blind user has no way to
+        tell "still generating" from "this is never going to work" — and the
+        old code could not tell them either, because it had already announced
+        success. Every path that fails to paint one is silent on its own:
+        status-session answering no qrcode, a qrCode event that carries nothing
+        usable, an undecodable payload, a session that never reaches QRCODE.
+        """
+        self._cancel_qr_watchdog()
+        # Per attempt: a user who cancels and tries again must be told about
+        # the second failure too.
+        self._qr_failure_announced = False
+        self._qr_watchdog = wx.CallLater(
+            self._QR_WATCHDOG_SECONDS * 1000,
+            self._announce_qr_failure, "no QR within %ds" % self._QR_WATCHDOG_SECONDS,
+        )
+
+    def _cancel_qr_watchdog(self):
+        timer = getattr(self, "_qr_watchdog", None)
+        self._qr_watchdog = None
+        if timer is not None:
+            try:
+                timer.Stop()
+            except Exception:
+                pass
+
+    def _announce_qr_failure(self, reason: str):
+        """Error sound and a spoken explanation, at most once per attempt."""
+        self._cancel_qr_watchdog()
+        if getattr(self, "_qr_failure_announced", False):
+            return
+        self._qr_failure_announced = True
+        logging.warning("[display_qrcode_image] No QR reached the screen (%s).", reason)
+        try:
+            self.main_window.error_sound.play()
+        except Exception:
+            pass
+        self.main_window.output(self.i18n.t("qrcode_not_generated"))
 
     def reconnect_websocket(self):
         """Reconnects WebSocket for QR-CODE mode (instance already created)."""

--- a/tests/test_qr_is_announced_when_it_exists.py
+++ b/tests/test_qr_is_announced_when_it_exists.py
@@ -1,0 +1,197 @@
+"""The pairing dialog must not say the QR is ready before it is.
+
+Reported after the move from Evolution API to WPPConnect: the first time the
+dialog asks for the phone to be pointed at the code, nothing is on screen, and
+the QR only appears on the first WebSocket refresh. Measured on a real install:
+
+    21:47:13.174  POST /start-session -> 200
+    21:47:13.245  GET /status-session -> 200      (71 ms later, no qrcode)
+    21:47:13.245  "No QR in status-session yet — waiting for the qrCode event"
+    21:47:18.683  the QR finally arrives over the WebSocket
+
+Two announcements, both wrong, and together they are the whole report:
+
+* on_switch_to_qrcode() played the "QR loaded" sound and read the instructions
+  the instant start_qrcode_connection() returned — 71 ms after asking the
+  session to start, five and a half seconds before there was anything to point
+  a phone at. A sighted user watches the box fill in; a blind user was told a
+  code was on screen when the box was empty.
+* the code that did eventually arrive announced itself as an *update*
+  ("O QR-CODE foi atualizado"), because on_qrcode_update()'s refresh branch is
+  the path it comes through — which is exactly what "it only shows up after the
+  first refresh" describes.
+
+The suspicion was that the first read looks at the wrong fields. It does not:
+sessionController.ts answers `qrcode` at the top level and display_qrcode_image()
+strips the data-URI prefix it carries. The poll is simply fired 71 ms after
+/start-session, so on a fresh session it cannot have one yet — it only pays off
+when an already-running session is reused.
+
+So the announcement moves to the moment a QR is really painted, and a watchdog
+covers the case where none ever is: the dialog's whole content is an image, so
+a blind user cannot tell "still generating" from "this will never work", and
+every path that fails to paint one is otherwise silent.
+
+Connect builds real wx dialogs, so the methods are exercised unbound against a
+stub carrying only what they touch.
+"""
+
+import pytest
+
+from ui.dialogs.connect import Connect
+
+
+class _FakeSound:
+    def __init__(self, log, name):
+        self._log = log
+        self._name = name
+
+    def play(self):
+        self._log.append(self._name)
+
+
+class _FakeI18n:
+    def t(self, key):
+        return key
+
+
+class _FakeMainWindow:
+    def __init__(self):
+        self.i18n = _FakeI18n()
+        self.spoken = []
+        self.sounds = []
+        self.qrcode_loaded_sound = _FakeSound(self.sounds, "loaded")
+        self.pairing_code_updated_sound = _FakeSound(self.sounds, "updated")
+        self.error_sound = _FakeSound(self.sounds, "error")
+
+    def output(self, text, interrupt=False):
+        self.spoken.append(text)
+
+
+class _Stub:
+    _arm_qr_watchdog = Connect._arm_qr_watchdog
+    _cancel_qr_watchdog = Connect._cancel_qr_watchdog
+    _announce_qr_failure = Connect._announce_qr_failure
+    _QR_WATCHDOG_SECONDS = Connect._QR_WATCHDOG_SECONDS
+
+    def __init__(self):
+        self.main_window = _FakeMainWindow()
+        self.i18n = self.main_window.i18n
+        self._qr_displayed = False
+        self.armed = []
+
+    @property
+    def spoken(self):
+        return self.main_window.spoken
+
+    @property
+    def sounds(self):
+        return self.main_window.sounds
+
+
+@pytest.fixture
+def stub(monkeypatch):
+    s = _Stub()
+    # wx.CallLater would need a running app and a real 25 s wait; the timer's
+    # own scheduling is wx's business, not this feature's.
+    calls = []
+
+    class _FakeTimer:
+        def __init__(self, ms, fn, *args):
+            calls.append((ms, fn, args))
+            self.stopped = False
+
+        def Stop(self):
+            self.stopped = True
+
+    monkeypatch.setattr("ui.dialogs.connect.wx.CallLater", _FakeTimer)
+    s.armed = calls
+    return s
+
+
+class TestNothingClaimsAQrThatIsNotThere:
+    def test_the_watchdog_is_armed_for_the_measured_delay_and_then_some(
+            self, stub):
+        stub._arm_qr_watchdog()
+        assert len(stub.armed) == 1
+        ms, _fn, _args = stub.armed[0]
+        assert ms == stub._QR_WATCHDOG_SECONDS * 1000
+        assert ms >= 6000, (
+            "the QR took 5.4 s to arrive on the reporting install; a tighter "
+            "bound replaces one wrong announcement with another"
+        )
+
+    def test_a_qr_that_never_arrives_is_reported(self, stub):
+        stub._arm_qr_watchdog()
+        _ms, fire, args = stub.armed[0]
+
+        fire(*args)
+
+        assert stub.spoken == ["qrcode_not_generated"]
+        assert stub.sounds == ["error"]
+
+    def test_it_is_reported_only_once(self, stub):
+        stub._arm_qr_watchdog()
+        stub._announce_qr_failure("first")
+        stub._announce_qr_failure("second")
+        assert stub.spoken == ["qrcode_not_generated"]
+
+    def test_a_second_attempt_can_fail_out_loud_too(self, stub):
+        """A user who cancels and tries again has to be told about that
+        failure as well."""
+        stub._arm_qr_watchdog()
+        stub._announce_qr_failure("first attempt")
+        stub._arm_qr_watchdog()
+        stub._announce_qr_failure("second attempt")
+        assert stub.spoken == ["qrcode_not_generated", "qrcode_not_generated"]
+
+    def test_cancelling_stops_the_timer(self, stub):
+        stub._arm_qr_watchdog()
+        timer = stub._qr_watchdog
+        stub._cancel_qr_watchdog()
+        assert timer.stopped is True
+        assert stub._qr_watchdog is None
+
+    def test_arming_again_stops_the_previous_timer(self, stub):
+        stub._arm_qr_watchdog()
+        first = stub._qr_watchdog
+        stub._arm_qr_watchdog()
+        assert first.stopped is True
+
+
+class TestTheSourceSaysTheRightThingAtTheRightTime:
+    """Structural: the two announcements live inside methods that need a real
+    wx dialog to reach, and what matters is *where* they sit."""
+
+    def test_the_panel_no_longer_claims_the_qr_on_open(self):
+        import inspect
+        source = inspect.getsource(Connect.on_switch_to_qrcode)
+        body = "\n".join(l for l in source.splitlines()
+                         if not l.lstrip().startswith("#"))
+        assert "qrcode_generating" in body
+        assert "qrcode_instructions" not in body, (
+            "the instructions are announced on open again — before "
+            "start_qrcode_connection() can possibly have produced a code"
+        )
+        assert "qrcode_loaded_sound" not in body
+
+    def test_the_instructions_moved_to_the_first_real_paint(self):
+        import inspect
+        source = inspect.getsource(Connect.display_qrcode_image)
+        assert "qrcode_instructions" in source
+        assert "qrcode_loaded_sound" in source
+        assert "_qr_displayed" in source
+
+    def test_the_first_code_is_not_announced_as_an_update(self):
+        """on_qrcode_update()'s refresh branch is the path the first code
+        arrives through, and calling it a refresh is what "it only appears
+        after the first update" describes."""
+        from pathlib import Path
+        source = (Path(__file__).resolve().parents[1] / "client" / "core"
+                  / "websocket_client.py").read_text(encoding="utf-8")
+        start = source.index('self.i18n.t("qrcode_image_updated")')
+        guard = source.rindex('_qr_displayed', 0, start)
+        assert source.index("if", guard - 60, guard) < guard, (
+            "the update announcement is no longer gated on a QR already being "
+            "on screen"
+        )

--- a/tests/test_qrcode_unattended_session.py
+++ b/tests/test_qrcode_unattended_session.py
@@ -69,12 +69,20 @@ class _FakeField:
 
 
 class _FakeConnect:
-    def __init__(self, mode="qrcode", main_window=None):
+    def __init__(self, mode="qrcode", main_window=None, qr_displayed=True):
         self.connection_mode = mode
         self.main_window = main_window
         self.show_connection_dial_calls = 0
         self.displayed = []
         self.pairing_code_field = _FakeField()
+        # Whether a QR is already painted. The refresh announcement is gated on
+        # it, because the FIRST code arrives through this same branch — the
+        # single status-session poll fires 71 ms after /start-session, measured
+        # 5.4 s before the event — and calling that a refresh is what made the
+        # QR seem to appear only on the second try. Defaults True: every test
+        # here but one is about a rotation, which by definition has one on
+        # screen already. See tests/test_qr_is_announced_when_it_exists.py.
+        self._qr_displayed = qr_displayed
 
     def show_connection_dial(self):
         self.show_connection_dial_calls += 1
@@ -236,6 +244,18 @@ class TestNormalRotationStillWorks:
         assert mw.speak_output.spoken == ["qrcode_image_updated"]
         assert connect.displayed == [QR_EVENT["data"]]
         assert connect.show_connection_dial_calls == 0
+
+    def test_the_very_first_code_is_not_announced_as_an_update(self):
+        """It still gets drawn — display_qrcode_image() is what announces it,
+        at the moment it is really on screen."""
+        mw = _FakeMainWindow(paired=True, pairing_dialog_active=True)
+        connect = _FakeConnect(mode="qrcode", main_window=mw, qr_displayed=False)
+        s = _Stub(mw, connect)
+
+        s.on_qrcode_update(QR_EVENT)
+
+        assert mw.speak_output.spoken == []
+        assert connect.displayed == [QR_EVENT["data"]]
 
     def test_phone_mode_updates_the_field(self):
         mw = _FakeMainWindow(paired=True, pairing_dialog_active=True)


### PR DESCRIPTION
O QR que "só aparece depois da primeira atualização". Log de um install real dá a sequência inteira:

```
21:47:13.174  POST /start-session -> 200
21:47:13.245  GET /status-session -> 200      (71 ms depois, sem qrcode)
21:47:13.245  "No QR in status-session yet — waiting for the qrCode event"
21:47:18.683  o QR finalmente chega pelo WebSocket
```

## Os campos estão certos — a suspeita se refuta

O `sessionController.ts` responde `qrcode` no topo, que é o que o `start_qrcode_connection()` lê, e o `display_qrcode_image()` remove o prefixo de data-URI que esse valor carrega. A leitura é disparada **71 ms depois** de pedir para a sessão iniciar, então numa sessão nova ela não pode ter código ainda — só compensa quando uma sessão já em execução é reaproveitada. Foi mantida, e nada mais depende dela.

## O que estava errado são os dois anúncios

**O primeiro mentia.** O `on_switch_to_qrcode()` tocava o som de "QR carregado" e lia as instruções no instante em que o `start_qrcode_connection()` retornava — cinco segundos e meio antes de existir qualquer coisa para apontar o celular. Um usuário vidente vê a caixa preencher; um usuário cego era simplesmente informado de que havia um código na tela quando a caixa estava vazia.

**O segundo chamava o primeiro código de atualização.** O código que de fato chegava se anunciava como *update*, porque o ramo de refresh do `on_qrcode_update()` é o caminho por onde o primeiro passa — que é exatamente o que "só aparece depois da primeira atualização" descreve.

Então as instruções e o som de carregado passam para a primeira pintura bem-sucedida do `display_qrcode_image()`, o momento em que são verdade, e o anúncio de atualização passa a exigir que já exista um QR na tela.

## O aviso pedido

O conteúdo inteiro do diálogo é uma imagem, então um usuário cego não consegue distinguir "ainda gerando" de "isso não vai funcionar" — e todo caminho que falha em pintar um é silencioso por conta própria: `status-session` sem `qrcode`, um evento `qrCode` sem nada aproveitável, um payload indecodificável, uma sessão que nunca chega a QRCODE.

Watchdog de **25 s**, generosamente acima dos 5,4 s medidos, porque o que ele limita é uma falha *silenciosa* — cortar uma sessão lenta mas funcional trocaria um anúncio errado por outro. Som de erro mais uma explicação falada, no máximo uma vez por tentativa, e rearmado para que uma segunda tentativa também possa falhar em voz alta.

## De passagem

O som de atualização tocava **duas vezes** por rotação — aqui e no `on_qrcode_update()` — o que sai como um único blip truncado em vez de dois avisos, já que o sound_lib reinicia o stream (mesmo defeito documentado no CLAUDE.md sobre o focus_cloak). O chamador fica com ele.

## Testes

`tests/test_qr_is_announced_when_it_exists.py` — 9 testes: o watchdog armado com folga sobre o atraso medido, a falha reportada uma vez só, a segunda tentativa podendo falhar de novo, o cancelamento parando o timer, e as asserções estruturais de que as instruções saíram da abertura e foram para a pintura real.

`tests/test_qrcode_unattended_session.py` ganha o caso do primeiro código não ser anunciado como atualização; o fake aprendeu `_qr_displayed` (default `True`, já que todo teste de lá é sobre rotação).

Suíte completa: **6770 passed, 73 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)