### PR TITLE
Hand the unresolved @lid chats to the queue that resolves them

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -14094,6 +14094,28 @@ class MainWindow(wx.Frame):
                 "[Sync] Deferring %d unresolved @lid chat(s) to background name backfill.",
                 len(unresolved_lids),
             )
+            # …and actually hand them over. This said "deferring" and then did
+            # nothing: the only producers for that queue are per-message (a
+            # group message's sender, and @lid mentions), so a chat whose own
+            # JID is an @lid was bridged only if the same person happened to
+            # turn up as a sender or a mention somewhere. Measured on a real
+            # install: 132 of 159 chats are @lid and 244 of 487 contacts are,
+            # while _lid_to_phone held 42 entries.
+            #
+            # Everything downstream of that gap follows from it, because
+            # contact_dedup_key() collapses the two forms of one person only
+            # once the bridge holds the pair. Reported as duplicated contacts
+            # in the "new conversation" picker — 208 names appearing twice on
+            # that install, each once as @lid and once as the phone — and the
+            # same unbridged @lid is why those chats need a name backfill at
+            # all.
+            #
+            # Deferring is still honoured: _queue_lid_resolutions()' drain loop
+            # sleeps until _sync_completed, so this costs the sync nothing. It
+            # is a set, so re-queuing an already-pending JID on a later round
+            # is free, and resolve_lid_jids_via_api() skips whatever the bridge
+            # or _unresolvable_lids already answers for.
+            self._queue_lid_resolutions(unresolved_lids)
 
         # Conversations are fully sorted as soon as messages are synced.
         # Sort, display, play sync-complete sound, and announce to the user

--- a/tests/test_chat_lids_reach_the_resolution_queue.py
+++ b/tests/test_chat_lids_reach_the_resolution_queue.py
@@ -1,0 +1,93 @@
+"""A chat whose own JID is an @lid has to reach the LID resolution queue.
+
+Reported as duplicated contacts in the "new conversation" picker — the same
+person listed twice, once under @lid and once under their phone number.
+
+The picker already deduplicates, through core.utils.contact_dedup_key(), which
+collapses the two forms of one person **as long as _lid_to_phone holds the
+pair**. It usually did not. Measured live against a real install:
+
+    /list-chats     159 chats,   132 of them @lid
+    /all-contacts   487 contacts, 244 of them @lid, 208 names appearing twice
+    LID cache       42 lids bridged
+
+Neither payload carries the link — an @lid contact arrives with no phoneNumber
+field, and an @lid chat's `remoteJid` is null while `accountLid` merely repeats
+the @lid. The bridge is built from messages instead, and the only producers for
+the resolution queue are per-message: a group message's sender, and @lid
+mentions. So a chat whose own JID is an @lid was bridged only if that person
+happened to turn up as a sender or a mention somewhere else.
+
+_run_sync() computed exactly the right list, logged "Deferring N unresolved
+@lid chat(s) to background name backfill", and then dropped it on the floor.
+Nothing handed it to the queue.
+
+The resolution itself was never the missing part: resolve_lid_jids_via_api()
+exists, batches, caches what cannot be resolved, and persists — and
+WPPConnect's /contact/pn-lid/ answers every one of those lids with its phone
+number (verified live against three of them, including the exact pair behind a
+duplicate in the picker).
+"""
+
+import ast
+from pathlib import Path
+
+
+MAIN = Path(__file__).resolve().parents[1] / "client" / "main.py"
+
+
+def _run_sync_source():
+    source = MAIN.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_run_sync":
+            return "\n".join(lines[node.lineno - 1:node.end_lineno])
+    raise AssertionError("_run_sync() not found in main.py")
+
+
+def _uncommented(text):
+    return "\n".join(l for l in text.splitlines()
+                     if not l.lstrip().startswith("#"))
+
+
+def test_the_unresolved_chat_lids_are_queued_not_just_counted():
+    """The list was computed and logged, and that was all — which is why an
+    install could sit on 132 unbridged @lid chats indefinitely."""
+    body = _uncommented(_run_sync_source())
+    assert "unresolved_lids" in body
+    assert "_queue_lid_resolutions(unresolved_lids)" in body, (
+        "_run_sync() still only logs the unresolved @lid chats; nothing hands "
+        "them to the queue, so contact_dedup_key() never learns the pair and "
+        "the picker keeps listing both forms of the same person"
+    )
+
+
+def test_it_is_queued_rather_than_resolved_inline():
+    """Deferring is the point: resolving even one chunk here is serial and
+    keeps the app in "synchronizing" long after every conversation is already
+    usable. _queue_lid_resolutions()' drain loop sleeps until _sync_completed,
+    so the hand-off costs the sync nothing."""
+    body = _uncommented(_run_sync_source())
+    assert "resolve_lid_jids_via_api" not in body
+
+
+def test_the_queue_still_waits_for_the_sync_to_finish():
+    """The other half of the same promise, pinned here because this change is
+    what starts relying on it: if the drain loop stopped deferring, the sync
+    would now be the thing paying for these lookups."""
+    source = MAIN.read_text(encoding="utf-8")
+    start = source.index("def _queue_lid_resolutions")
+    body = source[start:start + 3000]
+    assert "_initial_sync_running" in body
+    assert "_sync_completed" in body
+
+
+def test_the_queue_is_a_set_so_requeuing_is_free():
+    """_run_sync() runs again on every full round and will re-offer whatever
+    is still unbridged, so the producer side has to tolerate repeats."""
+    source = MAIN.read_text(encoding="utf-8")
+    start = source.index("def _queue_lid_resolutions")
+    body = source[start:start + 3000]
+    assert "= set()" in body
+    assert "pending.update(unique)" in body


### PR DESCRIPTION
Contatos duplicados no diálogo de nova conversa: a mesma pessoa listada duas vezes, uma sob `@lid` e outra sob o telefone.

## O diagnóstico

O picker **já** deduplica, via `contact_dedup_key()`, que colapsa as duas formas de uma pessoa — **desde que `_lid_to_phone` tenha o par**. Normalmente não tinha. Medido ao vivo contra um install real:

```
/list-chats     159 chats,     132 deles @lid
/all-contacts   487 contatos,  244 deles @lid, 208 nomes aparecendo duas vezes
cache de LID    42 lids com ponte
```

Nenhum dos dois payloads carrega a ligação — um contato `@lid` chega sem campo `phoneNumber`, e o `remoteJid` de um chat `@lid` é `null` enquanto o `accountLid` só repete o `@lid`. A ponte é construída a partir das **mensagens**, e os únicos produtores da fila de resolução são por-mensagem: o remetente de uma mensagem de grupo e menções `@lid`.

Ou seja: um chat cujo próprio JID é `@lid` só ganhava ponte se aquela pessoa por acaso aparecesse como remetente ou menção em outro lugar. É por isso que um install fica com 132 chats `@lid` sem ponte indefinidamente.

O `_run_sync()` calculava exatamente a lista certa, logava *"Deferring N unresolved @lid chat(s) to background name backfill"* — e a descartava. Ninguém entregava.

## Por que isso é uma linha e não uma reescrita do dedup

Duas hipóteses foram testadas contra o install real antes, e as **duas estavam erradas**:

1. **Busca reversa em `_phone_to_lid`** — não acharia nada: todo ponto de escrita grava os dois mapas no mesmo movimento, então o reverso nunca tem o que o direto não tem.
2. **Parear pelo payload de contatos** — não há campo de telefone na entrada `@lid` para parear.

O que faltava mesmo era a entrega.

## O que já existia e é reaproveitado sem mudança

`resolve_lid_jids_via_api()` faz lotes, limita erros consecutivos, cacheia o que não dá para resolver e persiste. E o `/contact/pn-lid/` do WPPConnect responde o telefone de cada um desses lids — verificado ao vivo em três, incluindo o par exato por trás de uma duplicata no picker:

```
100742836789440@lid -> 5511953412096@c.us   ("Vinicius Siqueira", duplicado)
```

O adiamento continua respeitado, e os testes fixam isso: o laço de drenagem do `_queue_lid_resolutions()` dorme até o sync terminar, então a entrega não custa nada ao sync, e a fila é um `set`, então reoferecer um JID ainda sem ponte na próxima rodada é de graça.

## Alcance

Corrige as duplicatas **em todo lugar que consulta a ponte**, não só no diálogo que reportou: o picker de anexar contato compartilha o `contact_dedup_key()`, e o mesmo `@lid` sem ponte é a razão de aqueles chats precisarem de backfill de nome.

Suíte completa: **6775 passed, 73 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)