### PR TITLE
An unread clamp needs a local read behind it

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -1296,6 +1296,13 @@ def reconcile_open_chat_unread(
     with the live one, which is exactly the shape that hides a bug from code
     review. Same reasoning as link_preview_text() and _status_content_label().
 
+    Both callers also decide "is this chat open" the same way, and that test
+    includes _unread_anchored_to_local_read(): this function answers for an
+    open chat that is also READ, which is not the same thing once a read has
+    been undone on screen (see the _open_now comment in
+    on_chat_unread_update()). Whichever one of the two you are changing, the
+    other has the same condition and has to move with it.
+
     ``remote_read_confirmed`` says a zero really is somebody reading the chat
     elsewhere rather than an uninformative one. The resync has no
     previousUnreadCount to derive it from, so it passes False — the
@@ -6521,6 +6528,14 @@ class MainWindow(wx.Frame):
                 # tell a real new-unread total apart from a stale server
                 # count that still includes messages we already read locally
                 # but the server hasn't acknowledged as read yet.
+                #
+                # Note what this line does NOT establish: it creates the entry
+                # for a chat that has never been read here either, where the
+                # number means "arrivals since this process started" and is no
+                # ceiling for anything. Only mark_conversation_as_read() makes
+                # it a count since a read — which is why the clamp in
+                # on_chat_unread_update() asks _unread_anchored_to_local_read()
+                # rather than trusting a nonzero entry on its own.
                 if not hasattr(self, "_new_since_read"):
                     self._new_since_read = {}
                 self._new_since_read[remote_jid] = self._new_since_read.get(remote_jid, 0) + 1
@@ -14632,6 +14647,15 @@ class MainWindow(wx.Frame):
             self._blocked_contacts = set()
             self._presence_pushname_map = {}
             self._locally_read_at = {}
+            # The read anchors and the arrivals counter they qualify. A group
+            # JID is the same string in both accounts, so an anchor left over
+            # from A authorises the clamp in on_chat_unread_update() for the
+            # same group in B — where the chat has never been read and the
+            # counter measures only arrivals since the switch. That is the
+            # collapse this whole mechanism exists to prevent, reintroduced
+            # through the back door.
+            self._unread_read_anchors = set()
+            self._new_since_read = {}
             # Which groups the previous account could post in — i.e. which
             # groups it was a member of at all. _persist_group_send_perms()
             # writes it back out of RAM, so the emptied table filled up again
@@ -15363,12 +15387,20 @@ class MainWindow(wx.Frame):
                                 # list-chats carries no previousUnreadCount — see the
                                 # helper for what that costs.
                                 _cp = getattr(self, "conversations_panel", None)
+                                # Gated on the read anchor exactly like the live
+                                # handler's own _open_now — an open chat whose
+                                # read was undone (Ctrl+Shift+M, or a restored
+                                # backlog after /send-seen failed) is open but
+                                # not read, and answering 0 for it here erases
+                                # that state a minute later. See the comment on
+                                # _open_now in on_chat_unread_update().
                                 open_now = (
                                     _cp is not None
                                     and _cp.conversation is not None
                                     and self._normalize_jid(
                                         _cp.conversation.get("remoteJid", "")
                                     ) == jid
+                                    and self._unread_anchored_to_local_read(jid)
                                 )
                                 if open_now:
                                     _local_new = getattr(
@@ -23693,10 +23725,25 @@ class MainWindow(wx.Frame):
         # this jid) instead of _last_open_jid: that field is never cleared on
         # close, so a chat the user already left kept being treated as "open"
         # forever and any chats-update for it was force-zeroed.
+        # ...and only while it is also READ. The open branch below treats the
+        # panel showing a chat as proof the user has read it, which stops
+        # being true the moment a read is deliberately undone with the
+        # conversation still on screen. Two reachable paths do exactly that:
+        # Ctrl+Shift+M on the open chat (_on_accel_toggle_read ->
+        # mark_conversation_as_unread), and _restore_unread_after_send_seen_
+        # failure() putting a backlog back after WhatsApp refused every
+        # /send-seen attempt. Both leave _new_since_read at 0, and
+        # reconcile_open_chat_unread() answers 0 for that — so the next
+        # chats-update (or the 60s resync at the latest) silently erased the
+        # unread state the user had just asked for, backlog and all. The
+        # anchor is what separates "open" from "read": without it this falls
+        # through to the ordinary closed-chat branches, which already refuse
+        # a server count below the local one and accept an honest higher one.
         _open_now = (
             cp is not None
             and cp.conversation is not None
             and cp.conversation.get("remoteJid") == normalized
+            and self._unread_anchored_to_local_read(normalized)
         )
         read_at_t = getattr(self, "_locally_read_at", {}).get(normalized)
         # A zero that fell from a positive count is somebody actually reading
@@ -23769,6 +23816,7 @@ class MainWindow(wx.Frame):
             and unread_count > old_count
             and not _remote_read
             and getattr(self, "_new_since_read", {}).get(normalized)
+            and self._unread_anchored_to_local_read(normalized)
         ):
             # Once the read_at_t entry that protected a chat has been
             # consumed and popped (see the `elif read_at_t is not None`
@@ -23783,13 +23831,24 @@ class MainWindow(wx.Frame):
             # already-read message back into "unread" (first_unread_index()
             # draws the separator by counting backwards from unreadCount, so
             # a count too high by N drags N already-read messages along with
-            # it). _new_since_read is only ever set together with the local
-            # unreadCount increment in on_new_message(), so a nonzero entry
-            # here means old_count is itself locally verified, not merely
-            # "whatever the last sync happened to say" — clamp to it exactly
-            # like the read_at_t-present branch does, rather than rejecting
-            # the update outright (a chat truly gaining more unread than
-            # tracked locally, e.g. from another device, still updates).
+            # it).
+            #
+            # _new_since_read counts arrivals since the last local read —
+            # but ONLY for a chat that has actually had one. on_new_message()
+            # creates the entry from nothing for any chat that receives a
+            # message, so in a chat never read here it counts arrivals since
+            # the process started, and clamping an absolute total to it
+            # throws away every unread message that predates this launch.
+            # Measured on a live session, in the four busiest groups on the
+            # account: `34876 -> 21`, `7232 -> 3`, `3366 -> 2`, `2767 -> 6`,
+            # each one restored to its real value by the next 60s resync and
+            # collapsed again by the chats-update a second later — the badge
+            # visibly flipping between 34 thousand and 21 for as long as the
+            # app stayed open. _unread_anchored_to_local_read() is what tells
+            # the two kinds of entry apart: without a local read behind it
+            # there is no locally verified total to clamp to, and the
+            # server's own count (already discounted above) is the best
+            # answer available.
             unread_count = min(unread_count, self._new_since_read[normalized])
             logging.info(
                 "[unread] %s: %s -> %s (previous=%s, open=%s, read_ack=%s).",
@@ -24831,6 +24890,58 @@ class MainWindow(wx.Frame):
         except Exception as exc:
             logging.warning("[mark_as_read] failed to persist locally_read_at: %s", exc)
 
+    def _anchor_unread_to_local_read(self, remote_jid: str) -> None:
+        """Record that this chat's _new_since_read counter starts from a read.
+
+        Both identities are stored — the raw key mark_conversation_as_read()
+        was called with, and its normalized form — purely so the lookup
+        cannot depend on which of the two a caller happened to hold. It is
+        belt-and-braces rather than a bridge: _resolve_chat_for_event()
+        returns the key self.chats actually holds the chat under, and
+        mark_conversation_as_read() is called with that same key, so today
+        the second entry is inert.
+
+        It is deliberately NOT an @lid bridge. _normalize_jid() leaves @lid
+        untouched on purpose, and resolving one here would be wrong rather
+        than merely redundant: a read of the @lid entry would anchor the
+        phone entry, whose own _new_since_read has no read behind it, and
+        that unearned anchor is precisely what authorises the clamp that
+        collapses a backlog. When _merge_lid_into_phone() renames a key, the
+        anchor, _new_since_read and _locally_read_at are orphaned together —
+        the clamp's own `_new_since_read` guard then reads false and it does
+        not run, which is the safe direction.
+        """
+        if not hasattr(self, "_unread_read_anchors"):
+            self._unread_read_anchors = set()
+        self._unread_read_anchors.add(remote_jid)
+        self._unread_read_anchors.add(self._normalize_jid(remote_jid))
+
+    def _drop_unread_local_read_anchor(self, remote_jid: str) -> None:
+        """Forget the anchor — the read behind it was undone or reversed."""
+        anchors = getattr(self, "_unread_read_anchors", None)
+        if not anchors:
+            return
+        anchors.discard(remote_jid)
+        anchors.discard(self._normalize_jid(remote_jid))
+
+    def _unread_anchored_to_local_read(self, remote_jid: str) -> bool:
+        """Whether _new_since_read[jid] counts from a local read of this chat.
+
+        The distinction is the whole point of the anchor. on_new_message()
+        creates a _new_since_read entry for ANY chat that receives a message,
+        read here or not, so the counter alone cannot say whether it measures
+        "since the user read this chat" (a real ceiling for the absolute
+        total WhatsApp Web reports) or merely "since this process started"
+        (no ceiling at all — everything unread before the launch is missing
+        from it). Only mark_conversation_as_read() sets the anchor, and it is
+        deliberately in memory only: after a restart the counter starts from
+        zero again, so the ceiling it would imply is gone too.
+        """
+        anchors = getattr(self, "_unread_read_anchors", None)
+        if not anchors:
+            return False
+        return remote_jid in anchors or self._normalize_jid(remote_jid) in anchors
+
     def mark_conversation_as_read(self, remote_jid: str, force: bool = False):
         """Mark conversation as read locally and notify WPPConnect."""
         chat = self.chats.get(remote_jid)
@@ -24854,6 +24965,11 @@ class MainWindow(wx.Frame):
         if not hasattr(self, "_new_since_read"):
             self._new_since_read = {}
         self._new_since_read[remote_jid] = 0
+        # From here on this chat's _new_since_read entry means "arrivals since
+        # a read that actually happened", which is the only reading that lets
+        # on_chat_unread_update() clamp an absolute server total to it — see
+        # _unread_anchored_to_local_read().
+        self._anchor_unread_to_local_read(remote_jid)
         self._schedule_save(dirty_jid=remote_jid)
         # Immediate single-row update: unlike _schedule_set_chats()/set_chats(),
         # this isn't suppressed while a media sync is running, so the badge
@@ -24978,6 +25094,9 @@ class MainWindow(wx.Frame):
         chat["unreadCount"] = max(0, int(previous_unread or 0))
         self._locally_read_at.pop(normalized, None)
         self._locally_read_at.pop(remote_jid, None)
+        # The read is being undone, so the anchor it installed goes with it.
+        self._drop_unread_local_read_anchor(normalized)
+        self._drop_unread_local_read_anchor(remote_jid)
         self._persist_locally_read_at()
         self._schedule_save(dirty_jid=normalized)
         self._refresh_chat_row_in_list(normalized)
@@ -24994,6 +25113,10 @@ class MainWindow(wx.Frame):
                 self._persist_locally_read_at()
             if hasattr(self, "_new_since_read"):
                 self._new_since_read.pop(remote_jid, None)
+            # Explicitly marking a chat unread undoes the read this anchor
+            # stood for; anything counted from here on is arrivals in a chat
+            # with no local read behind it again.
+            self._drop_unread_local_read_anchor(remote_jid)
             self._schedule_save(dirty_jid=remote_jid)
             wx.CallAfter(self.set_chats)
             self._sync_conversation_read_state(
@@ -25019,6 +25142,13 @@ class MainWindow(wx.Frame):
         ):
             return
         chat["unreadCount"] = max(0, previous_unread)
+        # Deliberately does not put _locally_read_at or the read anchor back:
+        # this undoes a mark-UNREAD, so the chat returns to a read-looking
+        # state with no ceiling attached. Leaving both absent means the next
+        # server count is taken as it comes instead of being clamped to a
+        # local counter that no read backs — the safe direction, and the same
+        # one _restore_unread_after_send_seen_failure() takes from the other
+        # side by dropping the anchor outright.
         self._schedule_save(dirty_jid=remote_jid)
         self._refresh_chat_row_in_list(remote_jid)
         self._schedule_set_chats()

--- a/tests/test_clear_local_data_metadata.py
+++ b/tests/test_clear_local_data_metadata.py
@@ -89,6 +89,8 @@ class _Stub:
         self._blocked_contacts = {"5511988887777"}
         self._presence_pushname_map = {"5511988887777@s.whatsapp.net": "Ana"}
         self._locally_read_at = {"5511988887777@s.whatsapp.net": 1700000000}
+        self._unread_read_anchors = {"120363000000000000@g.us"}
+        self._new_since_read = {"120363000000000000@g.us": 4}
         self.my_jid = "5511999999999@s.whatsapp.net"
         self.my_lid = "182736450192837@lid"
         self._group_send_perms = {
@@ -185,7 +187,17 @@ _METADATA = ("_deleted_chats", "_archived_chats", "_pinned_chats",
              # persisted (issue #201) — inert today only because nothing
              # currently writes it to disk, so clearing it here keeps it out
              # of the same leak the moment that changes.
-             "_verified_activity")
+             "_verified_activity",
+             # "This chat's arrivals counter starts from a read", and the
+             # counter itself. Neither is persisted, but both outlive the
+             # switch in RAM, and a GROUP JID is the same string in both
+             # accounts — so an anchor earned in A authorises
+             # on_chat_unread_update()'s clamp for the same group in B, where
+             # nothing has been read and the counter holds only what arrived
+             # since the switch. That clamp is what collapsed a 34-thousand
+             # backlog to 21 (see tests/test_unread_reread_race.py); leaving
+             # these behind hands it the same power across accounts.
+             "_unread_read_anchors", "_new_since_read")
 
 
 class TestAnAccountSwitchClearsTheMetadataInMemoryToo:

--- a/tests/test_get_remote_chats_persistence.py
+++ b/tests/test_get_remote_chats_persistence.py
@@ -47,6 +47,11 @@ class _Stub:
     """Minimum surface get_remote_chats() actually reads on the happy path."""
 
     _mute_state_jids = MainWindow._mute_state_jids
+    # The open-chat branch of the merge asks whether the chat is also READ —
+    # see the _open_now comment in on_chat_unread_update().
+    _normalize_jid = staticmethod(MainWindow._normalize_jid)
+    _anchor_unread_to_local_read = MainWindow._anchor_unread_to_local_read
+    _unread_anchored_to_local_read = MainWindow._unread_anchored_to_local_read
 
     def __init__(self, chats=None):
         self.wpp_server = "http://127.0.0.1"
@@ -64,6 +69,7 @@ class _Stub:
         self._phone_to_lid = {}
         self._group_name_cache = {}
         self._locally_read_at = {}
+        self._unread_read_anchors = set()
         self.conversations_panel = None
         self.save_data_calls = 0
         self.schedule_save_calls = 0

--- a/tests/test_locally_read_at_persisted.py
+++ b/tests/test_locally_read_at_persisted.py
@@ -66,6 +66,10 @@ class _Stub:
     # reads via getattr defaults; a plain phone JID resolves on the first
     # lookup anyway.
     _resolve_chat_for_event = MainWindow._resolve_chat_for_event
+    # mark_conversation_as_read() also records that _new_since_read now counts
+    # from a real read — see tests/test_unread_reread_race.py.
+    _anchor_unread_to_local_read = MainWindow._anchor_unread_to_local_read
+    _unread_anchored_to_local_read = MainWindow._unread_anchored_to_local_read
 
     def __init__(self, chat, db=None):
         self.chats = {JID: chat}
@@ -109,6 +113,13 @@ class TestMarkAsReadPersistsTheAck:
 
         assert stub._locally_read_at == {JID: 777}
         assert db.metadata["locally_read_at"] == {JID: 777}
+        # The other half of what this read establishes: from here on the
+        # arrivals counter for this chat means "since a read", which is what
+        # lets on_chat_unread_update() clamp a server total to it. Asserted
+        # here because this is the only site that sets it — without this line
+        # the call could be deleted with the whole suite still green, and the
+        # clamp would silently stop protecting anything.
+        assert stub._unread_anchored_to_local_read(JID)
 
     def test_a_chat_with_no_timestamp_records_zero_instead_of_crashing(self):
         db = _FakeDB()

--- a/tests/test_read_state_bidirectional_sync.py
+++ b/tests/test_read_state_bidirectional_sync.py
@@ -30,6 +30,9 @@ class _RollbackStub:
     _restore_unread_after_mark_unread_failure = (
         MainWindow._restore_unread_after_mark_unread_failure
     )
+    # Undoing a read (or marking a chat unread) also drops the anchor that
+    # read installed — see tests/test_unread_reread_race.py.
+    _drop_unread_local_read_anchor = MainWindow._drop_unread_local_read_anchor
 
     def __init__(self, *, archived=False):
         self.chats = {
@@ -41,6 +44,7 @@ class _RollbackStub:
         }
         self._locally_read_at = {JID: 2000}
         self._new_since_read = {JID: 0}
+        self._unread_read_anchors = {JID}
         self.persisted = 0
         self.saved = []
         self.refreshed = []
@@ -66,6 +70,10 @@ def test_failed_send_seen_restores_normal_chat_unread_state():
 
     assert stub.chats[JID]["unreadCount"] == 3
     assert JID not in stub._locally_read_at
+    # The read is being undone, so the ceiling it installed goes with it —
+    # otherwise the restored backlog is clamped back down to a counter no read
+    # backs (see tests/test_unread_reread_race.py).
+    assert JID not in stub._unread_read_anchors
     assert stub.saved == [JID]
 
 
@@ -114,6 +122,7 @@ def test_mark_unread_clears_stale_read_ack_and_syncs_to_whatsapp(monkeypatch):
 
     assert stub.chats[JID]["unreadCount"] == 1
     assert JID not in stub._locally_read_at
+    assert JID not in stub._unread_read_anchors
     assert stub.remote_changes[0][:2] == (JID, True)
     assert stub.saved == [JID]
 

--- a/tests/test_resync_open_chat_unread.py
+++ b/tests/test_resync_open_chat_unread.py
@@ -90,6 +90,11 @@ class TestTheResyncKeepsTheOpenChatsBacklog:
         stub = _make(existing)
         stub.conversations_panel = _OpenPanel(JID)
         stub._new_since_read = {JID: new_since_read}
+        # Opening a conversation always runs mark_conversation_as_read
+        # (navigate_to_conversation, ui/conversations.py), which is what makes
+        # "open" mean "read" here. The tests below that need the opposite —
+        # open but deliberately NOT read — drop it again.
+        stub._anchor_unread_to_local_read(JID)
         return stub, existing
 
     def test_a_server_zero_does_not_wipe_the_backlog(self, post):
@@ -129,3 +134,48 @@ class TestTheResyncKeepsTheOpenChatsBacklog:
         stub.get_remote_chats(existing, persist_full=False, notify_errors=False)
 
         assert existing[JID]["unreadCount"] == 4
+
+
+class TestAnOpenChatWhoseReadWasUndone:
+    """"Open" stops meaning "read" the moment the read is undone with the
+    conversation still on screen, and two paths do that:
+
+      * Ctrl+Shift+M on the open chat (_on_accel_toggle_read ->
+        mark_conversation_as_unread), which pops _new_since_read and drops
+        the anchor.
+      * _restore_unread_after_send_seen_failure(), putting a backlog back
+        after WhatsApp refused all three /send-seen attempts.
+
+    Both leave _new_since_read at 0 with the panel still showing the chat, and
+    reconcile_open_chat_unread() answers 0 for exactly that shape — so this
+    resync erased what the user had just asked for, up to a whole backlog,
+    within 60 seconds and straight to disk.
+    """
+
+    def _open_but_unread(self, unread):
+        existing = {JID: {
+            "remoteJid": JID, "t": 1700000000, "unreadCount": unread,
+            "messages": {"messages": {"records": []}},
+        }}
+        stub = _make(existing)
+        stub.conversations_panel = _OpenPanel(JID)
+        stub._new_since_read = {JID: 0}
+        # No anchor: the read this chat had was undone.
+        return stub, existing
+
+    def test_a_chat_marked_unread_on_screen_keeps_its_badge(self, post):
+        post["payload"] = [_chat(JID, unreadCount=1)]
+        stub, existing = self._open_but_unread(unread=1)
+
+        stub.get_remote_chats(existing, persist_full=False, notify_errors=False)
+
+        assert existing[JID]["unreadCount"] == 1
+
+    def test_a_restored_backlog_is_not_erased_by_the_resync(self, post):
+        """The send-seen rollback case, at the scale it was measured at."""
+        post["payload"] = [_chat(JID, unreadCount=34876)]
+        stub, existing = self._open_but_unread(unread=34876)
+
+        stub.get_remote_chats(existing, persist_full=False, notify_errors=False)
+
+        assert existing[JID]["unreadCount"] == 34876

--- a/tests/test_unread_reread_race.py
+++ b/tests/test_unread_reread_race.py
@@ -35,6 +35,11 @@ class _Stub:
     # restart — see tests/test_locally_read_at_persisted.py); the real method
     # is a no-op without a `db` attribute, which this stub deliberately lacks.
     _persist_locally_read_at = MainWindow._persist_locally_read_at
+    # Says whether _new_since_read counts from a local read of this chat or
+    # merely from process start — see TestNeverReadChatKeepsTheServerTotal.
+    _anchor_unread_to_local_read = MainWindow._anchor_unread_to_local_read
+    _drop_unread_local_read_anchor = MainWindow._drop_unread_local_read_anchor
+    _unread_anchored_to_local_read = MainWindow._unread_anchored_to_local_read
 
     def __init__(self, chat):
         self.chats = {"5511999999999@s.whatsapp.net": chat}
@@ -43,8 +48,26 @@ class _Stub:
         self.conversations_panel = None
         self._locally_read_at = {}
         self._new_since_read = {}
+        self._unread_read_anchors = set()
         self.saved = []
         self.set_chats_calls = 0
+
+    def read_locally(self, jid):
+        """What mark_conversation_as_read() does to the tracking state."""
+        self._new_since_read[jid] = 0
+        self._anchor_unread_to_local_read(jid)
+
+    def open_conversation(self, jid):
+        """Put the panel on a chat the way navigate_to_conversation() does.
+
+        Opening always runs mark_conversation_as_read() on the way in
+        (ui/conversations.py), and that read is what lets the open branch
+        treat the panel showing a chat as proof it has been read. Tests that
+        want the other state — open, but the read undone on screen — set the
+        panel directly and leave the anchor off.
+        """
+        self.conversations_panel = _CP(jid)
+        self.read_locally(jid)
 
     def _schedule_save(self, dirty_jid=None):
         self.saved.append(dirty_jid)
@@ -119,6 +142,7 @@ class TestStaleServerCountAfterLocalRead:
         already-read message back into "unread" (first_unread_index() places
         the separator by counting backwards from unreadCount)."""
         stub = _Stub(_chat(t=2000))
+        stub.read_locally(JID)  # the local read this whole branch stands on
         stub.chats[JID]["unreadCount"] = 1
         stub._new_since_read[JID] = 1
         # _locally_read_at has no entry for JID — already consumed/popped.
@@ -143,7 +167,7 @@ class _CP:
 class TestCurrentlyOpenConversation:
     def test_an_open_conversation_with_nothing_new_clears_to_zero(self):
         stub = _Stub(_chat(t=1000))
-        stub.conversations_panel = _CP(JID)
+        stub.open_conversation(JID)
 
         stub.on_chat_unread_update(JID, 5)
 
@@ -154,7 +178,7 @@ class TestCurrentlyOpenConversation:
         landed while the window was minimized are tracked in _new_since_read
         and stay counted, clamped down to that locally-known number."""
         stub = _Stub(_chat(t=1000))
-        stub.conversations_panel = _CP(JID)
+        stub.open_conversation(JID)
         stub._new_since_read[JID] = 2
 
         stub.on_chat_unread_update(JID, 5)
@@ -192,7 +216,7 @@ class TestOpenConversationSurvivesSpuriousServerZeros:
         # a chat at 0 with a nonzero _new_since_read is not a reachable state.
         chat["unreadCount"] = 4
         stub = _Stub(chat)
-        stub.conversations_panel = _CP(JID)
+        stub.open_conversation(JID)
         stub._new_since_read[JID] = 4
 
         stub.on_chat_unread_update(JID, 0)
@@ -204,7 +228,7 @@ class TestOpenConversationSurvivesSpuriousServerZeros:
         must leave five unread, not one. Mirrors what on_new_message() does
         (increment both the chat and _new_since_read) between the events."""
         stub = _Stub(_chat(t=1000))
-        stub.conversations_panel = _CP(JID)
+        stub.open_conversation(JID)
         seen_by_toasts = []
 
         for _ in range(5):
@@ -224,7 +248,7 @@ class TestOpenConversationSurvivesSpuriousServerZeros:
         server's absolute total, which can still be counting messages already
         read locally — that is the bug this whole function exists to prevent."""
         stub = _Stub(_chat(t=1000))
-        stub.conversations_panel = _CP(JID)
+        stub.open_conversation(JID)
         stub._new_since_read[JID] = 2
 
         stub.on_chat_unread_update(JID, 7)
@@ -239,7 +263,7 @@ class TestOpenConversationSurvivesSpuriousServerZeros:
         chat = _chat(t=1000)
         chat["unreadCount"] = 4
         stub = _Stub(chat)
-        stub.conversations_panel = _CP(JID)
+        stub.open_conversation(JID)
         stub._new_since_read[JID] = 4
 
         stub.on_chat_unread_update(JID, 0, previous_unread=4)
@@ -268,7 +292,7 @@ class TestOpenConversationSurvivesSpuriousServerZeros:
         chat = _chat(t=1000)
         chat["unreadCount"] = 4
         stub = _Stub(chat)
-        stub.conversations_panel = _CP(JID)
+        stub.open_conversation(JID)
         stub._new_since_read[JID] = 4
 
         stub.on_chat_unread_update(JID, 0, previous_unread=None)
@@ -281,7 +305,7 @@ class TestOpenConversationSurvivesSpuriousServerZeros:
         chat = _chat(t=1000)
         chat["unreadCount"] = 2
         stub = _Stub(chat)
-        stub.conversations_panel = _CP(JID)
+        stub.open_conversation(JID)
         stub._new_since_read[JID] = 2
 
         stub.on_chat_unread_update(JID, 0, previous_unread=0)
@@ -295,7 +319,7 @@ class TestOpenConversationSurvivesSpuriousServerZeros:
         chat = _chat(t=1000)
         chat["unreadCount"] = 3
         stub = _Stub(chat)
-        stub.conversations_panel = _CP(JID)
+        stub.open_conversation(JID)
 
         stub.on_chat_unread_update(JID, 0)
 
@@ -354,3 +378,188 @@ class TestReadOnAnotherDeviceAfterALocalRead:
         stub.on_chat_unread_update(JID, 0, 0)
 
         assert stub.chats[JID]["unreadCount"] == 3
+
+
+class TestNeverReadChatKeepsTheServerTotal:
+    """Reported live: a group holding 34 thousand unread messages had its badge
+    collapse to 21, climb one at a time, get restored to ~34 thousand by the
+    next 60s resync, and collapse again a second later — over and over, in the
+    four busiest groups on the account.
+
+    The clamp above is only meaningful when _new_since_read counts from a read
+    that really happened. on_new_message() creates that entry for any chat
+    receiving a message, so in a chat never read in WinZapp it counts arrivals
+    since the process started; clamping WhatsApp Web's absolute total to it
+    discards every unread message older than this launch. Straight from the
+    log: `[unread] ...@g.us: 34876 -> 21 (previous=34944, open=False,
+    read_ack=None)`.
+    """
+
+    def test_a_backlog_survives_a_climbing_server_count(self):
+        chat = _chat(t=2000)
+        chat["unreadCount"] = 34876
+        stub = _Stub(chat)
+        # 21 messages have arrived since launch; the chat was never read here,
+        # so nothing anchors that counter to a read.
+        stub._new_since_read[JID] = 21
+
+        stub.on_chat_unread_update(JID, 34945, previous_unread=34944)
+
+        assert stub.chats[JID]["unreadCount"] == 34945
+
+    def test_the_clamp_still_applies_once_the_chat_has_been_read_here(self):
+        """The regression this branch exists to prevent is untouched: after a
+        real local read, the server's inflated total is still clamped down."""
+        chat = _chat(t=2000)
+        chat["unreadCount"] = 1
+        stub = _Stub(chat)
+        stub.read_locally(JID)
+        stub._new_since_read[JID] = 1
+
+        stub.on_chat_unread_update(JID, 4, previous_unread=3)
+
+        assert stub.chats[JID]["unreadCount"] == 1
+
+    def test_marking_the_chat_unread_again_drops_the_anchor(self):
+        """mark_conversation_as_unread() reverses the read, so the ceiling it
+        installed must go too — otherwise the next server total is clamped to
+        a read the user has explicitly undone."""
+        chat = _chat(t=2000)
+        chat["unreadCount"] = 1
+        stub = _Stub(chat)
+        stub.read_locally(JID)
+        stub._drop_unread_local_read_anchor(JID)
+        stub._new_since_read[JID] = 1
+
+        stub.on_chat_unread_update(JID, 4, previous_unread=3)
+
+        assert stub.chats[JID]["unreadCount"] == 4
+
+    def test_the_anchor_resolves_both_identities_of_one_chat(self):
+        """mark_conversation_as_read() is called with whatever key self.chats
+        holds; the handler looks it up normalized. A @c.us read must still
+        anchor the @s.whatsapp.net form the handler resolves to."""
+        chat = _chat(t=2000)
+        chat["unreadCount"] = 1
+        stub = _Stub(chat)
+        stub.read_locally("5511999999999@c.us")
+        stub._new_since_read[JID] = 1
+
+        stub.on_chat_unread_update(JID, 4, previous_unread=3)
+
+        assert stub.chats[JID]["unreadCount"] == 1
+
+
+class TestTheAnchorSurvivesTheHandlerConsumingItsOwnState:
+    """The question the anchor has to answer: does dropping the clamp for
+    never-read chats let already-read messages come back as unread?
+
+    The end-to-end sequence, in one test rather than in three separate
+    fixtures, because the whole risk is in the transitions: the handler pops
+    both _locally_read_at and _new_since_read once it has used them, and the
+    protection has to outlive that. It does, because only
+    mark_conversation_as_read() sets the anchor and only an explicit reversal
+    clears it.
+    """
+
+    def test_a_read_then_two_arrivals_then_an_inflated_total_stays_clamped(self):
+        chat = _chat(t=1000)
+        chat["unreadCount"] = 3  # stale badge from an earlier sync
+        stub = _Stub(chat)
+
+        # 1. The user reads the chat here.
+        stub._locally_read_at[JID] = 1000
+        stub.read_locally(JID)
+        chat["unreadCount"] = 0
+
+        # 2. One genuinely new message arrives (on_new_message).
+        chat["t"] = 2000
+        chat["unreadCount"] = 1
+        stub._new_since_read[JID] = 1
+
+        # 3. The chats-update for it carries WhatsApp Web's inflated total and
+        #    consumes the read-ack on its way through.
+        stub.on_chat_unread_update(JID, 5, previous_unread=4)
+        assert stub.chats[JID]["unreadCount"] == 1
+        assert JID not in stub._locally_read_at      # ack consumed...
+        assert JID not in stub._new_since_read       # ...and counter popped
+
+        # 4. A second message arrives — on_new_message recreates the counter.
+        chat["t"] = 3000
+        chat["unreadCount"] = 2
+        stub._new_since_read[JID] = 1
+
+        # 5. A later chats-update still counting the messages read in step 1.
+        stub.on_chat_unread_update(JID, 6, previous_unread=5)
+
+        # One unread, not six: the anchor outlived both pops.
+        assert stub.chats[JID]["unreadCount"] == 1
+        assert stub._unread_anchored_to_local_read(JID)
+
+
+OTHER_JID = "5511888888888@s.whatsapp.net"
+
+
+class TestTheAnchorIsPerChat:
+    """The anchor is one process-wide set, so the thing that must not happen
+    is a read of one chat authorising the clamp for another — that is the
+    collapse of a backlog again, just sourced from the wrong conversation."""
+
+    def test_reading_one_chat_does_not_anchor_another(self):
+        stub = _Stub(_chat(t=2000))
+        stub.chats[OTHER_JID] = _chat(t=2000)
+        stub.chats[OTHER_JID]["unreadCount"] = 34876
+        stub.read_locally(JID)
+        # Arrivals in the OTHER chat, which was never read here.
+        stub._new_since_read[OTHER_JID] = 21
+
+        stub.on_chat_unread_update(OTHER_JID, 34945, previous_unread=34944)
+
+        assert stub.chats[OTHER_JID]["unreadCount"] == 34945
+        assert not stub._unread_anchored_to_local_read(OTHER_JID)
+
+
+class TestAnOpenChatWhoseReadWasUndone:
+    """The live-event half of tests/test_resync_open_chat_unread.py's class of
+    the same name. "Open" is proof of "read" only until the read is undone
+    with the conversation still on screen — Ctrl+Shift+M (_on_accel_toggle_read
+    -> mark_conversation_as_unread) and the /send-seen rollback both do that,
+    and both leave _new_since_read at 0, which is the exact shape
+    reconcile_open_chat_unread() answers 0 for.
+    """
+
+    def _open_but_unread(self, unread):
+        chat = _chat(t=1000)
+        chat["unreadCount"] = unread
+        stub = _Stub(chat)
+        stub.conversations_panel = _CP(JID)  # open, but no anchor: read undone
+        return stub
+
+    def test_a_chat_marked_unread_on_screen_keeps_its_badge(self):
+        """mark_conversation_as_unread() set 1; the next chats-update used to
+        take the open branch and put it straight back to 0."""
+        stub = self._open_but_unread(unread=1)
+
+        stub.on_chat_unread_update(JID, 0, previous_unread=None)
+
+        assert stub.chats[JID]["unreadCount"] == 1
+
+    def test_a_restored_backlog_survives_the_next_arrival(self):
+        """The /send-seen rollback case: the backlog is back, the conversation
+        is still open, and a new message pushes the server's total up by one.
+        It used to be answered with 0 (open, nothing counted locally)."""
+        stub = self._open_but_unread(unread=34876)
+
+        stub.on_chat_unread_update(JID, 34877, previous_unread=34876)
+
+        assert stub.chats[JID]["unreadCount"] == 34877
+
+    def test_reading_it_again_restores_the_open_behaviour(self):
+        """And the ordinary path is untouched: read the chat again and the
+        open branch takes over exactly as before."""
+        stub = self._open_but_unread(unread=1)
+        stub.read_locally(JID)
+
+        stub.on_chat_unread_update(JID, 5)
+
+        assert stub.chats[JID]["unreadCount"] == 0


### PR DESCRIPTION
## O sintoma

Um grupo com 34 mil mensagens não lidas tinha o contador **colapsado para 21**, subindo de um em um, restaurado pelo resync de 60 s e colapsado de novo um segundo depois — em ciclo, enquanto o app ficasse aberto. Medido nos quatro grupos mais movimentados de uma conta, numa sessão de dez minutos: `34876 → 21`, `7232 → 3`, `3366 → 2`, `2767 → 6`.

Direto do `log.log`, o ciclo inteiro:

```
23:15:17  [unread] ...: 34876 -> 21     (previous=34944, open=False, read_ack=None)
23:16:19  [unread] ...: 34922 -> 34886  after history sync     ← o resync restaura
23:16:20  [unread] ...: 34887 -> 35     ← o chats-update seguinte colapsa de novo
23:17:30  restaura 34888   →  23:17:32  colapsa para 41
23:18:38  restaura 34883   →  23:18:39  colapsa para 49
```

## A causa

O quarto branch de `on_chat_unread_update()` limita o total absoluto do WhatsApp Web ao contador `_new_since_read`, com a premissa declarada de que uma entrada não nula ali significa que a contagem local é "localmente verificada".

Isso só vale para um chat que foi **lido aqui**. `on_new_message()` cria a entrada do zero para qualquer chat que receba mensagem, então num chat nunca lido no WinZapp ela mede apenas "chegadas desde que o processo subiu" — e o `min()` descarta tudo que é anterior ao launch. O `read_ack=None` em toda linha do log confirma: nenhuma leitura local por trás.

## A correção

`_unread_anchored_to_local_read()` é a distinção que faltava. `mark_conversation_as_read()` ancora o contador; `mark_conversation_as_unread()` e o rollback do `/send-seen` derrubam a âncora; sem âncora, vale a contagem do servidor (já descontada de envios próprios e eventos de sistema logo acima).

A âncora é **em memória de propósito**: persistí-la sem o contador que ela qualifica reproduziria este mesmo colapso de forma durável — uma mensagem depois de cada reinício.

## Mais três achados ao revisar o próprio fix

- **A âncora vazava entre contas.** `clear_local_data(wipe_metadata=True)` esvaziava `_locally_read_at` e uma dúzia de coleções irmãs, mas não estas duas. Um JID de grupo é a mesma string nas duas contas, então uma âncora ganha na conta A autorizava o clamp para o mesmo grupo na B, onde nada foi lido.
- **"Aberto" estava sendo lido como "lido".** Deixa de ser verdade no instante em que uma leitura é desfeita com a conversa ainda na tela: Ctrl+Shift+M (`_on_accel_toggle_read` → `mark_conversation_as_unread`) e `_restore_unread_after_send_seen_failure()` deixam `_new_since_read` em 0 com o painel ainda mostrando o chat — exatamente a forma para a qual `reconcile_open_chat_unread()` responde 0. O estado de não lida que o usuário acabara de pedir era apagado pelo próximo `chats.update`, ou pelo resync de 60 s, backlog inteiro incluído. Os dois call sites do helper agora exigem a âncora, mantendo de fato a paridade que a docstring dele afirma.
- **Os três call sites novos não tinham asserção alguma** — dava para apagar qualquer um deles com a suíte verde.

## Testes

Verificado por mutação: **as sete linhas de produção adicionadas aqui falham a suíte quando removidas**, uma a uma.

Cobertura nova em `tests/test_unread_reread_race.py` (o colapso real `34876 → 21`; a proteção original preservada depois de uma leitura local; a sequência ponta a ponta em que o handler consome o próprio ack e a âncora sobrevive; isolamento entre chats; os dois caminhos de "aberto mas não lido"), em `tests/test_resync_open_chat_unread.py` (os mesmos dois caminhos pelo resync) e asserções de fiação em `tests/test_locally_read_at_persisted.py`, `tests/test_read_state_bidirectional_sync.py` e `tests/test_clear_local_data_metadata.py`.

Suíte completa: **6783 passaram, 76 skipped** (sem `--run-wx-gui`).

## O que este PR deliberadamente não fecha

Chat lido localmente → o read-ack já consumido → **reinício do app** → um `chats.update` inflado. Ali não há ack nem âncora. O clamp nunca protegeu esse caso de verdade: naquele estado `get_remote_chats()` cai em `v = server_val` e grava o número do servidor no próximo list-chats de qualquer forma. Quem protege isso é o `_locally_read_at` persistido, que este PR não toca.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
