### PR TITLE
Repaint the rows that changed instead of rebuilding the message list

### DIFF
--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -12211,9 +12211,22 @@ class ConversationsPanel(wx.Panel):
             i for i, m in enumerate(self._sorted_messages)
             if isinstance(m, dict) and m.get("key", {}).get("id") in msg_ids
         )
-        if not indices:
-            return
-        earliest = indices[0]
+        # An id with no row on screen still has to leave `records` and the DB.
+        # This used to `return` here, and that turned _mirror_remote_deletions()
+        # into a permanent no-op loop: the ids it mirrors are the ones the phone
+        # no longer has, and those are routinely NOT rendered rows — a reaction
+        # or other non-displayable record (_is_displayable_message()), or a
+        # message paginated out of the current window. Nothing was removed, so
+        # the next poll found exactly the same ids missing, and the next, and
+        # the next. Measured on a real session: the same 21 ids re-reported
+        # every 60s, sixty times in one log, each round paying a
+        # get-messages?count=200 round trip and printing a line claiming a
+        # removal that never happened.
+        #
+        # Only the row-level work below is conditional now. Everything from
+        # `if self.conversation:` on is unconditional, because it is what makes
+        # the removal stick.
+        earliest = indices[0] if indices else -1
         _preserved_msg_id = self._focused_msg_id() if focus_previous else ""
         _preserved_idx = self.messages_list.GetFocusedItem() if focus_previous else -1
         _preserved_was_separator = (
@@ -12266,7 +12279,14 @@ class ConversationsPanel(wx.Panel):
                 self.main_window._recompute_chat_last_message(jid)
                 self.main_window._schedule_set_chats()
 
-        if focus_previous:
+        if focus_previous and indices:
+            # `and indices`: with no row removed there is nothing to adjust
+            # focus for, and calling Focus()/Select() on the row the user is
+            # already sitting on fires EVT_LIST_ITEM_FOCUSED for a move that
+            # did not happen — the screen reader re-announces the row and the
+            # selection sound fires again. Reached whenever the ids being
+            # removed are all off-screen, which is the ordinary case for
+            # _mirror_remote_deletions().
             count = self.messages_list.GetItemCount()
             if count > 0:
                 new_focus = -1
@@ -15065,6 +15085,205 @@ class ConversationsPanel(wx.Panel):
         self._adopt_signature_after_repaint(ids)
         return True
 
+    def _sorted_deduped_records(self, messages: list) -> list:
+        """The record list ``populate_messages()`` renders from: sorted by
+        timestamp, then de-duplicated by key.id keeping the LAST occurrence.
+
+        Extracted from that method verbatim so the in-place repaint path below
+        can derive the same reaction map the rebuild would, rather than a second
+        opinion about it. Records accumulate duplicates when the same message
+        arrives via both the initial sync and messages.upsert; the latest
+        version of the message wins. A record with no id is never a duplicate of
+        anything and is always kept.
+        """
+        try:
+            messages_sorted = sorted(
+                messages, key=lambda m: self._extract_timestamp(m) or 0
+            )
+        except Exception:
+            messages_sorted = messages
+        _seen_ids: dict = {}
+        for i, m in enumerate(messages_sorted):
+            if not isinstance(m, dict):
+                continue
+            mid = m.get("key", {}).get("id", "")
+            if mid:
+                _seen_ids[mid] = i
+        _kept = set(_seen_ids.values())
+        return [
+            m for i, m in enumerate(messages_sorted)
+            if isinstance(m, dict) and (
+                not m.get("key", {}).get("id", "") or i in _kept
+            )
+        ]
+
+    def _reaction_map_from_sorted(self, messages_sorted: list) -> dict:
+        """Build the reaction map from an already sorted+deduped record list.
+
+        Each sender can only have ONE active reaction on a message at a time —
+        later records for the same (message, sender) pair replace the earlier
+        one instead of accumulating a count, and an empty emoji means that
+        sender removed their reaction. Order therefore matters, which is why
+        this takes the sorted list rather than raw records.
+        """
+        reaction_map: dict = {}
+        for m in messages_sorted:
+            if isinstance(m, dict) and m.get("messageType") == "reactionMessage":
+                reaction   = (m.get("message") or {}).get("reactionMessage") or {}
+                emoji      = reaction.get("text", "")
+                orig_id    = (reaction.get("key") or {}).get("id", "")
+                sender_key = self._reactor_key_from_msg(m)
+                if orig_id and sender_key:
+                    per_msg = reaction_map.setdefault(orig_id, {})
+                    if emoji:
+                        per_msg[sender_key] = emoji
+                    else:
+                        per_msg.pop(sender_key, None)
+        return reaction_map
+
+    @staticmethod
+    def _reaction_target_id(msg: dict) -> str:
+        """The id of the message a reaction record decorates, or ""."""
+        if not isinstance(msg, dict) or msg.get("messageType") != "reactionMessage":
+            return ""
+        reaction = (msg.get("message") or {}).get("reactionMessage") or {}
+        return (reaction.get("key") or {}).get("id", "") or ""
+
+    def _repaint_changed_rows_in_place(self, old_sig, new_sig) -> bool:
+        """Rewrite only the rows whose text actually changed, instead of
+        rebuilding the whole list. Returns whether the entire difference between
+        the two signatures was covered.
+
+        This is the rung that was missing between _append_new_tail_rows() (rows
+        added at the END) and the full rebuild, and its absence is what the 60s
+        poll was landing on. Two very ordinary things change a row that is
+        already on screen without adding or removing any row:
+
+        * a delivery/read receipt moving a message's ``status``;
+        * a reaction, which is a record that never becomes a row of its own and
+          instead changes the text of ANOTHER row.
+
+        Neither is expressible as a tail append, so both fell through to
+        ``populate_messages(preserve_focus=True)`` — DeleteAllItems() plus one
+        Append() per row, followed by re-Focus()/re-Select()ing the row the user
+        was already on. That last part is the damage: a native ListView row is a
+        single MSAA object, so re-focusing it fires EVT_LIST_ITEM_FOCUSED and
+        the screen reader re-announces a row the user never moved off, once a
+        minute, mid-read. It cannot be fixed by making the rebuild quieter —
+        the focus event is unavoidable once the control has been cleared — so
+        the rebuild has to not happen.
+
+        Refuses anything that moves, adds or removes a ROW, because only the
+        rebuild knows where a row goes:
+
+        * a changed record whose timestamp moved (the list is sorted by
+          timestamp, so it may belong somewhere else now);
+        * a displayable record added or removed (that is a row appearing or
+          disappearing — _append_new_tail_rows() owns the tail case);
+        * a reaction whose target is not currently rendered (paginated out, or
+          in another conversation) — there is no row to repaint;
+        * everything _signature_changed_ids() already refuses on its own: a
+          different conversation, a moved unread separator, an empty or
+          repeated id;
+        * a list out of step with the control, or the placeholder list, on the
+          same reasoning as _repaint_message_rows().
+        """
+        if self.conversation is None or not self._sorted_messages:
+            return False
+        changed = self._signature_changed_ids(old_sig, new_sig)
+        if not changed:
+            # None (not comparable) and the empty set (nothing to do, which
+            # refresh_messages_if_changed() would not have called us for) both
+            # belong to the caller's slower path.
+            return False
+        old_rows = {r[0]: r for r in old_sig[3]}
+        new_rows = {r[0]: r for r in new_sig[3]}
+
+        records = []
+        container = self.conversation.get("messages")
+        if isinstance(container, dict):
+            inner = container.get("messages")
+            if isinstance(inner, dict) and isinstance(inner.get("records"), list):
+                records = inner["records"]
+        by_id = {}
+        for m in records:
+            if isinstance(m, dict):
+                mid = (m.get("key") or {}).get("id", "")
+                if mid:
+                    by_id[mid] = m
+
+        rendered = {}
+        for idx, m in enumerate(self._sorted_messages):
+            if isinstance(m, dict) and not self._is_separator(m):
+                mid = (m.get("key") or {}).get("id", "")
+                if mid:
+                    rendered[mid] = idx
+
+        targets = set()
+        for mid in changed:
+            before, after = old_rows.get(mid), new_rows.get(mid)
+            if before is not None and after is not None:
+                # Index 7 of the signature tuple is the timestamp; a row whose
+                # sort key moved may not belong where it currently sits.
+                if before[7] != after[7]:
+                    return False
+                if mid in rendered:
+                    targets.add(mid)
+                    continue
+                # Not a row of its own: only a reaction may legitimately be
+                # invisible, and only if what it decorates is on screen.
+                target = self._reaction_target_id(by_id.get(mid) or {})
+                if target and target in rendered:
+                    targets.add(target)
+                    continue
+                return False
+            # Added or removed outright.
+            record = by_id.get(mid)
+            if record is None:
+                # Gone from `records`: either a row disappeared, or a reaction
+                # was withdrawn. Both need the rebuild — a withdrawn reaction
+                # changed some other row's text and there is nothing left to
+                # read the target off, so it cannot be repainted either.
+                return False
+            if self._is_displayable_message(record):
+                return False        # a row appears — not ours to place
+            target = self._reaction_target_id(record)
+            if not (target and target in rendered):
+                return False
+            targets.add(target)
+
+        if not targets:
+            return False
+        if self.messages_list.GetItemCount() != len(self._sorted_messages):
+            logging.info("[_repaint_changed_rows_in_place] list out of step with rows — full path")
+            return False
+        first_row = self._sorted_messages[0]
+        if isinstance(first_row, dict) and first_row.get("_type") == "empty_placeholder":
+            return False
+
+        # The reaction map has to move first: _render_message_line() reads it,
+        # so repainting before rebuilding it would write the OLD reaction back
+        # into the row that just changed.
+        try:
+            self._reaction_map = self._reaction_map_from_sorted(
+                self._sorted_deduped_records(records)
+            )
+            found = self._set_message_row_texts(targets)
+        except Exception:
+            logging.exception("[_repaint_changed_rows_in_place] failed — full path")
+            return False
+        if found != targets:
+            logging.info("[_repaint_changed_rows_in_place] %d of %d rows not rendered — full path",
+                         len(targets - found), len(targets))
+            return False
+        self._messages_signature_cache = new_sig
+        logging.info(
+            "[_repaint_changed_rows_in_place] %d changed record(s) -> %d row(s) "
+            "repainted, %d row(s) total — no rebuild.",
+            len(changed), len(targets), len(self._sorted_messages),
+        )
+        return True
+
     def _repaint_or_repopulate(self, msg_ids) -> None:
         """Repaint just the rows of *msg_ids*, rebuilding the list only if
         that isn't possible. The shape every local flag change uses."""
@@ -15290,16 +15509,37 @@ class ConversationsPanel(wx.Panel):
             return
         if sig == getattr(self, "_messages_signature_cache", None):
             return
+        cached = getattr(self, "_messages_signature_cache", None)
         try:
-            if self._append_new_tail_rows(
-                getattr(self, "_messages_signature_cache", None), sig
-            ):
+            if self._append_new_tail_rows(cached, sig):
                 return
         except Exception:
             # O rebuild abaixo repinta a conversa inteira de qualquer forma, e
             # é ele que estava aqui antes: uma falha no atalho não pode custar
             # a atualização.
             logging.exception("[refresh_messages_if_changed] tail append failed — full path")
+        try:
+            if self._repaint_changed_rows_in_place(cached, sig):
+                return
+        except Exception:
+            logging.exception("[refresh_messages_if_changed] in-place repaint failed — full path")
+        # Neither shortcut covered it, so the list really is being rebuilt and
+        # the user really will be re-announced their own row. Say what forced
+        # it: without this the only evidence in a log is a populate_messages
+        # line every 60s, and working out which record moved took a session of
+        # inference. Cheap — it runs only on the path that is about to spend
+        # tens of milliseconds rebuilding.
+        try:
+            changed = self._signature_changed_ids(cached, sig)
+            if changed is None:
+                logging.info("[refresh_messages_if_changed] rebuild: signatures not "
+                             "comparable (conversation, unread separator, or an "
+                             "empty/repeated message id changed)")
+            else:
+                logging.info("[refresh_messages_if_changed] rebuild: %d record(s) "
+                             "changed, ids=%s", len(changed), sorted(changed)[:8])
+        except Exception:
+            pass
         self._messages_signature_cache = sig
         self.populate_messages(preserve_focus=True)
 
@@ -15394,48 +15634,8 @@ class ConversationsPanel(wx.Panel):
                 inner = messages_container.get("messages")
                 if isinstance(inner, dict) and isinstance(inner.get("records"), list):
                     messages = inner["records"]
-            try:
-                messages_sorted = sorted(
-                    messages, key=lambda m: self._extract_timestamp(m) or 0
-                )
-            except Exception:
-                messages_sorted = messages
-
-            # Deduplicate by key.id — records may accumulate duplicates when the
-            # same message arrives via both the initial sync and messages.upsert.
-            # Keep the last occurrence (latest version of the message wins).
-            _seen_ids: dict = {}
-            for i, m in enumerate(messages_sorted):
-                if not isinstance(m, dict):
-                    continue
-                mid = m.get("key", {}).get("id", "")
-                if mid:
-                    _seen_ids[mid] = i
-            _kept = set(_seen_ids.values())
-            messages_sorted = [
-                m for i, m in enumerate(messages_sorted)
-                if isinstance(m, dict) and (
-                    not m.get("key", {}).get("id", "") or i in _kept
-                )
-            ]
-
-            # Build reaction map from all reaction messages. Each sender can only
-            # have ONE active reaction on a message at a time — later records for
-            # the same (message, sender) pair replace the earlier one instead of
-            # accumulating a count, and an empty emoji means that sender removed
-            # their reaction.
-            for m in messages_sorted:
-                if isinstance(m, dict) and m.get("messageType") == "reactionMessage":
-                    reaction   = (m.get("message") or {}).get("reactionMessage") or {}
-                    emoji      = reaction.get("text", "")
-                    orig_id    = (reaction.get("key") or {}).get("id", "")
-                    sender_key = self._reactor_key_from_msg(m)
-                    if orig_id and sender_key:
-                        per_msg = self._reaction_map.setdefault(orig_id, {})
-                        if emoji:
-                            per_msg[sender_key] = emoji
-                        else:
-                            per_msg.pop(sender_key, None)
+            messages_sorted = self._sorted_deduped_records(messages)
+            self._reaction_map = self._reaction_map_from_sorted(messages_sorted)
 
             # Exclude reaction messages — they must not affect index mapping
             displayable = [

--- a/tests/test_mirrored_deletion_sticks.py
+++ b/tests/test_mirrored_deletion_sticks.py
@@ -1,0 +1,208 @@
+"""A mirrored deletion has to leave `records`, even with no row on screen.
+
+``remove_messages_by_id()`` used to `return` as soon as none of the ids it was
+given matched a rendered row, and that turned ``_mirror_remote_deletions()``
+into a permanent no-op loop. The ids it mirrors are precisely the ones the phone
+no longer has, and those are routinely NOT rendered rows: a reaction or other
+non-displayable record, or a message paginated out of the current window.
+Nothing was removed, so the next 60s poll found exactly the same ids missing,
+and so did the next.
+
+Measured on a real session (2026-09-10): "21 message(s) in <group> no longer on
+the phone — removing locally" sixty times in one log, the same count every
+minute, each round paying its own `get-messages?count=200` round trip — and the
+log line printed before the early return, so it claimed work that never
+happened.
+
+ConversationsPanel is a wx.Panel, so the method runs unbound against a stub —
+same approach as tests/test_selective_message_repaint.py.
+"""
+
+import pytest
+
+from ui.conversations import ConversationsPanel
+
+JID = "5511900000001@s.whatsapp.net"
+
+
+class _FakeList:
+    def __init__(self, rows):
+        self._count = rows
+        self.deleted = []
+        self.focused = []
+        self.selected = []
+        self.ensured = []
+
+    def GetItemCount(self):
+        return self._count
+
+    def GetFocusedItem(self):
+        return 0
+
+    def DeleteItem(self, idx):
+        self.deleted.append(idx)
+        self._count -= 1
+
+    def Focus(self, idx):
+        self.focused.append(idx)
+
+    def Select(self, idx, on=True):
+        self.selected.append(idx)
+
+    def EnsureVisible(self, idx):
+        self.ensured.append(idx)
+
+
+class _DB:
+    def __init__(self):
+        self.deleted = []
+
+    def delete_message(self, jid, mid):
+        self.deleted.append((jid, mid))
+
+
+class _Main:
+    def __init__(self):
+        self.db = _DB()
+        self.recomputed = []
+        self.set_chats = 0
+
+    def _recompute_chat_last_message(self, jid):
+        self.recomputed.append(jid)
+
+    def _schedule_set_chats(self):
+        self.set_chats += 1
+
+
+def _msg(mid):
+    return {"key": {"id": mid, "remoteJid": JID}, "messageType": "conversation",
+            "message": {"conversation": mid}, "messageTimestamp": 100}
+
+
+class _Panel:
+    remove_messages_by_id = ConversationsPanel.remove_messages_by_id
+
+    def __init__(self, records, rendered_ids):
+        self.conversation = {
+            "remoteJid": JID,
+            "messages": {"messages": {"records": list(records)}},
+        }
+        rendered = [r for r in records if r["key"]["id"] in rendered_ids]
+        self._sorted_messages = list(rendered)
+        self._all_sorted_messages = list(records)
+        self._messages_offset = 0
+        self._unread_sep_idx = -1
+        self.messages_list = _FakeList(len(rendered))
+        self.main_window = _Main()
+        self.stopped_playback = []
+
+    def _stop_playback_for_removed_messages(self, ids):
+        self.stopped_playback.append(set(ids))
+
+    def _focused_msg_id(self):
+        if self._sorted_messages:
+            return self._sorted_messages[0]["key"]["id"]
+        return ""
+
+    def _record_ids(self):
+        return [
+            r["key"]["id"]
+            for r in self.conversation["messages"]["messages"]["records"]
+        ]
+
+
+class TestAnOffScreenIdIsStillRemoved:
+    """The regression. Every id here is absent from _sorted_messages, which is
+    the ordinary shape of a mirrored phone-side deletion."""
+
+    def test_it_leaves_the_records(self):
+        p = _Panel([_msg("a"), _msg("hidden")], rendered_ids={"a"})
+
+        p.remove_messages_by_id({"hidden"}, focus_previous=True)
+
+        assert p._record_ids() == ["a"], (
+            "the record survived, so the next poll reports it missing again — "
+            "forever, once a minute"
+        )
+
+    def test_it_reaches_the_database(self):
+        """Memory alone would not survive a reload: the next launch reads the
+        record straight back in and the loop resumes."""
+        p = _Panel([_msg("a"), _msg("hidden")], rendered_ids={"a"})
+
+        p.remove_messages_by_id({"hidden"}, focus_previous=True)
+
+        assert p.main_window.db.deleted == [(JID, "hidden")]
+
+    def test_it_leaves_the_unpaginated_list(self):
+        p = _Panel([_msg("a"), _msg("hidden")], rendered_ids={"a"})
+
+        p.remove_messages_by_id({"hidden"}, focus_previous=True)
+
+        assert [m["key"]["id"] for m in p._all_sorted_messages] == ["a"]
+
+    def test_the_chat_list_preview_is_recomputed(self):
+        """The removed message can be the one the conversations list is showing
+        as the preview and sorting by."""
+        p = _Panel([_msg("a"), _msg("hidden")], rendered_ids={"a"})
+
+        p.remove_messages_by_id({"hidden"}, focus_previous=True)
+
+        assert p.main_window.recomputed == [JID]
+        assert p.main_window.set_chats == 1
+
+    def test_no_row_is_deleted_from_the_control(self):
+        p = _Panel([_msg("a"), _msg("hidden")], rendered_ids={"a"})
+
+        p.remove_messages_by_id({"hidden"}, focus_previous=True)
+
+        assert p.messages_list.deleted == []
+
+    def test_focus_is_not_touched(self):
+        """No row disappeared, so there is nothing to adjust focus for. Calling
+        Focus()/Select() on the row the user is already sitting on fires
+        EVT_LIST_ITEM_FOCUSED for a move that did not happen — the screen reader
+        re-announces the row and the selection sound fires again."""
+        p = _Panel([_msg("a"), _msg("hidden")], rendered_ids={"a"})
+
+        p.remove_messages_by_id({"hidden"}, focus_previous=True)
+
+        assert p.messages_list.focused == []
+        assert p.messages_list.selected == []
+
+
+class TestTheOnScreenPathIsUnchanged:
+    def test_a_rendered_row_is_still_deleted(self):
+        p = _Panel([_msg("a"), _msg("b")], rendered_ids={"a", "b"})
+
+        p.remove_messages_by_id({"b"}, focus_previous=True)
+
+        assert p.messages_list.deleted == [1]
+        assert p._record_ids() == ["a"]
+
+    def test_focus_is_still_adjusted_when_a_row_goes(self):
+        """The user-initiated single-delete path: the deleted message IS what
+        was focused, so focus has to land somewhere."""
+        p = _Panel([_msg("a"), _msg("b")], rendered_ids={"a", "b"})
+
+        p.remove_messages_by_id({"a"}, focus_previous=True)
+
+        assert p.messages_list.focused == [0]
+
+    def test_playback_is_stopped_for_every_id_either_way(self):
+        """A playing audio message may not be in _sorted_messages at all —
+        pagination can scroll it out while it keeps playing."""
+        p = _Panel([_msg("a"), _msg("hidden")], rendered_ids={"a"})
+
+        p.remove_messages_by_id({"hidden"})
+
+        assert p.stopped_playback == [{"hidden"}]
+
+    def test_an_empty_id_set_still_does_nothing(self):
+        p = _Panel([_msg("a")], rendered_ids={"a"})
+
+        p.remove_messages_by_id(set())
+
+        assert p._record_ids() == ["a"]
+        assert p.stopped_playback == []
+        assert p.main_window.db.deleted == []

--- a/tests/test_periodic_refresh_does_not_rebuild.py
+++ b/tests/test_periodic_refresh_does_not_rebuild.py
@@ -1,0 +1,325 @@
+"""The 60s poll must repaint the rows that changed, never rebuild the list.
+
+A native ListView row is a single MSAA object, so ``populate_messages()``'s
+DeleteAllItems() + re-Append() + re-Focus()/re-Select() fires
+EVT_LIST_ITEM_FOCUSED for the row the user is already sitting on. The screen
+reader re-announces it and the selection sound fires again — once a minute,
+mid-read. It cannot be fixed by making the rebuild quieter: once the control has
+been cleared, re-focusing is the only way to put the user back, and that event
+is unavoidable. So the rebuild has to not happen.
+
+``refresh_messages_if_changed()`` already had two rungs — "nothing changed" and
+_append_new_tail_rows() for rows added at the END. The two ordinary changes that
+fit neither are the ones the poll actually delivers:
+
+* a delivery/read receipt moving an existing message's ``status``;
+* a reaction, a record that never becomes a row of its own and instead changes
+  the text of ANOTHER row.
+
+Measured on a real session (2026-09-10): a full rebuild every ~60s, including
+one pair two minutes apart that both rebuilt an identical 209 rows.
+
+ConversationsPanel is a wx.Panel, so the methods run unbound against a stub
+carrying a fake list control — same approach as
+tests/test_selective_message_repaint.py.
+"""
+
+import pytest
+
+from ui.conversations import ConversationsPanel
+
+JID = "5511900000001@s.whatsapp.net"
+
+
+class _FakeList:
+    """Just enough wx.ListCtrl for the repaint path, recording every write."""
+
+    def __init__(self, rows=0):
+        self._count = rows
+        self.texts = {}
+        self.deleted_all = 0
+        self.focused = []
+        self.selected = []
+
+    def GetItemCount(self):
+        return self._count
+
+    def SetItemText(self, idx, text):
+        self.texts[idx] = text
+
+    def DeleteAllItems(self):
+        self.deleted_all += 1
+        self._count = 0
+
+    def Focus(self, idx):
+        self.focused.append(idx)
+
+    def Select(self, idx, on=True):
+        self.selected.append(idx)
+
+
+def _msg(mid, ts, status="", body="hi"):
+    return {
+        "key": {"id": mid, "remoteJid": JID, "fromMe": False},
+        "message": {"conversation": body},
+        "messageType": "conversation",
+        "messageTimestamp": ts,
+        "status": status,
+    }
+
+
+def _reaction(mid, ts, target, emoji="👍"):
+    return {
+        "key": {"id": mid, "remoteJid": JID, "fromMe": False,
+                "participant": "5511900000002@s.whatsapp.net"},
+        "message": {"reactionMessage": {"key": {"id": target}, "text": emoji}},
+        "messageType": "reactionMessage",
+        "messageTimestamp": ts,
+    }
+
+
+class _Panel:
+    _messages_signature = ConversationsPanel._messages_signature
+    # staticmethod on the real class: unwrapped here it would be rebound as a
+    # plain method and receive `self` as its first argument.
+    _signature_changed_ids = staticmethod(ConversationsPanel._signature_changed_ids)
+    _repaint_changed_rows_in_place = ConversationsPanel._repaint_changed_rows_in_place
+    _sorted_deduped_records = ConversationsPanel._sorted_deduped_records
+    _reaction_map_from_sorted = ConversationsPanel._reaction_map_from_sorted
+    _reaction_target_id = staticmethod(ConversationsPanel._reaction_target_id)
+    _set_message_row_texts = ConversationsPanel._set_message_row_texts
+    _extract_timestamp = ConversationsPanel._extract_timestamp
+    _SELF_REACTOR_KEY = ConversationsPanel._SELF_REACTOR_KEY
+
+    def __init__(self, records):
+        self._set_records(records)
+        self._first_unread_msg_id = ""
+        self._pending_open_unread = 0
+        self._reaction_map = {}
+        self._messages_signature_cache = None
+        self.rebuilds = 0
+        displayable = [r for r in records if r.get("messageType") != "reactionMessage"]
+        self._sorted_messages = list(displayable)
+        self._all_sorted_messages = list(displayable)
+        self.messages_list = _FakeList(len(displayable))
+
+    def _set_records(self, records):
+        self.conversation = {
+            "remoteJid": JID,
+            "messages": {"messages": {"records": list(records)}},
+        }
+
+    # -- collaborators the methods under test reach for ---------------------
+    def _is_separator(self, m):
+        return isinstance(m, dict) and m.get("_type") in ("separator", "unread_separator")
+
+    def _is_displayable_message(self, m):
+        return isinstance(m, dict) and m.get("messageType") != "reactionMessage"
+
+    def _get_message_content(self, m):
+        return (m.get("message") or {}).get("conversation", "")
+
+    def _reactor_key_from_msg(self, m):
+        return (m.get("key") or {}).get("participant", "")
+
+    def _render_message_line(self, m, index=None, total=None):
+        mid = (m.get("key") or {}).get("id", "")
+        emoji = "".join((self._reaction_map.get(mid) or {}).values())
+        return f"{self._get_message_content(m)}|{m.get('status', '')}|{emoji}"
+
+    def populate_messages(self, preserve_focus=False):
+        self.rebuilds += 1
+        self.messages_list.DeleteAllItems()
+
+    def _repaint(self):
+        """Drive the rung the way refresh_messages_if_changed() does."""
+        old = self._messages_signature_cache
+        new = self._messages_signature()
+        return self._repaint_changed_rows_in_place(old, new)
+
+
+def _panel_with_cache(records):
+    p = _Panel(records)
+    p._messages_signature_cache = p._messages_signature()
+    p._reaction_map = p._reaction_map_from_sorted(p._sorted_deduped_records(records))
+    return p
+
+
+class TestAStatusChangeRepaintsOneRow:
+    def test_it_does_not_rebuild(self):
+        records = [_msg("a", 100), _msg("b", 200), _msg("c", 300)]
+        p = _panel_with_cache(records)
+
+        records[1]["status"] = "READ"
+        p._set_records(records)
+
+        assert p._repaint() is True
+        assert p.rebuilds == 0
+        assert p.messages_list.deleted_all == 0
+
+    def test_only_the_changed_row_is_rewritten(self):
+        records = [_msg("a", 100), _msg("b", 200), _msg("c", 300)]
+        p = _panel_with_cache(records)
+
+        records[1]["status"] = "READ"
+        p._set_records(records)
+        p._repaint()
+
+        assert set(p.messages_list.texts) == {1}
+        assert "READ" in p.messages_list.texts[1]
+
+    def test_focus_is_never_touched(self):
+        """The whole point: no Focus()/Select() means no EVT_LIST_ITEM_FOCUSED,
+        so the screen reader stays quiet on a row the user never left."""
+        records = [_msg("a", 100), _msg("b", 200)]
+        p = _panel_with_cache(records)
+
+        records[0]["status"] = "DELIVERY_ACK"
+        p._set_records(records)
+        p._repaint()
+
+        assert p.messages_list.focused == []
+        assert p.messages_list.selected == []
+
+    def test_the_fingerprint_moves_forward(self):
+        """Left behind, the next poll would find the same mismatch and rebuild
+        anyway — the repaint would only have delayed the announcement."""
+        records = [_msg("a", 100), _msg("b", 200)]
+        p = _panel_with_cache(records)
+
+        records[0]["status"] = "READ"
+        p._set_records(records)
+        p._repaint()
+
+        assert p._messages_signature_cache == p._messages_signature()
+
+
+class TestAReactionRepaintsTheRowItDecorates:
+    def test_a_new_reaction_repaints_its_target_and_nothing_else(self):
+        """A reaction is not a row. It changes the text of another one, and the
+        signature does not say which — which is exactly why
+        _append_new_tail_rows() refuses it and why this rung has to resolve the
+        target itself."""
+        records = [_msg("a", 100), _msg("b", 200)]
+        p = _panel_with_cache(records)
+
+        records.append(_reaction("r1", 300, target="a"))
+        p._set_records(records)
+
+        assert p._repaint() is True
+        assert p.rebuilds == 0
+        assert set(p.messages_list.texts) == {0}
+        assert "👍" in p.messages_list.texts[0]
+
+    def test_the_reaction_map_is_rebuilt_before_the_row_is_written(self):
+        """Repainting first would write the OLD reaction back into the row that
+        just changed."""
+        records = [_msg("a", 100)]
+        p = _panel_with_cache(records)
+
+        records.append(_reaction("r1", 300, target="a", emoji="🎉"))
+        p._set_records(records)
+        p._repaint()
+
+        assert p._reaction_map.get("a")
+        assert "🎉" in p.messages_list.texts[0]
+
+    def test_a_reaction_for_an_off_screen_target_falls_back(self):
+        """Nothing to repaint — only the rebuild can show it."""
+        records = [_msg("a", 100)]
+        p = _panel_with_cache(records)
+
+        records.append(_reaction("r1", 300, target="paginated-out"))
+        p._set_records(records)
+
+        assert p._repaint() is False
+
+
+class TestItRefusesAnythingThatMovesARow:
+    def test_a_new_displayable_message_falls_back(self):
+        """A row appears; _append_new_tail_rows() owns the tail case and the
+        rebuild owns the rest. Placing a row is never this method's job."""
+        records = [_msg("a", 100), _msg("b", 200)]
+        p = _panel_with_cache(records)
+
+        records.append(_msg("c", 300))
+        p._set_records(records)
+
+        assert p._repaint() is False
+
+    def test_a_removed_record_falls_back(self):
+        records = [_msg("a", 100), _msg("b", 200)]
+        p = _panel_with_cache(records)
+
+        p._set_records(records[:1])
+
+        assert p._repaint() is False
+
+    def test_a_changed_timestamp_falls_back(self):
+        """The list is sorted by timestamp, so a row whose sort key moved may
+        not belong where it currently sits."""
+        records = [_msg("a", 100), _msg("b", 200)]
+        p = _panel_with_cache(records)
+
+        records[0]["messageTimestamp"] = 500
+        p._set_records(records)
+
+        assert p._repaint() is False
+
+    def test_a_list_out_of_step_with_the_control_falls_back(self):
+        """A targeted SetItemText would write the right text into the wrong
+        row. Same guard as _repaint_message_rows()."""
+        records = [_msg("a", 100), _msg("b", 200)]
+        p = _panel_with_cache(records)
+        p.messages_list._count = 5
+
+        records[0]["status"] = "READ"
+        p._set_records(records)
+
+        assert p._repaint() is False
+
+    def test_the_placeholder_list_falls_back(self):
+        records = [_msg("a", 100)]
+        p = _panel_with_cache(records)
+        p._sorted_messages = [{"_type": "empty_placeholder"}]
+        p.messages_list._count = 1
+
+        records[0]["status"] = "READ"
+        p._set_records(records)
+
+        assert p._repaint() is False
+
+    def test_no_cached_signature_falls_back(self):
+        """First refresh after a rebuild has nothing to diff against."""
+        p = _Panel([_msg("a", 100)])
+        assert p._repaint() is False
+
+
+class TestTheExtractedHelpersMatchTheRebuild:
+    """The rung derives its reaction map from the same two helpers
+    populate_messages() uses, rather than a second opinion about them."""
+
+    def test_records_are_sorted_by_timestamp(self):
+        p = _Panel([])
+        out = p._sorted_deduped_records([_msg("b", 300), _msg("a", 100)])
+        assert [m["key"]["id"] for m in out] == ["a", "b"]
+
+    def test_the_last_duplicate_wins(self):
+        p = _Panel([])
+        out = p._sorted_deduped_records(
+            [_msg("a", 100, body="old"), _msg("a", 100, body="new")]
+        )
+        assert len(out) == 1 and out[0]["message"]["conversation"] == "new"
+
+    def test_a_record_without_an_id_is_kept(self):
+        p = _Panel([])
+        anon = _msg("", 100)
+        assert p._sorted_deduped_records([anon]) == [anon]
+
+    def test_an_empty_emoji_removes_that_senders_reaction(self):
+        p = _Panel([])
+        records = p._sorted_deduped_records([
+            _reaction("r1", 100, target="a", emoji="👍"),
+            _reaction("r2", 200, target="a", emoji=""),
+        ])
+        assert p._reaction_map_from_sorted(records).get("a") == {}


### PR DESCRIPTION
## O sintoma e por que não dá para deixar o rebuild silencioso

A cada 60s a lista de mensagens é reescrita inteira, o que dispara uma mudança de foco na linha em que o usuário está — o NVDA re-anuncia a linha e o som de seleção toca de novo, no meio da leitura.

Uma linha de ListView nativa é **um único objeto MSAA**, então o `DeleteAllItems()` + re-`Append()` + re-`Focus()`/re-`Select()` do `populate_messages()` não tem como evitar esse evento: depois que o controle foi limpo, re-focar é a única forma de devolver o usuário ao lugar. Não dá para tornar o rebuild quieto — ele tem que **não acontecer**.

(Registro do que foi descartado: o `focus_cloak.py` não serve aqui. O `GetState()` dele responde `ACC_NOT_IMPLEMENTED` para `childId != 0`, e o objeto focado numa SysListView32 é o *item*, não a janela — o NVDA encontraria `FOCUSED` no próprio item.)

## Duas causas independentes, as duas visíveis no log de uma sessão

### 1. A deleção espelhada não colava

`remove_messages_by_id()` retornava assim que nenhum dos ids batia com uma linha **renderizada** — antes de tocar em `records` ou no banco. Só que os ids que `_mirror_remote_deletions()` passa são exatamente os que o telefone não tem mais, e esses rotineiramente **não são linhas renderizadas**: uma reação ou outro registro não exibível, ou uma mensagem paginada para fora da janela.

Então nada era removido, e o poll seguinte encontrava os mesmos ids faltando:

```
10:50:09  21 message(s) ... no longer on the phone — removing locally
10:51:09  21 message(s) ...
10:52:12  21 message(s) ...
```

**Sessenta dessas em um único log, a mesma contagem todo minuto**, cada rodada pagando um `get-messages?count=200` — e a linha era impressa *antes* do return, reivindicando um trabalho que nunca aconteceu.

Agora só as mutações de linha são condicionais; a remoção de registro e banco não é. A restauração de foco também é pulada quando nenhuma linha saiu — não há o que ajustar, e re-`Focus()`ar a linha atual é justamente o evento de que trata esta PR.

### 2. Faltava um degrau na escada de refresh

`refresh_messages_if_changed()` tinha dois degraus — "nada mudou" e `_append_new_tail_rows()` para linhas acrescentadas no **fim**. As duas mudanças que o poll realmente entrega não cabem em nenhum dos dois:

- um recibo de entrega/leitura mexendo no `status` de uma mensagem existente;
- uma **reação**, que é um registro que nunca vira linha própria e em vez disso muda o texto de **outra** linha.

`_repaint_changed_rows_in_place()` é o degrau que faltava. Ele resolve a reação até a linha que ela decora, reconstrói o mapa de reações **antes** de escrever (repintar primeiro colocaria a reação antiga de volta), e recusa qualquer coisa que mova, adicione ou remova uma linha: timestamp alterado, registro exibível aparecendo ou sumindo, reação com alvo fora da tela, lista fora de passo com o controle.

A construção do mapa de reações e o sort+dedup saem de `populate_messages()` **verbatim**, para que a repintura derive o mesmo mapa que o rebuild derivaria, e não uma segunda opinião sobre ele.

## Diagnóstico

Quando nenhum atalho cobre, o rebuild ainda roda — e agora registra **quais registros** o forçaram. Descobrir isso nos logs anteriores exigiu uma sessão inteira de inferência a partir de uma linha `populate_messages` seca a cada 60s.

## Testes

27 testes novos em dois arquivos, mais a suíte completa.

> Nota: `tests/test_api_patches_in_sync.py` falha nesta branch por artefato de working tree — `client/api/` é git-ignored e ainda carrega os arquivos da #222. Resolve ao mesclar a #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)