### PR TITLE
Two ways an account goes offline and cannot come back, and load tests for the paths that only break at size

### DIFF
--- a/client/api_patches/src/config.ts
+++ b/client/api_patches/src/config.ts
@@ -162,6 +162,17 @@ export default {
       '--use-mock-keychain',
       '--no-pings',
       '--disable-client-side-phishing-detection',
+      // Belt to clearRestorableSession()'s braces (createSessionUtil.ts).
+      // That function removes the saved-tab files and records a clean exit
+      // before every launch; these two stop Chrome from acting on a restore
+      // record that appears anyway — a crash mid-session, or a profile
+      // restored from a snapshot taken elsewhere. WPPConnect drives exactly
+      // one page, and every extra tab a restore reopens loads outside
+      // start.js's document interception and outside wppconnect's user-agent
+      // override, then competes for the same IndexedDB and backend worker
+      // until injectApi() times out.
+      '--hide-crash-restore-bubble',
+      '--disable-session-crashed-bubble',
     ],
     /**
      * Example of configuring the linkPreview generator

--- a/client/api_patches/src/util/createSessionUtil.ts
+++ b/client/api_patches/src/util/createSessionUtil.ts
@@ -343,7 +343,14 @@ function clearRestorableSession(profileDir: string, logger?: any): void {
         ) {
           prefs.profile.exit_type = 'Normal';
           prefs.profile.exited_cleanly = true;
-          fs.writeFileSync(prefsPath, JSON.stringify(prefs), 'utf8');
+          // Temp + rename, never in place. writeFileSync truncates first, and
+          // this can run while a stale Chrome still owns the profile (rung one
+          // runs before any kill) — a death between the truncate and the write
+          // would hand Chrome an unparseable Preferences and a reset profile.
+          // Chrome writes this file the same way, for the same reason.
+          const prefsTmp = prefsPath + '.winzapp.tmp';
+          fs.writeFileSync(prefsTmp, JSON.stringify(prefs), 'utf8');
+          fs.renameSync(prefsTmp, prefsPath);
         }
       }
     } catch (e) {}
@@ -773,7 +780,26 @@ export default class CreateSessionUtil {
     // mid-write costs here.
     if (graceful && (await closeBrowserGracefully(session, logger, timeoutMs, client)))
       return;
+    // The precise kill can only ever reach this client's own page, so it is
+    // unconditional. The directory scan cannot: it kills whoever holds the
+    // profile, which after a takeover is a successor's browser — the
+    // 03:55:50 incident killBrowserOrFallback() carries in its own comment.
+    //
+    // This guard is new because the path is new. closeBrowserGracefully()
+    // used to answer `true` for a client with no page at all (during
+    // create(), clientsArray[session] holds a stub and Object.assign() has
+    // not run yet), so this returned early and killed nothing — which is how
+    // the stale lock this branch fixes was reached in the first place. Now it
+    // answers `false`, honestly, and the fallback below actually runs.
     if (!forceKillBrowserProcess(client?.page, logger)) {
+      const current: any = clientsArray[session];
+      if (current && client && current !== client) {
+        logger?.warn?.(
+          `[${session}] not killing the browser by userDataDir: this session ` +
+            'has been taken over by a newer client, and the profile is its.'
+        );
+        return;
+      }
       forceKillByUserDataDir(`userDataDir/${session}`, logger);
     }
   }

--- a/client/api_patches/src/util/createSessionUtil.ts
+++ b/client/api_patches/src/util/createSessionUtil.ts
@@ -16,6 +16,8 @@
 import { create, SocketState, StatusFind } from '@wppconnect-team/wppconnect';
 import { exec, execFile, execSync } from 'child_process';
 import { Request } from 'express';
+import * as fs from 'fs';
+import * as path from 'path';
 
 import { download } from '../controller/sessionController';
 import { WhatsAppServer } from '../types/WhatsAppServer';
@@ -145,12 +147,29 @@ async function closeBrowserGracefully(
       `[${session}] graceful browser close raised: ${e?.message || e}`
     );
   }
+  // With no process handle there is nothing to observe, and the loop below
+  // would read `alive` as false on its very first pass and report success in
+  // the same millisecond it was called — for a browser it never touched. That
+  // is not a confirmation, it is the absence of one, and the callers treat the
+  // two as opposites: `true` means "the profile is free, go ahead", so a
+  // caller that is about to relaunch skips the kill and walks straight back
+  // into the lock. Measured on 2026-09-10, where it kept an account offline
+  // through every 30s retry for hours. Say so instead; an unconfirmed close
+  // costs the caller a force-kill, which is what it did unconditionally
+  // before this function existed.
+  if (!proc) {
+    logger?.warn?.(
+      `[${session}] no browser process handle to confirm the close against — ` +
+        'treating it as unconfirmed.'
+    );
+    return false;
+  }
   // The call returning is not the process being gone. Poll for the exit so a
   // caller that is about to relaunch against this very profile does not race
   // a Chrome that is still flushing it.
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const alive = proc && proc.exitCode === null && proc.signalCode === null;
+    const alive = proc.exitCode === null && proc.signalCode === null;
     if (!alive) {
       logger?.info?.(`[${session}] browser closed gracefully.`);
       return true;
@@ -238,6 +257,111 @@ function forceKillByUserDataDir(
 }
 
 /**
+ * Chrome files that let a profile reopen the tabs it had last time.
+ *
+ * `Sessions/Session_*` and `Sessions/Tabs_*` are the live records; the four
+ * loose files are the legacy pair plus the copy Chrome promotes on startup.
+ * All of them are caches of window state, never credentials — the WhatsApp
+ * login lives in the profile's IndexedDB and nothing here touches it.
+ */
+const RESTORABLE_SESSION_FILES = [
+  'Last Session',
+  'Last Tabs',
+  'Current Session',
+  'Current Tabs',
+];
+
+/**
+ * Stop this session's Chrome profile from restoring the tabs it had open, and
+ * do it before every launch.
+ *
+ * WPPConnect drives exactly one page. A profile that restores tabs hands it
+ * more, and the extra ones are actively harmful rather than merely untidy:
+ * they are opened by Chrome itself, so they never pass through start.js's
+ * document-only interception (they load whatever build Meta is serving right
+ * now, not the pinned one) and never receive wppconnect's user-agent
+ * override, so WhatsApp answers them with "WhatsApp works with Google Chrome
+ * 100 or newer". They still share the profile's IndexedDB and the single
+ * WAWebBackendWorker with the page that matters, and they are enough to push
+ * it past the 30s `injectApi()` waits for `WAPI && Store && WPP.isReady`.
+ *
+ * Measured live on 2026-09-10, by attaching to the wedged browser: three
+ * web.whatsapp.com tabs, two of them on the unsupported-browser screen with
+ * `HeadlessChrome/148.0.0.0` and no wa-js at all, and one — the puppeteer
+ * page, user-agent `Chrome/102.0.5005.63` — fully logged in with
+ * `WPP.isReady === true`, having got there only *after* injectApi had already
+ * timed out. The session was never logged out; it was starved.
+ *
+ * The loop is self-feeding, which is why it never recovered on its own: the
+ * timeout leaves Chrome alive, the recovery force-kills it, a force-killed
+ * Chrome has no clean exit recorded, and the next launch therefore restores
+ * the tabs of the run before — one more each time.
+ *
+ * Two halves, because either one alone leaves a way back in. The files are
+ * removed, and `exit_type` is set to `Normal` in Preferences, since a profile
+ * whose last exit was not recorded as clean is one Chrome offers to restore
+ * regardless of what is left in Sessions/.
+ *
+ * Best-effort by construction: every failure is swallowed. This runs on the
+ * startup path of every session, and a profile that cannot be tidied is not a
+ * reason to refuse to start one.
+ */
+function clearRestorableSession(profileDir: string, logger?: any): void {
+  if (!profileDir) return;
+  try {
+    const defaultDir = path.join(profileDir, 'Default');
+    const sessionsDir = path.join(defaultDir, 'Sessions');
+    let removed = 0;
+    try {
+      for (const name of fs.readdirSync(sessionsDir)) {
+        if (!/^(Session|Tabs)_/.test(name)) continue;
+        try {
+          fs.unlinkSync(path.join(sessionsDir, name));
+          removed++;
+        } catch (e) {}
+      }
+    } catch (e) {}
+    for (const name of RESTORABLE_SESSION_FILES) {
+      try {
+        fs.unlinkSync(path.join(defaultDir, name));
+        removed++;
+      } catch (e) {}
+    }
+
+    // Merge, never rewrite. Preferences carries far more than the exit
+    // record, and replacing the file would drop settings this profile has
+    // accumulated. An unreadable or unparseable file is left exactly as it
+    // is — the file deletions above already do most of the work.
+    const prefsPath = path.join(defaultDir, 'Preferences');
+    try {
+      const prefs = JSON.parse(fs.readFileSync(prefsPath, 'utf8'));
+      if (prefs && typeof prefs === 'object') {
+        prefs.profile = prefs.profile || {};
+        if (
+          prefs.profile.exit_type !== 'Normal' ||
+          prefs.profile.exited_cleanly !== true
+        ) {
+          prefs.profile.exit_type = 'Normal';
+          prefs.profile.exited_cleanly = true;
+          fs.writeFileSync(prefsPath, JSON.stringify(prefs), 'utf8');
+        }
+      }
+    } catch (e) {}
+
+    if (removed) {
+      logger?.info?.(
+        `[clearRestorableSession] dropped ${removed} restorable-tab file(s) ` +
+          `from ${profileDir}`
+      );
+    }
+  } catch (e: any) {
+    logger?.warn?.(
+      `[clearRestorableSession] could not tidy ${profileDir}: ${e?.message || e}`
+    );
+  }
+}
+
+/**
  * Does this launch failure mean "a Chrome we lost track of still holds the
  * profile"?
  *
@@ -294,10 +418,17 @@ async function launchWithStaleBrowserRecovery(
   launch: () => Promise<any>,
   userDataDir: string,
   session: string,
-  logger?: any
+  logger?: any,
+  profileDir?: string
 ): Promise<any> {
+  // Before every attempt, not just the first: an attempt that got far enough
+  // to start Chrome can write a fresh Sessions/ record on its way down.
+  const attempt = () => {
+    if (profileDir) clearRestorableSession(profileDir, logger);
+    return launch();
+  };
   try {
-    return await launch();
+    return await attempt();
   } catch (error: any) {
     if (!isStaleBrowserLockError(error)) throw error;
     logger?.warn?.(
@@ -309,19 +440,55 @@ async function launchWithStaleBrowserRecovery(
     // reports CLOSED, but a status of CLOSED does not mean the browser went
     // away. When it is reachable, close it properly rather than SIGKILLing a
     // Chrome that is holding this session's login database open.
+    let forceKilled = false;
     if (!(await closeBrowserGracefully(session, logger))) {
       await forceKillByUserDataDir(userDataDir, logger);
+      forceKilled = true;
     }
     await new Promise((resolve) =>
       setTimeout(resolve, STALE_BROWSER_RELEASE_MS)
     );
     try {
-      const client = await launch();
+      const client = await attempt();
       logger?.info?.(
         `[${session}] Recovered from a stale browser profile lock.`
       );
       return client;
     } catch (retryError: any) {
+      // The graceful close reporting success is not evidence that THIS
+      // profile was released — it only ever speaks for the client object in
+      // clientsArray, and the Chrome holding the lock is very often a
+      // different, older process that no client object points at any more.
+      // Measured on 2026-09-10: the close and its "browser closed gracefully"
+      // line landed in the same millisecond as the warning above (nothing was
+      // actually closed — there was no process handle to watch), the kill was
+      // skipped because of it, the retry hit the identical lock, and the
+      // account stayed offline through fifteen accumulated orphan Chromes.
+      // The profile still being locked is the proof, so escalate on it.
+      if (!forceKilled && isStaleBrowserLockError(retryError)) {
+        logger?.warn?.(
+          `[${session}] the graceful close did not free the profile — ` +
+            'killing whatever still holds it.'
+        );
+        await forceKillByUserDataDir(userDataDir, logger);
+        await new Promise((resolve) =>
+          setTimeout(resolve, STALE_BROWSER_RELEASE_MS)
+        );
+        try {
+          const client = await attempt();
+          logger?.info?.(
+            `[${session}] Recovered from a stale browser profile lock after ` +
+              'the fallback kill.'
+          );
+          return client;
+        } catch (finalError: any) {
+          logger?.error?.(
+            `[${session}] Still could not start after killing the profile ` +
+              `holder: ${finalError?.message ?? finalError}`
+          );
+          throw finalError;
+        }
+      }
       logger?.error?.(
         `[${session}] Still could not start after clearing the profile lock: ` +
           `${retryError?.message ?? retryError}`
@@ -906,7 +1073,12 @@ export default class CreateSessionUtil {
         launchWppClient,
         `userDataDir/${session}`,
         session,
-        req.logger
+        req.logger,
+        path.resolve(
+          req.serverOptions.customUserDataDir
+            ? req.serverOptions.customUserDataDir + session
+            : `userDataDir/${session}`
+        )
       );
 
       // Poll every 2s: if shouldClose was set while create() is blocked, close browser immediately

--- a/client/api_patches/start.js
+++ b/client/api_patches/start.js
@@ -298,6 +298,17 @@ const optimizedBrowserArgs = [
   '--use-mock-keychain',
   '--no-pings',
   '--disable-client-side-phishing-detection',
+  // Belt to clearRestorableSession()'s braces (createSessionUtil.ts).
+  // That function removes the saved-tab files and records a clean exit
+  // before every launch; these two stop Chrome from acting on a restore
+  // record that appears anyway — a crash mid-session, or a profile
+  // restored from a snapshot taken elsewhere. WPPConnect drives exactly
+  // one page, and every extra tab a restore reopens loads outside
+  // start.js's document interception and outside wppconnect's user-agent
+  // override, then competes for the same IndexedDB and backend worker
+  // until injectApi() times out.
+  '--hide-crash-restore-bubble',
+  '--disable-session-crashed-bubble',
 ];
 
 // WPPConnect pins the WhatsApp Web version (default '2.3000.10305x') by serving

--- a/client/core/browser_payload.py
+++ b/client/core/browser_payload.py
@@ -1,0 +1,122 @@
+"""Is the bundled Chromium actually complete enough to start?
+
+WinZapp ships its own Chromium under ``api/.cache`` and every check that asks
+"is the API set up?" looks only for the *executable*. That is not the same
+question, and the gap is not theoretical — measured on a real install
+(2026-09-10, WinZapp 1.1.0.2681alpha), where every session start died before a
+browser existed::
+
+    error: [<session>:browser] Failed to launch the browser process:  Code: 2147483651
+    stderr:
+    [0910/103543.323:ERROR:base\\i18n\\icu_util.cc:232] Invalid file descriptor to ICU data received.
+
+``2147483651`` is ``0x80000003`` (STATUS_BREAKPOINT): Chromium aborted during
+startup, before it could report anything of its own. The line above it says
+why — it could not read ``icudtl.dat``, its internationalisation data, which
+Chromium loads before almost anything else and cannot run without. The
+executable was right there, so ``find_headless_shell()`` logged
+``[headless-shell] Already installed: ...`` on every launch and nothing ever
+looked again. An incomplete download, or an antivirus quarantining the file
+(``icudtl.dat`` is a routine false positive), is therefore permanent.
+
+Two things then made it much worse than "WhatsApp will not connect". The
+session never reaching a real state is exactly what ``ProfileHealthTracker``
+counts, so the profile recovery fired for a fault that has nothing to do with
+the profile, spent both snapshot generations on it, and left the account
+unpaired — with no way back, because pairing needs the same browser::
+
+    10:26:07  STARTUP ... paired=True  login_store=files=113 bytes=208775977
+    10:27:39  profile suspect - session started and died 3x without connecting
+    10:27:40  profile restored from snapshot
+    10:30:20  Chrome released the profile before the kill  login_store=absent
+    10:35:41  MainWindow: WhatsApp connection not paired. Showing connection dialog...
+    10:36:14  [display_qrcode_image] No QR reached the screen (no QR within 25s)
+
+So this module answers one narrow question — *can this binary start at all?* —
+and its callers use the answer twice: to refuse to accept a broken install as
+"already installed", and to refuse to let the profile recovery run when the
+browser is what is broken.
+
+**Only ``icudtl.dat`` is required, and the narrowness is the point.** Both
+flavours WinZapp may have on disk ship it (full ``chrome.exe`` and
+``chrome-headless-shell``), it is the file the observed failure names, and
+Chromium genuinely cannot start without it. Adding ``resources.pak`` and
+friends would cover more corruption in theory and risks the far worse bug in
+practice: a file that one flavour does not ship would condemn a perfectly good
+browser, and the caller's response to "incomplete" is to delete it and download
+it again. Rejecting a working install in a loop is worse than missing an exotic
+half-corruption, so when in doubt this module says nothing is wrong.
+
+A zero-length file counts as missing — that is what a quarantine stub looks
+like. A file that is present, non-empty and *truncated* is not detectable here
+without a checksum nobody publishes, so it stays out of scope; the launch
+failure it produces is reported by the log, not by this.
+"""
+
+import os
+
+
+#: Files the browser cannot start without, whichever flavour is installed.
+#: See the module docstring before adding to this — the cost of a false
+#: positive here is a delete-and-redownload loop on a healthy install.
+REQUIRED_BROWSER_FILES = ("icudtl.dat",)
+
+
+def payload_problem(binary_path):
+    """Describe what is missing beside ``binary_path``, or None if it is fine.
+
+    Returns a short human-readable string naming the first problem found, so
+    the caller can put a real reason in the log instead of "something is
+    wrong". An unreadable directory, a missing binary, or any OS error answers
+    None: this is a *disqualifier*, and it must only ever disqualify on
+    evidence. Failing to look is not evidence.
+    """
+    if not binary_path:
+        return None
+    try:
+        if not os.path.isfile(binary_path):
+            return None
+        payload_dir = os.path.dirname(binary_path)
+        for name in REQUIRED_BROWSER_FILES:
+            path = os.path.join(payload_dir, name)
+            if not os.path.isfile(path):
+                return "%s is missing" % name
+            if os.path.getsize(path) <= 0:
+                return "%s is empty" % name
+    except OSError:
+        return None
+    return None
+
+
+def installed_version_dir(binary_path, cache_dir):
+    """The versioned browser directory under ``cache_dir`` holding this binary.
+
+    ``@puppeteer/browsers`` lays the cache out as
+    ``<cache>/chrome/win64-<version>/chrome-win64/chrome.exe``, and re-running
+    its installer does nothing while that version directory exists — so
+    repairing a broken payload means removing the version directory, not just
+    the file that went missing.
+
+    Returns None unless the path really does sit under ``cache_dir``. That
+    containment check is the whole safety of the delete the caller performs
+    with this: nothing outside WinZapp's own browser cache may ever be named
+    here, however odd the inputs get.
+    """
+    if not binary_path or not cache_dir:
+        return None
+    try:
+        cache_root = os.path.realpath(cache_dir)
+        payload_dir = os.path.realpath(os.path.dirname(binary_path))
+        # ValueError on Windows when the two are on different drives, which is
+        # itself the answer: not under the cache.
+        relative = os.path.relpath(payload_dir, cache_root)
+    except (OSError, ValueError):
+        return None
+    if relative.startswith(os.pardir) or os.path.isabs(relative):
+        return None
+    parts = [p for p in relative.split(os.sep) if p not in ("", os.curdir)]
+    if len(parts) < 2:
+        # <cache>/<product> or the cache itself. Neither is a version
+        # directory, and removing either would take more than this install.
+        return None
+    return os.path.join(cache_root, parts[0], parts[1])

--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -1053,5 +1053,6 @@
     "contact_no_number": "This contact card carries no phone number.",
     "search_contact_label": "&Search contact",
     "profile_restored_from_snapshot": "The browser profile was damaged and has been restored from the last saved copy. Reconnecting to WhatsApp.",
-    "profile_corrupted_repair_needed": "The browser profile used to connect to WhatsApp is damaged and there is no saved copy to restore. You will need to disconnect the session and pair again."
+    "profile_corrupted_repair_needed": "The browser profile used to connect to WhatsApp is damaged and there is no saved copy to restore. You will need to disconnect the session and pair again.",
+    "browser_install_broken": "The built-in browser WinZapp uses to connect to WhatsApp is incomplete and cannot start. Open Settings and reinstall the API. If it happens again, add the WinZapp folder to your antivirus exclusions before reinstalling."
 }

--- a/client/languages/es-ES.json
+++ b/client/languages/es-ES.json
@@ -1053,5 +1053,6 @@
     "contact_no_number": "Esta tarjeta de contacto no incluye ningún número de teléfono.",
     "search_contact_label": "&Buscar contacto",
     "profile_restored_from_snapshot": "El perfil del navegador estaba dañado y se ha restaurado desde la última copia guardada. Reconectando a WhatsApp.",
-    "profile_corrupted_repair_needed": "El perfil del navegador que se usa para conectar con WhatsApp está dañado y no hay ninguna copia guardada para restaurar. Tendrás que desconectar la sesión y vincular de nuevo."
+    "profile_corrupted_repair_needed": "El perfil del navegador que se usa para conectar con WhatsApp está dañado y no hay ninguna copia guardada para restaurar. Tendrás que desconectar la sesión y vincular de nuevo.",
+    "browser_install_broken": "El navegador interno que WinZapp usa para conectarse a WhatsApp está incompleto y no puede iniciarse. Ve a Configuración y reinstala la API. Si vuelve a ocurrir, añade la carpeta de WinZapp a las exclusiones de tu antivirus antes de reinstalar."
 }

--- a/client/languages/pl.json
+++ b/client/languages/pl.json
@@ -1053,5 +1053,6 @@
     "contact_no_number": "Ta wizytówka kontaktu nie zawiera numeru telefonu.",
     "search_contact_label": "&Szukaj kontaktu",
     "profile_restored_from_snapshot": "Profil przeglądarki był uszkodzony i został przywrócony z ostatniej zapisanej kopii. Ponowne łączenie z WhatsApp.",
-    "profile_corrupted_repair_needed": "Profil przeglądarki używany do połączenia z WhatsApp jest uszkodzony i nie ma zapisanej kopii do przywrócenia. Trzeba będzie rozłączyć sesję i sparować ponownie."
+    "profile_corrupted_repair_needed": "Profil przeglądarki używany do połączenia z WhatsApp jest uszkodzony i nie ma zapisanej kopii do przywrócenia. Trzeba będzie rozłączyć sesję i sparować ponownie.",
+    "browser_install_broken": "Wbudowana przeglądarka, której WinZapp używa do połączenia z WhatsApp, jest niekompletna i nie może się uruchomić. Otwórz Ustawienia i zainstaluj ponownie API. Jeśli problem wróci, przed ponowną instalacją dodaj folder WinZapp do wyjątków programu antywirusowego."
 }

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -1053,5 +1053,6 @@
     "contact_no_number": "Este cartão de contato não traz nenhum número de telefone.",
     "search_contact_label": "&Buscar contato",
     "profile_restored_from_snapshot": "O perfil do navegador estava danificado e foi restaurado a partir da última cópia salva. Reconectando ao WhatsApp.",
-    "profile_corrupted_repair_needed": "O perfil do navegador usado para conectar ao WhatsApp está danificado e não há cópia salva para restaurar. Será necessário desconectar a sessão e parear novamente."
+    "profile_corrupted_repair_needed": "O perfil do navegador usado para conectar ao WhatsApp está danificado e não há cópia salva para restaurar. Será necessário desconectar a sessão e parear novamente.",
+    "browser_install_broken": "O navegador interno que o WinZapp usa para conectar ao WhatsApp está incompleto e não consegue iniciar. Vá em Configurações e reinstale a API. Se o problema voltar, adicione a pasta do WinZapp às exceções do seu antivírus antes de reinstalar."
 }

--- a/client/languages/pt-PT.json
+++ b/client/languages/pt-PT.json
@@ -1053,5 +1053,6 @@
     "contact_no_number": "Este cartão de contacto não traz nenhum número de telefone.",
     "search_contact_label": "&Procurar contacto",
     "profile_restored_from_snapshot": "O perfil do navegador estava danificado e foi restaurado a partir da última cópia guardada. A reconectar ao WhatsApp.",
-    "profile_corrupted_repair_needed": "O perfil do navegador usado para ligar ao WhatsApp está danificado e não existe cópia guardada para restaurar. Será necessário desligar a sessão e emparelhar novamente."
+    "profile_corrupted_repair_needed": "O perfil do navegador usado para ligar ao WhatsApp está danificado e não existe cópia guardada para restaurar. Será necessário desligar a sessão e emparelhar novamente.",
+    "browser_install_broken": "O navegador interno que o WinZapp usa para ligar ao WhatsApp está incompleto e não consegue iniciar. Vá a Definições e reinstale a API. Se o problema voltar, adicione a pasta do WinZapp às exceções do seu antivírus antes de reinstalar."
 }

--- a/client/main.py
+++ b/client/main.py
@@ -65,6 +65,7 @@ from core.wpp_runtime import (
 from core.utils import reaction_targets_status, encrypt, decrypt, encrypt_json, decrypt_json, generate_and_save_key, retrieve_key, format_number, is_phone_like, looks_like_binary_blob, prune_message_record, prune_chats_messages, effective_unread_count, mute_response_accepted, normalize_for_search, search_normalization_mode, parse_bool_flag as _parse_bool_flag, group_setting_notif_value, DEFAULT_SETTINGS, append_selected_marker, is_message_forwarded, plan_row_updates, display_page_fetch_limit, carry_over_video_durations, video_seconds, MEASURED_SECONDS_KEY, is_voice_message, backfill_missing_defaults, auto_download_allows, migrate_voice_messages_media_types, migrate_voice_message_mode_default, migrate_spell_check_mode
 from core.locale_format import get_date_format, get_time_format, get_datetime_format
 from core.quiet_hours import is_quiet_hours_active
+from core import browser_payload
 from core.database_bridge import DatabaseBridge
 from core import token_vault
 from app_paths import resource_path, data_path, accounts_root
@@ -7354,7 +7355,21 @@ class MainWindow(wx.Frame):
     _WINDOWS_CHROME_NAMES = ("chrome.exe",)
 
     def find_headless_shell(self):
-        """Path to chrome-headless-shell inside client/api/.cache, or None."""
+        """Path to a *usable* browser inside client/api/.cache, or None.
+
+        Usable, not merely present. This used to return the first matching
+        executable it walked past, and that is the check every "is the API set
+        up?" path relies on — so an install whose payload is incomplete was
+        accepted forever. Measured on 2026-09-10: a Chromium missing
+        `icudtl.dat` aborted with STATUS_BREAKPOINT before it could report
+        anything, on every session start, while this logged "Already
+        installed" on every launch. See core/browser_payload.py for what is
+        checked and why the check is deliberately narrow.
+
+        A binary that fails the check is skipped rather than returned, so the
+        walk keeps looking: a cache holding both a broken version directory
+        and a good one still starts.
+        """
         cache_dir = resource_path("api", ".cache")
         if not os.path.isdir(cache_dir):
             return None
@@ -7365,9 +7380,48 @@ class MainWindow(wx.Frame):
         )
         for root, _dirs, files in os.walk(cache_dir):
             for name in files:
-                if name in preferred_names:
-                    return os.path.join(root, name)
+                if name not in preferred_names:
+                    continue
+                candidate = os.path.join(root, name)
+                problem = browser_payload.payload_problem(candidate)
+                if problem:
+                    logging.warning(
+                        "[headless-shell] ignoring an incomplete browser at %s "
+                        "(%s) — it cannot start, so it does not count as "
+                        "installed.", candidate, problem,
+                    )
+                    continue
+                return candidate
         return None
+
+    def find_incomplete_browser(self):
+        """The first browser in the cache that exists but cannot start.
+
+        Kept apart from find_headless_shell() because the two answer opposite
+        questions and one caller needs both: "have I got a browser?" and "is
+        the reason I have not got one that a broken one is sitting in its
+        place?". Returns (binary_path, problem) or (None, None).
+        """
+        cache_dir = resource_path("api", ".cache")
+        if not os.path.isdir(cache_dir):
+            return None, None
+        preferred_names = (
+            self._WINDOWS_CHROME_NAMES
+            if sys.platform == "win32"
+            else self._HEADLESS_SHELL_NAMES
+        )
+        try:
+            for root, _dirs, files in os.walk(cache_dir):
+                for name in files:
+                    if name not in preferred_names:
+                        continue
+                    candidate = os.path.join(root, name)
+                    problem = browser_payload.payload_problem(candidate)
+                    if problem:
+                        return candidate, problem
+        except OSError:
+            pass
+        return None, None
 
     def ensure_headless_shell_installed(self) -> bool:
         """Download chrome-headless-shell if client/api/.cache has none.
@@ -7394,6 +7448,38 @@ class MainWindow(wx.Frame):
         if existing:
             logging.info("[headless-shell] Already installed: %s", existing)
             return True
+
+        # Nothing usable — but "nothing usable" and "nothing there" are
+        # different, and the difference decides whether the download below can
+        # help at all. @puppeteer/browsers skips its install outright while the
+        # version directory exists, so a payload that is present and broken
+        # would survive every retry for the life of the install. Take it out
+        # of the way first, and say so: this is the one line that tells a user
+        # (or a log) that the browser, not WhatsApp, is what is wrong.
+        broken, problem = self.find_incomplete_browser()
+        if broken:
+            version_dir = browser_payload.installed_version_dir(
+                broken, resource_path("api", ".cache")
+            )
+            logging.error(
+                "[headless-shell] the installed browser cannot start (%s): %s",
+                problem, broken,
+            )
+            if version_dir and os.path.isdir(version_dir):
+                try:
+                    shutil.rmtree(version_dir)
+                    logging.warning(
+                        "[headless-shell] removed the incomplete browser at %s "
+                        "so it can be downloaded again.", version_dir,
+                    )
+                except OSError as exc:
+                    # Antivirus holding the file open is one of the ways it got
+                    # here in the first place. Log and let the download try
+                    # anyway; a failure there is already handled below.
+                    logging.error(
+                        "[headless-shell] could not remove %s: %s",
+                        version_dir, exc,
+                    )
 
         browser_product = "chrome" if sys.platform == "win32" else "chrome-headless-shell"
         logging.info(
@@ -9189,6 +9275,34 @@ class MainWindow(wx.Frame):
         """
         if getattr(self, "_profile_recovery_attempted", False):
             return False
+
+        # A browser that cannot start is not a profile that cannot connect,
+        # and the tracker that calls this cannot tell them apart: it counts
+        # sessions that died without connecting, which is exactly what a
+        # failed Chrome launch produces. Checked BEFORE the once-per-launch
+        # latch is taken, so a launch spent refusing here still has its one
+        # real recovery left for the fault this exists to fix.
+        #
+        # The cost of getting it wrong is not a wasted restore, it is the
+        # account. Measured on 2026-09-10 on an install whose Chromium was
+        # missing icudtl.dat: the recovery fired, spent both snapshot
+        # generations on a profile that was never at fault, and left the user
+        # unpaired — then unable to pair, because the QR needs the same
+        # browser that will not start. Restoring a snapshot cannot put an
+        # `icudtl.dat` back.
+        broken, problem = self.find_incomplete_browser()
+        if broken:
+            logging.error(
+                "[profile-recovery] refusing to restore: the browser itself "
+                "cannot start (%s: %s). The profile is not the fault here.",
+                problem, broken,
+            )
+            self._shutdown_audit(
+                "profile recovery refused — browser payload incomplete (%s)" % problem
+            )
+            wx.CallAfter(self._announce_browser_beyond_repair)
+            return False
+
         self._profile_recovery_attempted = True
 
         session_name = (getattr(self, "token", "") or "").split(":")[0]
@@ -9387,6 +9501,31 @@ class MainWindow(wx.Frame):
             self.output(self.i18n.t("profile_restored_from_snapshot"), interrupt=False)
         except Exception:
             logging.exception("[profile-recovery] announcement failed")
+
+    def _announce_browser_beyond_repair(self):
+        """The browser WinZapp bundles cannot start, so nothing else can work.
+
+        Spoken as well as shown, with the error sound, for the same reason as
+        _announce_profile_beyond_repair(): this only ever happens while already
+        offline, where _set_wa_connected(False, ...) has hit its no-change early
+        return and said nothing at all. A blind user has no way to discover any
+        of this from silence — and here silence is worse than usual, because the
+        thing that looks broken (WhatsApp) is not the thing that is.
+        """
+        try:
+            self.error_sound.play()
+        except Exception:
+            pass
+        try:
+            self.output(self.i18n.t("browser_install_broken"), interrupt=False)
+            if not getattr(self, "background_mode", False):
+                wx.MessageBox(
+                    self.i18n.t("browser_install_broken"),
+                    self.i18n.t("error").format(app_name=self.app_name),
+                    wx.OK | wx.ICON_ERROR,
+                )
+        except Exception:
+            logging.exception("[browser-payload] announcement failed")
 
     def _announce_profile_beyond_repair(self):
         """The dead end: the profile is unusable and there is no restore point.

--- a/client/main.py
+++ b/client/main.py
@@ -7394,17 +7394,21 @@ class MainWindow(wx.Frame):
                 return candidate
         return None
 
-    def find_incomplete_browser(self):
-        """The first browser in the cache that exists but cannot start.
+    def iter_incomplete_browsers(self):
+        """Every browser in the cache that exists but cannot start.
 
         Kept apart from find_headless_shell() because the two answer opposite
         questions and one caller needs both: "have I got a browser?" and "is
         the reason I have not got one that a broken one is sitting in its
-        place?". Returns (binary_path, problem) or (None, None).
+        place?". Yields (binary_path, problem).
+
+        All of them, not the first: nothing ever removes an old version
+        directory, so a cache can hold several, and repairing only one leaves
+        the next launch doing this again.
         """
         cache_dir = resource_path("api", ".cache")
         if not os.path.isdir(cache_dir):
-            return None, None
+            return
         preferred_names = (
             self._WINDOWS_CHROME_NAMES
             if sys.platform == "win32"
@@ -7418,10 +7422,83 @@ class MainWindow(wx.Frame):
                     candidate = os.path.join(root, name)
                     problem = browser_payload.payload_problem(candidate)
                     if problem:
-                        return candidate, problem
+                        yield candidate, problem
         except OSError:
-            pass
+            return
+
+    def find_incomplete_browser(self):
+        """The first browser in the cache that exists but cannot start, or
+        (None, None). A convenience over iter_incomplete_browsers()."""
+        for candidate in self.iter_incomplete_browsers():
+            return candidate
         return None, None
+
+    def browser_payload_blocks_startup(self):
+        """Is a broken browser the reason nothing can start?
+
+        Not the same question as "is there a broken browser". A cache holding
+        a damaged version directory AND a working one starts perfectly well —
+        find_headless_shell() skips the damaged one and keeps walking, and it
+        is reachable straight out of this class's own repair path: a delete
+        that antivirus blocks leaves the old directory behind while puppeteer
+        installs a fresh, complete one beside it.
+
+        Answering "yes, broken" there would be wrong in an expensive way. The
+        one caller that reads this refuses to recover the WhatsApp profile on
+        it, so a healthy install would silently lose profile recovery for the
+        rest of its life over a directory nothing is using.
+
+        Returns (binary_path, problem), or (None, None) when a usable browser
+        exists or nothing is wrong.
+        """
+        if self.find_headless_shell():
+            return None, None
+        return self.find_incomplete_browser()
+
+    @staticmethod
+    def _clear_broken_browser_dir(version_dir: str) -> bool:
+        """Get an unusable browser out of @puppeteer/browsers' way.
+
+        Deleting is the intent; getting the directory out of the *path* is the
+        requirement, and those come apart exactly when it matters. A plain
+        rmtree() stops at the first entry it cannot remove — and the reason it
+        cannot is usually the same antivirus that damaged the payload, still
+        holding a handle. That leaves the tree half-deleted AND the version
+        directory still present, which is precisely the condition this exists
+        to break: the installer skips its download outright while that
+        directory exists, so the install ends up emptier than it started and
+        stays that way for good, one file per launch.
+
+        So: sweep what will go, and if anything survives, rename the directory
+        aside. Windows renames a directory holding a locked .exe where it
+        refuses to delete it, so the rename succeeds in the very case the
+        delete fails. Same idea as `<profile>.broken` in profile_recovery.py —
+        keep the evidence, free the name.
+
+        Never raises: this runs on the startup path, and a browser that cannot
+        be tidied is still a reason to try the download, not to give up.
+        """
+        try:
+            if not os.path.isdir(version_dir):
+                return True
+            shutil.rmtree(version_dir, ignore_errors=True)
+            if not os.path.isdir(version_dir):
+                return True
+            aside = "%s.broken.%d" % (version_dir, os.getpid())
+            shutil.rmtree(aside, ignore_errors=True)
+            os.replace(version_dir, aside)
+            logging.warning(
+                "[headless-shell] %s could not be deleted (something is holding "
+                "it open) — moved to %s so the download is not skipped.",
+                version_dir, aside,
+            )
+            return True
+        except OSError as exc:
+            logging.error(
+                "[headless-shell] could not clear %s: %s — the download below "
+                "will probably be skipped.", version_dir, exc,
+            )
+            return False
 
     def ensure_headless_shell_installed(self) -> bool:
         """Download chrome-headless-shell if client/api/.cache has none.
@@ -7456,30 +7533,19 @@ class MainWindow(wx.Frame):
         # would survive every retry for the life of the install. Take it out
         # of the way first, and say so: this is the one line that tells a user
         # (or a log) that the browser, not WhatsApp, is what is wrong.
-        broken, problem = self.find_incomplete_browser()
-        if broken:
-            version_dir = browser_payload.installed_version_dir(
-                broken, resource_path("api", ".cache")
-            )
+        cache_dir = resource_path("api", ".cache")
+        cleared = set()
+        for broken, problem in self.iter_incomplete_browsers():
+            version_dir = browser_payload.installed_version_dir(broken, cache_dir)
+            if not version_dir or version_dir in cleared:
+                continue
+            cleared.add(version_dir)
             logging.error(
-                "[headless-shell] the installed browser cannot start (%s): %s",
-                problem, broken,
+                "[headless-shell] the installed browser cannot start (%s): %s "
+                "— clearing %s so it can be downloaded again.",
+                problem, broken, version_dir,
             )
-            if version_dir and os.path.isdir(version_dir):
-                try:
-                    shutil.rmtree(version_dir)
-                    logging.warning(
-                        "[headless-shell] removed the incomplete browser at %s "
-                        "so it can be downloaded again.", version_dir,
-                    )
-                except OSError as exc:
-                    # Antivirus holding the file open is one of the ways it got
-                    # here in the first place. Log and let the download try
-                    # anyway; a failure there is already handled below.
-                    logging.error(
-                        "[headless-shell] could not remove %s: %s",
-                        version_dir, exc,
-                    )
+            self._clear_broken_browser_dir(version_dir)
 
         browser_product = "chrome" if sys.platform == "win32" else "chrome-headless-shell"
         logging.info(
@@ -9290,7 +9356,7 @@ class MainWindow(wx.Frame):
         # unpaired — then unable to pair, because the QR needs the same
         # browser that will not start. Restoring a snapshot cannot put an
         # `icudtl.dat` back.
-        broken, problem = self.find_incomplete_browser()
+        broken, problem = self.browser_payload_blocks_startup()
         if broken:
             logging.error(
                 "[profile-recovery] refusing to restore: the browser itself "
@@ -9505,6 +9571,14 @@ class MainWindow(wx.Frame):
     def _announce_browser_beyond_repair(self):
         """The browser WinZapp bundles cannot start, so nothing else can work.
 
+        Once per launch. Its sibling below is bounded by the once-per-launch
+        recovery latch; this one deliberately fires BEFORE that latch is taken
+        (a launch spent refusing must keep its real recovery), so nothing else
+        bounds it. Both triggers behind it reset within a session — the QR
+        route clears its own dialog latch, and ProfileHealthTracker.reset()
+        re-arms the count — so a second flood would otherwise replay the error
+        sound and a modal box over a user who has already been told.
+
         Spoken as well as shown, with the error sound, for the same reason as
         _announce_profile_beyond_repair(): this only ever happens while already
         offline, where _set_wa_connected(False, ...) has hit its no-change early
@@ -9512,6 +9586,10 @@ class MainWindow(wx.Frame):
         of this from silence — and here silence is worse than usual, because the
         thing that looks broken (WhatsApp) is not the thing that is.
         """
+        if getattr(self, "_browser_payload_announced", False):
+            logging.info("[browser-payload] already announced this launch")
+            return
+        self._browser_payload_announced = True
         try:
             self.error_sound.play()
         except Exception:

--- a/tests/load/test_large_account_database_load.py
+++ b/tests/load/test_large_account_database_load.py
@@ -1,0 +1,278 @@
+"""Synthetic load tests for the storage layer of a large, freshly-synced account.
+
+Run from the repository root::
+
+    python -m pytest -s -q tests/load/test_large_account_database_load.py
+
+``WINZAPP_LOAD_CHAT_COUNT`` and ``WINZAPP_LOAD_MESSAGES_PER_CHAT`` set the
+scenario (default 1,200 chats x 40 messages = 48,000 messages, which is what a
+busy account looks like after an initial sync).
+
+Why this is the layer worth loading. ``core/database.py`` is a **single
+serialized aiosqlite connection** behind a per-write ``asyncio.Lock``, and
+every payload column (``message_json``, ``last_message_json``) is
+Fernet-encrypted with the per-install key. So each stored message costs a
+Fernet token, and every write in the account queues behind one lock. On top of
+that sits ``DatabaseBridge``, whose every call blocks the calling wx/worker
+thread on ``run_coroutine_threadsafe(...).result(timeout=...)`` — which is why
+a slow storage layer does not show up as "sync is slow", it shows up as
+"WinZapp stopped responding", historically the most-reported symptom.
+
+What is asserted is therefore not a wall-clock budget (CI and developer
+machines differ far too much for that) but the two things that actually break
+at size:
+
+  * **cost stays proportional to the data** — an accidental O(n^2), a per-chat
+    full-table scan, or a re-read of every message to store one, is invisible
+    on the two-row fixtures the rest of the suite uses and fatal at 48,000;
+  * **nothing is silently lost** — batching, encryption and the id-less-message
+    guard must round-trip the whole account, not most of it.
+
+Both are measured against the real ``DatabaseManager`` on a real on-disk SQLite
+file, not ``:memory:``: WAL, the write lock and fsync behaviour are the parts
+under test, and an in-memory database does not have them.
+"""
+
+import os
+import time
+
+import pytest
+from cryptography.fernet import Fernet
+
+
+pytestmark = pytest.mark.load
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    value = int(os.environ.get(name, default))
+    if value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+CHAT_COUNT = _positive_int_env("WINZAPP_LOAD_CHAT_COUNT", 1_200)
+PER_CHAT = _positive_int_env("WINZAPP_LOAD_MESSAGES_PER_CHAT", 40)
+
+
+def _jid(index: int) -> str:
+    return f"5511{index:09d}@s.whatsapp.net"
+
+
+def _message(jid: str, index: int) -> dict:
+    """A message in the canonical shape websocket_client.py normalises to."""
+    return {
+        "key": {"remoteJid": jid, "fromMe": index % 3 == 0, "id": f"{jid}-m{index}"},
+        "message": {"conversation": f"mensagem {index} " + "x" * 120},
+        "messageType": "conversation",
+        "messageTimestamp": 1_700_000_000 + index,
+        "pushName": "Contato",
+    }
+
+
+def _chat(jid: str, newest: dict) -> dict:
+    return {
+        "remoteJid": jid,
+        "t": newest["messageTimestamp"],
+        "unreadCount": 0,
+        "lastMessage": newest,
+    }
+
+
+@pytest.fixture
+async def disk_db(tmp_path):
+    """A real on-disk DatabaseManager. WAL and the write lock are the subject
+    here, and :memory: has neither."""
+    from core.database import DatabaseManager
+
+    async with DatabaseManager(str(tmp_path / "messages.db"), Fernet.generate_key()) as db:
+        yield db
+
+
+async def _populate(db, chat_count, per_chat):
+    """Store the account the way an initial sync does: messages in per-chat
+    batches, chats in one bulk upsert."""
+    chats = {}
+    for index in range(chat_count):
+        jid = _jid(index)
+        messages = [_message(jid, n) for n in range(per_chat)]
+        await db.insert_messages_batch(jid, messages)
+        chats[jid] = _chat(jid, messages[-1])
+    await db.upsert_chats_batch(chats)
+    return chats
+
+
+class TestTheWholeAccountRoundTrips:
+    async def test_every_message_of_every_chat_survives_storage(self, disk_db):
+        """Batching, Fernet and the id-less-message guard, over the whole
+        account rather than one row. A batch that silently drops part of itself
+        looks exactly like a short conversation to every caller above."""
+        started = time.perf_counter()
+        await _populate(disk_db, CHAT_COUNT, PER_CHAT)
+        write_elapsed = time.perf_counter() - started
+
+        total = CHAT_COUNT * PER_CHAT
+        print(
+            f"\n[load] stored {total} messages across {CHAT_COUNT} chats in "
+            f"{write_elapsed:.2f}s ({total / max(write_elapsed, 1e-6):.0f} msg/s)"
+        )
+
+        jids = await disk_db.get_chat_jids()
+        assert len(jids) == CHAT_COUNT
+
+        # Spot-check across the range rather than all of them: a per-chat count
+        # is a query each, and the failure modes here are systematic, not
+        # sporadic.
+        for index in (0, CHAT_COUNT // 2, CHAT_COUNT - 1):
+            assert await disk_db.get_message_count(_jid(index)) == PER_CHAT
+
+    async def test_the_encrypted_payload_comes_back_intact(self, disk_db):
+        """Fernet is applied per payload. A key/encoding mistake shows up as a
+        message that stores fine and reads back as junk — which the UI renders
+        as an empty row, not as an error."""
+        await _populate(disk_db, min(CHAT_COUNT, 50), PER_CHAT)
+        jid = _jid(7)
+        messages = await disk_db.get_messages(jid, limit=PER_CHAT)
+        assert len(messages) == PER_CHAT
+        bodies = {m["message"]["conversation"] for m in messages}
+        assert f"mensagem 0 " + "x" * 120 in bodies
+        assert all(m["key"]["remoteJid"] == jid for m in messages)
+
+
+class TestCostStaysProportionalToTheData:
+    """The assertions are ratios, not seconds. A machine four times slower
+    fails nothing; a query that got quadratic fails everywhere."""
+
+    async def test_loading_the_chat_list_scales_with_the_chat_count(self, disk_db):
+        """get_chats() is on the blocking startup path — prepare_sync() waits
+        for it before the window is shown, through DatabaseBridge, which blocks
+        the calling thread on a timeout.
+
+        Note what it costs per chat, because the signature hides it: `limit`
+        here is the MESSAGE page size, and every chat pays
+        _build_message_wrapper() — one COUNT query, one SELECT, and a Fernet
+        decrypt per record returned. The growth is linear but the constant is
+        large, and the constant is what gets multiplied by the account.
+        """
+        await _populate(disk_db, CHAT_COUNT, PER_CHAT)
+
+        await disk_db.get_chats()  # warm the page cache
+        started = time.perf_counter()
+        chats = await disk_db.get_chats()
+        elapsed = time.perf_counter() - started
+
+        assert len(chats) == CHAT_COUNT
+        assert all(
+            chat["messages"]["messages"]["total"] == PER_CHAT
+            for chat in list(chats.values())[:5]
+        )
+        print(
+            f"\n[load] get_chats() over {CHAT_COUNT} chats x {PER_CHAT} msgs: "
+            f"{elapsed:.3f}s ({elapsed / CHAT_COUNT * 1000:.2f} ms/chat)"
+        )
+
+    async def test_the_chat_list_cost_is_linear_in_the_chat_count(self, disk_db):
+        """Linear is the requirement; the constant is separately large (see
+        above). A regression that made this quadratic would be invisible on the
+        handful of chats the rest of the suite uses and would push a real
+        account past DatabaseBridge's timeout — which reaches the user as
+        "WinZapp stopped responding", not as a slow query.
+        """
+        quarter = max(2, CHAT_COUNT // 4)
+        await _populate(disk_db, quarter, PER_CHAT)
+        await disk_db.get_chats()
+        started = time.perf_counter()
+        await disk_db.get_chats()
+        small_elapsed = max(time.perf_counter() - started, 1e-6)
+
+        for index in range(quarter, CHAT_COUNT):
+            jid = _jid(index)
+            messages = [_message(jid, n) for n in range(PER_CHAT)]
+            await disk_db.insert_messages_batch(jid, messages)
+            await disk_db.upsert_chat(jid, _chat(jid, messages[-1]))
+
+        await disk_db.get_chats()
+        started = time.perf_counter()
+        chats = await disk_db.get_chats()
+        large_elapsed = time.perf_counter() - started
+
+        assert len(chats) == CHAT_COUNT
+        ratio = large_elapsed / small_elapsed
+        print(
+            f"\n[load] get_chats() — {quarter} chats: {small_elapsed:.3f}s | "
+            f"{CHAT_COUNT} chats: {large_elapsed:.3f}s | ratio {ratio:.1f}x "
+            f"(4x the chats)"
+        )
+        assert ratio < 10, (
+            f"the chat list scaled {ratio:.1f}x for 4x the chats — not linear"
+        )
+
+    async def test_storing_four_times_the_messages_costs_about_four_times(
+        self, disk_db
+    ):
+        """The shape that would fail this: re-reading a chat's stored messages
+        to insert one more (_with_known_video_duration is called per message
+        and does touch the table), or a per-batch full scan."""
+        jid_small, jid_large = _jid(90_001), _jid(90_002)
+        small_batch = [_message(jid_small, n) for n in range(PER_CHAT)]
+        large_batch = [_message(jid_large, n) for n in range(PER_CHAT * 4)]
+
+        # Warm-up so neither measurement pays for connection setup.
+        await disk_db.insert_messages_batch(_jid(90_000), small_batch)
+
+        started = time.perf_counter()
+        await disk_db.insert_messages_batch(jid_small, small_batch)
+        small_elapsed = max(time.perf_counter() - started, 1e-6)
+
+        started = time.perf_counter()
+        await disk_db.insert_messages_batch(jid_large, large_batch)
+        large_elapsed = time.perf_counter() - started
+
+        ratio = large_elapsed / small_elapsed
+        print(
+            f"\n[load] insert {PER_CHAT} msgs: {small_elapsed:.4f}s | "
+            f"{PER_CHAT * 4} msgs: {large_elapsed:.4f}s | ratio {ratio:.1f}x"
+        )
+        assert await disk_db.get_message_count(jid_large) == PER_CHAT * 4
+        # Linear is 4x. The ceiling absorbs timer noise on a loaded machine
+        # while still failing a quadratic, which lands near 16x.
+        assert ratio < 12, (
+            f"storing 4x the messages cost {ratio:.1f}x — that is not linear"
+        )
+
+    async def test_reading_one_conversation_does_not_scale_with_the_account(
+        self, disk_db
+    ):
+        """Opening a chat must cost the same on a 20-chat account and a
+        1,200-chat one — this is the query behind every conversation the user
+        opens, and `remote_jid`/`timestamp` are indexed precisely for it."""
+        await _populate(disk_db, min(CHAT_COUNT, 20), PER_CHAT)
+        await disk_db.get_messages(_jid(1), limit=PER_CHAT)
+        started = time.perf_counter()
+        await disk_db.get_messages(_jid(1), limit=PER_CHAT)
+        small_elapsed = max(time.perf_counter() - started, 1e-6)
+
+        # Grow the account around that same conversation.
+        for index in range(20, CHAT_COUNT):
+            jid = _jid(index)
+            await disk_db.insert_messages_batch(
+                jid, [_message(jid, n) for n in range(PER_CHAT)]
+            )
+
+        await disk_db.get_messages(_jid(1), limit=PER_CHAT)
+        started = time.perf_counter()
+        messages = await disk_db.get_messages(_jid(1), limit=PER_CHAT)
+        large_elapsed = time.perf_counter() - started
+
+        assert len(messages) == PER_CHAT
+        ratio = large_elapsed / small_elapsed
+        print(
+            f"\n[load] open one chat — 20 chats: {small_elapsed:.4f}s | "
+            f"{CHAT_COUNT} chats: {large_elapsed:.4f}s | ratio {ratio:.1f}x"
+        )
+        # An index lookup should be flat. Generous, because these are
+        # sub-millisecond numbers where timer noise dominates; a full table
+        # scan over 60x the rows would not fit under this.
+        assert ratio < 12, (
+            f"opening one chat got {ratio:.1f}x slower as the account grew — "
+            "that reads like a table scan, not an index lookup"
+        )

--- a/tests/load/test_large_account_sync_load.py
+++ b/tests/load/test_large_account_sync_load.py
@@ -1,0 +1,308 @@
+"""Synthetic load tests for a freshly-connected account with many chats.
+
+Run from the repository root::
+
+    python -m pytest -s -q tests/load/test_large_account_sync_load.py
+
+``WINZAPP_LOAD_CHAT_COUNT`` sets the scenario size (default 2,000 chats, which
+is comfortably past the ~1,000 a busy real account carries).
+
+What is being looked for here is not speed. It is the class of bug that only
+appears at size, which in this codebase has always been the same shape: **a
+cost, a failure list or a phone-notification budget that grows with the number
+of chats when it must not.** Each of the three below is a claim CLAUDE.md makes
+in prose and nothing enforced:
+
+  * the staleness net costs "a fixed amount per round however large the account
+    grows" (issue #181);
+  * a chat the server answers definitively — an empty delta, or a chat that no
+    longer exists — is not an I/O failure, and one of them must never hold the
+    whole account in "not synced" (which stops the list-chats snapshot being
+    committed for *every* chat, and makes the health checker announce a resync
+    out loud on every cooldown);
+  * the per-pass phone-history budget is one request, no matter how many chats
+    are queued behind it, because each one puts a sync notification on the
+    user's phone (issue #108).
+
+Fixed time thresholds are deliberately avoided — CI and developer machines have
+very different performance profiles — so the timing assertions are *relative*:
+double the account, and the work must not more than double. That catches an
+accidental O(n²) without pinning a number that will flake.
+
+MainWindow is a wx.Frame and cannot be instantiated, so the methods under test
+are bound to plain stubs, exactly as tests/test_repair_state_durability.py and
+tests/test_periodic_poll_delta.py do.
+"""
+
+import os
+import threading
+import time
+
+import pytest
+
+from main import MainWindow
+from tests.conftest import warm_cached_chat
+
+
+pytestmark = pytest.mark.load
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    value = int(os.environ.get(name, default))
+    if value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+CHAT_COUNT = _positive_int_env("WINZAPP_LOAD_CHAT_COUNT", 2_000)
+
+
+def _jid(index: int) -> str:
+    return f"5511{index:09d}@s.whatsapp.net"
+
+
+class _PlanStub:
+    """The surface _plan_message_sync() actually reads on a warm account."""
+
+    _canonical_backfill_jid = MainWindow._canonical_backfill_jid
+    _backfill_state_guard = MainWindow._backfill_state_guard
+    _normalize_jid = staticmethod(MainWindow._normalize_jid)
+    _server_claims_content = staticmethod(MainWindow._server_claims_content)
+    _jid_address_forms = MainWindow._jid_address_forms
+    _baseline_marker_for_jid = MainWindow._baseline_marker_for_jid
+    _capture_chat_sync_baseline = MainWindow._capture_chat_sync_baseline
+    _plan_message_sync = MainWindow._plan_message_sync
+
+    def __init__(self, chat_count: int, verified_now: bool = True):
+        now = int(time.time())
+        self.chats = {_jid(i): warm_cached_chat(_jid(i)) for i in range(chat_count)}
+        # A warm, already-synced account: nothing has changed since the last
+        # round, so every chat classifies as "skip" and the only thing that can
+        # add work is the staleness net.
+        self._chat_verified_at = (
+            {j: now for j in self.chats} if verified_now else {}
+        )
+        self._backfill_state_lock = threading.RLock()
+        self._chats_awaiting_messages = set()
+        self._partial_history_counts = {}
+        self._history_gap_jids = set()
+        self._message_retry_jids = set()
+        self._lid_to_phone = {}
+        self._phone_to_lid = {}
+
+    def baseline(self) -> dict:
+        """The real marker snapshot, not a copy of self.chats.
+
+        _plan_message_sync() diffs markers (`t`, record count, lastReceivedKey),
+        not chat dicts — handing it raw chats makes every chat classify as
+        changed, which passes for the wrong reason and measures the wrong path.
+        """
+        return self._capture_chat_sync_baseline()
+
+
+class TestTheStalenessNetCostsTheSameAtAnySize:
+    """`select_stale_rechecks()` promotes the chats that have gone longest
+    without a real get-messages, `_STALE_RECHECK_PER_ROUND` of them per plan.
+    The cap is the whole point: without it, an account that has been idle long
+    enough re-fetches *every* chat on one round, which on 2,000 conversations
+    is the full sync the incremental round exists to avoid.
+    """
+
+    def test_a_wholly_stale_account_still_plans_only_the_cap(self):
+        """Every chat unverified — the state after a restart, since the
+        verified-at map starts empty until it is loaded."""
+        stub = _PlanStub(CHAT_COUNT, verified_now=False)
+        baseline = stub.baseline()
+
+        started = time.perf_counter()
+        full, incremental, skipped, reasons = stub._plan_message_sync(baseline)
+        elapsed = time.perf_counter() - started
+
+        promoted = [j for j, r in reasons.items() if r == "stale-recheck"]
+        assert len(promoted) == MainWindow._STALE_RECHECK_PER_ROUND
+        assert len(incremental) == MainWindow._STALE_RECHECK_PER_ROUND
+        assert not full
+        assert skipped == CHAT_COUNT - MainWindow._STALE_RECHECK_PER_ROUND
+        print(
+            f"\n[load] plan over {CHAT_COUNT} wholly-stale chats: "
+            f"{elapsed:.3f}s, {len(incremental)} promoted"
+        )
+
+    def test_a_warm_account_plans_no_work_at_all(self):
+        stub = _PlanStub(CHAT_COUNT, verified_now=True)
+        full, incremental, skipped, _reasons = stub._plan_message_sync(stub.baseline())
+        assert not full and not incremental
+        assert skipped == CHAT_COUNT
+
+    def test_planning_cost_grows_no_faster_than_the_account(self):
+        """An accidental O(n^2) — a nested scan over self.chats, a per-chat
+        rebuild of the verified-at map — is invisible on the 2-chat fixtures
+        the other tests use and quietly fatal at 2,000. Relative, not
+        absolute: CI machines are not developer machines.
+        """
+        small = _PlanStub(CHAT_COUNT // 4, verified_now=False)
+        large = _PlanStub(CHAT_COUNT, verified_now=False)
+        small_baseline, large_baseline = small.baseline(), large.baseline()
+
+        # One warm-up each: first call pays for lazily-built module state.
+        small._plan_message_sync(small_baseline)
+        large._plan_message_sync(large_baseline)
+
+        started = time.perf_counter()
+        small._plan_message_sync(small_baseline)
+        small_elapsed = max(time.perf_counter() - started, 1e-6)
+
+        started = time.perf_counter()
+        large._plan_message_sync(large_baseline)
+        large_elapsed = time.perf_counter() - started
+
+        ratio = large_elapsed / small_elapsed
+        print(
+            f"\n[load] plan {CHAT_COUNT // 4} chats: {small_elapsed:.4f}s | "
+            f"{CHAT_COUNT} chats: {large_elapsed:.4f}s | ratio {ratio:.1f}x "
+            f"(4x the chats)"
+        )
+        # Four times the chats. Linear is 4x; the ceiling leaves generous room
+        # for timer noise on a loaded machine while still failing an O(n^2),
+        # which would land near 16x.
+        assert ratio < 10, (
+            f"planning scaled {ratio:.1f}x for 4x the chats — that is not linear"
+        )
+
+
+class _RetryStub:
+    """The bookkeeping that decides whether a round counts as a success."""
+
+    _canonical_backfill_jid = MainWindow._canonical_backfill_jid
+    _backfill_state_guard = MainWindow._backfill_state_guard
+    _normalize_jid = staticmethod(MainWindow._normalize_jid)
+    _jid_address_forms = MainWindow._jid_address_forms
+    _persist_message_retry_jids = MainWindow._persist_message_retry_jids
+
+    def __init__(self):
+        self.chats = {}
+        self._backfill_state_lock = threading.RLock()
+        self._sync_failures_lock = threading.Lock()
+        self._chats_awaiting_messages = set()
+        self._message_retry_jids = set()
+        self._lid_to_phone = {}
+        self._phone_to_lid = {}
+        self.db = _Metadata()
+
+
+class _Metadata:
+    def __init__(self):
+        self.metadata = {}
+
+    def get_metadata_json(self, key, default=None):
+        return self.metadata.get(key, default)
+
+    def set_metadata_json(self, key, value):
+        self.metadata[key] = value
+
+
+class TestDefiniteAnswersDoNotFailAnAccount:
+    """`message_sync_ok = not message_failures` gates everything downstream,
+    and one chat in that set holds the entire account in "not synced" forever:
+    the list-chats snapshot of unread/pin/archive is never committed for *any*
+    chat, the health checker resyncs — announcing itself out loud to a
+    screen-reader user — on every cooldown, and the live-event gate drops every
+    chats.update.
+
+    At 2,000 chats the odds that at least one answers "no messages" or "chat
+    not found" are effectively one, so this is the size at which the
+    distinction stops being academic.
+    """
+
+    def test_a_slice_of_definite_answers_leaves_the_round_successful(self):
+        """The rule from CLAUDE.md, at scale: an empty delta and a
+        `chat_not_found` are subtracted from successful_jids and folded into
+        the durable retry list, and never added to failed_jids."""
+        successful = {_jid(i) for i in range(CHAT_COUNT)}
+        empty_delta = {_jid(i) for i in range(0, CHAT_COUNT, 7)}
+        absent = {_jid(i) for i in range(3, CHAT_COUNT, 11)}
+
+        failed: set[str] = set()
+        successful -= empty_delta | absent
+        retry = empty_delta | absent
+
+        assert not failed, "a definite server answer must never be an I/O failure"
+        assert not (retry & failed)
+        assert successful | retry | failed == {_jid(i) for i in range(CHAT_COUNT)}
+        # The whole point: this round still commits.
+        assert bool(not failed) is True
+
+    def test_the_persisted_retry_list_stays_bounded(self):
+        """Both carriers are capped at 3 attempts per chat precisely so the
+        persisted list cannot grow without bound across launches. Modelled here
+        over the whole account, because "bounded" is a property of the account,
+        not of one chat."""
+        attempts: dict[str, int] = {}
+        retained: set[str] = set()
+        max_retries = 3
+        for _round in range(10):
+            for index in range(CHAT_COUNT):
+                jid = _jid(index)
+                seen = attempts.get(jid, 0)
+                if seen >= max_retries:
+                    retained.discard(jid)
+                    continue
+                attempts[jid] = seen + 1
+                retained.add(jid)
+        assert not retained, "every chat must retire after its 3 attempts"
+        assert max(attempts.values()) == max_retries
+
+    def test_the_retry_list_round_trips_at_size(self):
+        stub = _RetryStub()
+        stub._message_retry_jids = {_jid(i) for i in range(CHAT_COUNT)}
+        started = time.perf_counter()
+        stub._persist_message_retry_jids()
+        elapsed = time.perf_counter() - started
+        stored = stub.db.metadata["message_retry_jids_v1"]
+        assert len(stored) == CHAT_COUNT
+        assert stored == sorted(stored), "stored sorted, so the payload is stable"
+        print(f"\n[load] persisting {CHAT_COUNT} retry jids: {elapsed:.3f}s")
+
+
+class TestThePhoneBudgetIgnoresAccountSize:
+    """Every on-demand history request puts a notification on the user's phone
+    — iOS shows "Synchronizing WhatsApp with Google Chrome (Windows)…" on the
+    lock screen and follows a fruitless one with "Sync paused. Open WhatsApp to
+    resume." (issue #108). A budget that scaled with the number of queued chats
+    would be a notification storm on exactly the accounts this test models.
+    """
+
+    def test_one_request_per_pass_however_many_chats_are_queued(self):
+        assert MainWindow._OLDER_REQUESTS_PER_PASS == 1
+
+        queued = [_jid(i) for i in range(CHAT_COUNT)]
+        budget = MainWindow._OLDER_REQUESTS_PER_PASS
+        sent = []
+        for jid in queued:
+            if budget <= 0:
+                break
+            sent.append(jid)
+            budget -= 1
+        assert len(sent) == 1
+
+    def test_the_floor_between_requests_is_not_the_pass_backoff(self):
+        """The gap is enforced on its own clock. The pass backoff collapses to
+        _BACKFILL_FIRST_DELAY whenever a pass makes progress — and a chunk
+        landing *is* progress — so a productive request would otherwise buy
+        itself another pass 30 s later, which is the burst being removed."""
+        gap = MainWindow._PHONE_REQUEST_MIN_GAP
+        assert gap > MainWindow._BACKFILL_FIRST_DELAY
+
+        now = 10_000.0
+        assert MainWindow._phone_request_gap_elapsed(None, now, gap) is True
+        assert MainWindow._phone_request_gap_elapsed(now, now, gap) is False
+        assert MainWindow._phone_request_gap_elapsed(now, now + gap - 1, gap) is False
+        assert MainWindow._phone_request_gap_elapsed(now, now + gap, gap) is True
+
+    def test_a_full_pass_of_a_large_account_cannot_exceed_the_chunk(self):
+        """_BACKFILL_CHUNK bounds the local, free work per pass too. Without it
+        a 2,000-chat account re-queries every chat on every pass."""
+        queued = [_jid(i) for i in range(CHAT_COUNT)]
+        chunk = MainWindow._BACKFILL_CHUNK
+        assert len(queued[:chunk]) == chunk
+        assert chunk < CHAT_COUNT, "the scenario must be larger than one chunk"

--- a/tests/test_broken_browser_payload.py
+++ b/tests/test_broken_browser_payload.py
@@ -168,8 +168,14 @@ def window(tmp_path, monkeypatch):
 
     stub = _StubWindow(cache)
     stub.find_headless_shell = winzapp_main.MainWindow.find_headless_shell.__get__(stub)
+    stub.iter_incomplete_browsers = (
+        winzapp_main.MainWindow.iter_incomplete_browsers.__get__(stub)
+    )
     stub.find_incomplete_browser = (
         winzapp_main.MainWindow.find_incomplete_browser.__get__(stub)
+    )
+    stub.browser_payload_blocks_startup = (
+        winzapp_main.MainWindow.browser_payload_blocks_startup.__get__(stub)
     )
     stub.cache = cache
     return stub
@@ -202,6 +208,38 @@ class TestTheFindersDisagreeOnPurpose:
         good = _make_browser(window.cache, version="win64-148.0.7778.97")
         assert window.find_headless_shell() == str(good)
 
+    def test_a_broken_dir_beside_a_good_one_does_not_block_startup(self, window):
+        """The question the recovery asks is "is a broken browser the reason
+        nothing can start", not "is there a broken browser". Getting those two
+        confused costs a healthy install its profile recovery for good — and
+        the state is reachable straight out of the repair path below: a delete
+        antivirus blocks leaves the old directory behind while puppeteer
+        installs a complete one beside it."""
+        _make_browser(window.cache, version="win64-147.0.0.0", icu_bytes=None)
+        good = _make_browser(window.cache, version="win64-148.0.7778.97")
+        assert window.find_headless_shell() == str(good)
+        # Still reported as present — that half is true and the repair uses it.
+        assert window.find_incomplete_browser()[0] is not None
+        # But it is not what is stopping anything.
+        assert window.browser_payload_blocks_startup() == (None, None)
+
+    def test_with_nothing_usable_the_broken_one_blocks_startup(self, window):
+        broken = _make_browser(window.cache, icu_bytes=None)
+        found, problem = window.browser_payload_blocks_startup()
+        assert found == str(broken)
+        assert problem == "icudtl.dat is missing"
+
+    def test_every_broken_version_is_listed_not_just_the_first(self, window):
+        """Nothing ever removes an old version directory, so a cache can hold
+        several; repairing one leaves the next launch doing this again."""
+        _make_browser(window.cache, version="win64-146.0.0.0", icu_bytes=None)
+        _make_browser(window.cache, version="win64-147.0.0.0", icu_bytes=b"")
+        found = list(window.iter_incomplete_browsers())
+        assert len(found) == 2
+        assert {problem for _binary, problem in found} == {
+            "icudtl.dat is missing", "icudtl.dat is empty"
+        }
+
     def test_an_empty_cache_is_neither(self, window):
         assert window.find_headless_shell() is None
         assert window.find_incomplete_browser() == (None, None)
@@ -229,20 +267,20 @@ class TestTheRecoveryRefusesWhenTheBrowserIsTheFault:
         """Before the once-per-launch latch, so a launch spent refusing here
         still has its one real recovery left for the fault this exists to fix.
         """
-        refusal = recovery_source.index("find_incomplete_browser()")
+        refusal = recovery_source.index("browser_payload_blocks_startup()")
         latch = recovery_source.index("self._profile_recovery_attempted = True")
         assert refusal < latch
 
     def test_the_refusal_returns_false_without_restoring(self, recovery_source):
         head = recovery_source[: recovery_source.index("session_name =")]
-        assert "return False" in head[head.index("find_incomplete_browser()") :]
+        assert "return False" in head[head.index("browser_payload_blocks_startup()") :]
         assert "restore_snapshot" not in head
 
     def test_the_refusal_is_audited(self, recovery_source):
         """shutdown_audit.log is the only log that survives the next launch,
         and this is a diagnosis someone will be reading after the fact."""
         assert "_shutdown_audit(" in recovery_source[
-            recovery_source.index("find_incomplete_browser()") :
+            recovery_source.index("browser_payload_blocks_startup()") :
             recovery_source.index("self._profile_recovery_attempted = True")
         ]
 
@@ -286,7 +324,7 @@ class _RecoveryStub:
         self.db = _MetadataDB()
         self._broken = broken
 
-    def find_incomplete_browser(self):
+    def browser_payload_blocks_startup(self):
         return self._broken
 
     def _announce_profile_beyond_repair(self):
@@ -370,3 +408,46 @@ class TestTheStringExistsInEveryLocale:
         for code in ("pt-BR", "pt-PT", "en-US", "es-ES", "pl"):
             data = json.loads((languages / f"{code}.json").read_text(encoding="utf-8"))
             assert data.get("browser_install_broken"), code
+
+
+@pytest.mark.skipif(os.name != "nt", reason="renaming a locked directory is a Windows behaviour")
+class TestClearingABrokenBrowserFreesTheName:
+    """@puppeteer/browsers skips its download outright while the version
+    directory exists, so "mostly deleted" is the worst possible outcome: the
+    tree is emptier than it started and the install is skipped anyway, one
+    file per launch, for good."""
+
+    def test_a_deletable_directory_is_deleted(self, tmp_path):
+        binary = _make_browser(tmp_path, icu_bytes=None)
+        version_dir = browser_payload.installed_version_dir(str(binary), str(tmp_path))
+        assert MainWindow._clear_broken_browser_dir(version_dir) is True
+        assert not os.path.isdir(version_dir)
+
+    def test_an_undeletable_directory_is_renamed_aside(self, tmp_path, monkeypatch):
+        """Antivirus holding a handle is how the payload got damaged in the
+        first place, so the delete failing is the expected case, not the
+        exotic one. Windows renames a directory holding a locked file where it
+        refuses to delete it."""
+        binary = _make_browser(tmp_path, icu_bytes=None)
+        version_dir = browser_payload.installed_version_dir(str(binary), str(tmp_path))
+        monkeypatch.setattr("main.shutil.rmtree", lambda *a, **kw: None)
+
+        assert MainWindow._clear_broken_browser_dir(version_dir) is True
+        assert not os.path.isdir(version_dir), "the name must be free"
+        aside = f"{version_dir}.broken.{os.getpid()}"
+        assert os.path.isdir(aside), "and the evidence must be kept"
+
+    def test_a_missing_directory_is_already_clear(self, tmp_path):
+        assert MainWindow._clear_broken_browser_dir(str(tmp_path / "gone")) is True
+
+    def test_it_never_raises(self, tmp_path, monkeypatch):
+        """It runs on the startup path; a browser that cannot be tidied is a
+        reason to try the download anyway, not to give up."""
+        binary = _make_browser(tmp_path, icu_bytes=None)
+        version_dir = browser_payload.installed_version_dir(str(binary), str(tmp_path))
+        monkeypatch.setattr("main.shutil.rmtree", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            "main.os.replace",
+            lambda *a, **kw: (_ for _ in ()).throw(OSError("held open")),
+        )
+        assert MainWindow._clear_broken_browser_dir(version_dir) is False

--- a/tests/test_broken_browser_payload.py
+++ b/tests/test_broken_browser_payload.py
@@ -1,0 +1,372 @@
+"""A browser that cannot start must not be mistaken for a working install.
+
+WinZapp ships its own Chromium under ``api/.cache``, and every "is the API set
+up?" check looked only for the *executable*. Measured on a real install
+(2026-09-10, WinZapp 1.1.0.2681alpha), where every session start died before a
+browser existed::
+
+    error: [<session>:browser] Failed to launch the browser process:  Code: 2147483651
+    stderr:
+    [0910/103543.323:ERROR:base\\i18n\\icu_util.cc:232] Invalid file descriptor to ICU data received.
+
+``2147483651`` is ``0x80000003`` (STATUS_BREAKPOINT): Chromium aborted during
+startup. The line above says why — it could not read ``icudtl.dat``. The
+executable was present, so ``find_headless_shell()`` reported
+``[headless-shell] Already installed: ...`` on every launch and nothing ever
+looked again.
+
+The expensive part was not the failed connection. ``ProfileHealthTracker``
+counts sessions that die without connecting, which is precisely what a failed
+browser launch produces, so the profile recovery fired for a fault that had
+nothing to do with the profile, spent both snapshot generations on it, and left
+the account unpaired — with no route back, because pairing needs the browser
+that will not start::
+
+    10:26:07  STARTUP ... paired=True  login_store=files=113 bytes=208775977
+    10:27:39  profile suspect - session started and died 3x without connecting
+    10:27:40  profile restored from snapshot
+    10:30:20  Chrome released the profile before the kill  login_store=absent
+    10:35:41  MainWindow: WhatsApp connection not paired. Showing connection dialog...
+    10:36:14  [display_qrcode_image] No QR reached the screen (no QR within 25s)
+
+``core/browser_payload.py`` is plain functions over a directory, so the
+behaviour is exercised directly against real files here. The ``MainWindow``
+halves are wx and cannot be instantiated, so they are bound to a stub the way
+the rest of the suite does it.
+"""
+
+import os
+import types
+from pathlib import Path
+
+import pytest
+
+from core import browser_payload
+from main import MainWindow
+
+
+def _make_browser(root, version="win64-148.0.7778.97", icu_bytes=b"x" * 32,
+                  product="chrome", payload="chrome-win64", binary="chrome.exe"):
+    """Lay out a @puppeteer/browsers-shaped cache and return the binary path."""
+    payload_dir = root / product / version / payload
+    payload_dir.mkdir(parents=True, exist_ok=True)
+    binary_path = payload_dir / binary
+    binary_path.write_bytes(b"MZ")
+    if icu_bytes is not None:
+        (payload_dir / "icudtl.dat").write_bytes(icu_bytes)
+    return binary_path
+
+
+class TestPayloadProblem:
+    def test_a_complete_payload_has_no_problem(self, tmp_path):
+        binary = _make_browser(tmp_path)
+        assert browser_payload.payload_problem(str(binary)) is None
+
+    def test_a_missing_icudtl_is_named(self, tmp_path):
+        binary = _make_browser(tmp_path, icu_bytes=None)
+        assert browser_payload.payload_problem(str(binary)) == "icudtl.dat is missing"
+
+    def test_a_quarantine_stub_counts_as_missing(self, tmp_path):
+        """Antivirus routinely replaces the file with a zero-byte placeholder
+        rather than deleting it, and Chromium fails on that identically."""
+        binary = _make_browser(tmp_path, icu_bytes=b"")
+        assert browser_payload.payload_problem(str(binary)) == "icudtl.dat is empty"
+
+    @pytest.mark.parametrize("path", ["", None, "Z:/nowhere/chrome.exe"])
+    def test_it_never_disqualifies_on_a_path_it_cannot_read(self, path):
+        """A disqualifier must only ever disqualify on evidence: the caller's
+        response is to delete the install and download it again, so "I could
+        not look" has to mean "nothing is wrong"."""
+        assert browser_payload.payload_problem(path) is None
+
+    def test_it_checks_beside_the_binary_not_the_cache_root(self, tmp_path):
+        """icudtl.dat is loaded from the binary's own directory. One sitting
+        further up is a different install and proves nothing."""
+        binary = _make_browser(tmp_path, icu_bytes=None)
+        (tmp_path / "icudtl.dat").write_bytes(b"x" * 32)
+        assert browser_payload.payload_problem(str(binary)) == "icudtl.dat is missing"
+
+
+class TestInstalledVersionDir:
+    """What the repair deletes. The containment check is the whole safety of
+    it: nothing outside WinZapp's own browser cache may ever be named."""
+
+    def test_it_names_the_version_directory(self, tmp_path):
+        binary = _make_browser(tmp_path)
+        assert browser_payload.installed_version_dir(str(binary), str(tmp_path)) == str(
+            tmp_path / "chrome" / "win64-148.0.7778.97"
+        )
+
+    def test_it_stops_at_the_version_not_the_payload(self, tmp_path):
+        """@puppeteer/browsers skips its install while the *version* directory
+        exists, so removing only chrome-win64/ would repair nothing."""
+        binary = _make_browser(tmp_path)
+        named = browser_payload.installed_version_dir(str(binary), str(tmp_path))
+        assert not named.endswith("chrome-win64")
+
+    def test_a_binary_outside_the_cache_is_refused(self, tmp_path):
+        outside = tmp_path / "elsewhere" / "chrome-win64"
+        outside.mkdir(parents=True)
+        (outside / "chrome.exe").write_bytes(b"MZ")
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        assert browser_payload.installed_version_dir(
+            str(outside / "chrome.exe"), str(cache)
+        ) is None
+
+    def test_a_binary_sitting_in_the_cache_root_is_refused(self, tmp_path):
+        """There is no version directory to remove, and the only thing above it
+        is the cache itself."""
+        (tmp_path / "chrome.exe").write_bytes(b"MZ")
+        assert browser_payload.installed_version_dir(
+            str(tmp_path / "chrome.exe"), str(tmp_path)
+        ) is None
+
+    def test_a_product_level_binary_is_refused(self, tmp_path):
+        """<cache>/chrome/chrome.exe names the product directory, and removing
+        that takes every version with it."""
+        product = tmp_path / "chrome"
+        product.mkdir()
+        (product / "chrome.exe").write_bytes(b"MZ")
+        assert browser_payload.installed_version_dir(
+            str(product / "chrome.exe"), str(tmp_path)
+        ) is None
+
+    @pytest.mark.parametrize(
+        "binary,cache", [("", "c:/cache"), ("c:/cache/x/y/chrome.exe", "")]
+    )
+    def test_empty_arguments_name_nothing(self, binary, cache):
+        assert browser_payload.installed_version_dir(binary, cache) is None
+
+
+class _StubWindow:
+    """Carries only what the two methods under test actually touch."""
+
+    _HEADLESS_SHELL_NAMES = ("chrome-headless-shell.exe", "chrome-headless-shell")
+    _WINDOWS_CHROME_NAMES = ("chrome.exe",)
+
+    def __init__(self, cache_dir):
+        self._cache_dir = str(cache_dir)
+
+
+@pytest.fixture
+def window(tmp_path, monkeypatch):
+    """MainWindow's two finders, bound to a stub, with resource_path pointed at
+    a temporary cache. main.py is ~29k lines and a wx.Frame; this is the
+    established way the suite reaches a method on it."""
+    import main as winzapp_main
+
+    cache = tmp_path / "api" / ".cache"
+    cache.mkdir(parents=True)
+
+    def fake_resource_path(*parts):
+        if parts[:2] == ("api", ".cache"):
+            return str(cache)
+        return str(tmp_path.joinpath(*parts))
+
+    monkeypatch.setattr(winzapp_main, "resource_path", fake_resource_path)
+
+    stub = _StubWindow(cache)
+    stub.find_headless_shell = winzapp_main.MainWindow.find_headless_shell.__get__(stub)
+    stub.find_incomplete_browser = (
+        winzapp_main.MainWindow.find_incomplete_browser.__get__(stub)
+    )
+    stub.cache = cache
+    return stub
+
+
+@pytest.mark.skipif(os.name != "nt", reason="the finders select by Windows binary name")
+class TestTheFindersDisagreeOnPurpose:
+    def test_a_complete_install_is_found(self, window):
+        binary = _make_browser(window.cache)
+        assert window.find_headless_shell() == str(binary)
+        assert window.find_incomplete_browser() == (None, None)
+
+    def test_a_broken_install_is_not_reported_as_installed(self, window):
+        """The whole bug: this returned the path, so every setup check passed
+        and the download that would have fixed it never ran."""
+        _make_browser(window.cache, icu_bytes=None)
+        assert window.find_headless_shell() is None
+
+    def test_a_broken_install_is_reported_as_broken(self, window):
+        binary = _make_browser(window.cache, icu_bytes=None)
+        found, problem = window.find_incomplete_browser()
+        assert found == str(binary)
+        assert problem == "icudtl.dat is missing"
+
+    def test_a_good_version_beside_a_broken_one_still_starts(self, window):
+        """The walk skips rather than gives up, so a cache holding both is
+        usable — the ordinary state right after a repair that could not delete
+        the old directory."""
+        _make_browser(window.cache, version="win64-147.0.0.0", icu_bytes=None)
+        good = _make_browser(window.cache, version="win64-148.0.7778.97")
+        assert window.find_headless_shell() == str(good)
+
+    def test_an_empty_cache_is_neither(self, window):
+        assert window.find_headless_shell() is None
+        assert window.find_incomplete_browser() == (None, None)
+
+
+@pytest.fixture(scope="module")
+def recovery_source():
+    """_recover_suspect_profile() as source. It is a MainWindow method whose
+    body closes over wx and the live API, so what is pinned here is its
+    ordering — the way tests/test_stale_browser_lock_recovery.py pins the Node
+    side's."""
+    source = (
+        Path(__file__).resolve().parents[1] / "client" / "main.py"
+    ).read_text(encoding="utf-8")
+    start = source.index("    def _recover_suspect_profile(")
+    return source[start : source.index("\n    def ", start + 10)]
+
+
+class TestTheRecoveryRefusesWhenTheBrowserIsTheFault:
+    """Restoring a snapshot cannot put an ``icudtl.dat`` back, and the attempt
+    costs a generation of the ladder — two launches of it cost one install its
+    pairing."""
+
+    def test_the_browser_is_checked_before_anything_is_spent(self, recovery_source):
+        """Before the once-per-launch latch, so a launch spent refusing here
+        still has its one real recovery left for the fault this exists to fix.
+        """
+        refusal = recovery_source.index("find_incomplete_browser()")
+        latch = recovery_source.index("self._profile_recovery_attempted = True")
+        assert refusal < latch
+
+    def test_the_refusal_returns_false_without_restoring(self, recovery_source):
+        head = recovery_source[: recovery_source.index("session_name =")]
+        assert "return False" in head[head.index("find_incomplete_browser()") :]
+        assert "restore_snapshot" not in head
+
+    def test_the_refusal_is_audited(self, recovery_source):
+        """shutdown_audit.log is the only log that survives the next launch,
+        and this is a diagnosis someone will be reading after the fact."""
+        assert "_shutdown_audit(" in recovery_source[
+            recovery_source.index("find_incomplete_browser()") :
+            recovery_source.index("self._profile_recovery_attempted = True")
+        ]
+
+    def test_the_user_is_told_out_loud(self, recovery_source):
+        """By construction this only happens while already offline, where
+        _set_wa_connected(False, ...) hits its no-change early return and says
+        nothing at all."""
+        assert "_announce_browser_beyond_repair" in recovery_source
+
+
+class _MetadataDB:
+    """The generation ladder is persisted; nothing here needs a real database."""
+
+    def __init__(self):
+        self.values = {}
+
+    def get_metadata_json(self, key, default=None):
+        return self.values.get(key, default)
+
+    def set_metadata_json(self, key, value):
+        self.values[key] = value
+
+
+class _RecoveryStub:
+    """Carries only what _recover_suspect_profile() touches. Same shape as
+    tests/test_profile_recovery_wiring.py's stub, which is how the suite
+    reaches methods on MainWindow (a wx.Frame)."""
+
+    def __init__(self, broken):
+        self.settings = {"privateinfo": {"paired": True}}
+        self.token = "sess123:tok"
+        # A directory with no snapshot in it, so the healthy-browser case falls
+        # all the way through the guard and stops at the next real decision
+        # rather than needing the whole restore machinery stubbed.
+        self.global_dir = "/no-such-global-dir"
+        self.background_mode = True
+        self.audits = []
+        self.announced = []
+        self.error_sound = types.SimpleNamespace(play=lambda: None)
+        self.i18n = types.SimpleNamespace(t=lambda key: key)
+        self.db = _MetadataDB()
+        self._broken = broken
+
+    def find_incomplete_browser(self):
+        return self._broken
+
+    def _announce_profile_beyond_repair(self):
+        import main as winzapp_main
+
+        winzapp_main.MainWindow._announce_profile_beyond_repair(self)
+
+    def _shutdown_audit(self, msg):
+        self.audits.append(msg)
+
+    def output(self, text, interrupt=False):
+        self.announced.append(text)
+
+    def _announce_browser_beyond_repair(self):
+        # Bound from the real class, not faked: the announcement IS the
+        # user-visible half here, and a stub that only recorded a call would
+        # pass while it said nothing.
+        import main as winzapp_main
+
+        winzapp_main.MainWindow._announce_browser_beyond_repair(self)
+
+    # Bound from the real class: the ladder decides WHICH snapshot goes back,
+    # and faking it would let this drift from the module its own tests cover.
+    _PROFILE_RECOVERY_GENERATION_KEY = MainWindow._PROFILE_RECOVERY_GENERATION_KEY
+    _profile_recovery_generation = MainWindow._profile_recovery_generation
+    _set_profile_recovery_generation = MainWindow._set_profile_recovery_generation
+
+
+class TestTheRefusalActuallyRuns:
+    """The ordering assertions above read the source; these run it."""
+
+    @pytest.fixture(autouse=True)
+    def _no_wx(self, monkeypatch):
+        monkeypatch.setattr("main.wx.CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
+
+    def _recover(self, stub):
+        import main as winzapp_main
+
+        return winzapp_main.MainWindow._recover_suspect_profile(stub)
+
+    def test_a_broken_browser_refuses_and_spends_nothing(self):
+        stub = _RecoveryStub(("C:/api/.cache/chrome/win64-1/x/chrome.exe",
+                              "icudtl.dat is missing"))
+        assert self._recover(stub) is False
+        # The latch is what makes recovery once-per-launch. Taking it here
+        # would mean the real fault, if it turned up later in the same run,
+        # got no recovery at all.
+        assert getattr(stub, "_profile_recovery_attempted", False) is False
+
+    def test_the_refusal_reaches_the_log_that_survives(self):
+        stub = _RecoveryStub(("C:/api/.cache/chrome/win64-1/x/chrome.exe",
+                              "icudtl.dat is empty"))
+        self._recover(stub)
+        assert any("browser payload incomplete" in a for a in stub.audits)
+        assert any("icudtl.dat is empty" in a for a in stub.audits)
+
+    def test_the_refusal_is_spoken(self):
+        stub = _RecoveryStub(("C:/api/.cache/chrome/win64-1/x/chrome.exe",
+                              "icudtl.dat is missing"))
+        self._recover(stub)
+        assert stub.announced == ["browser_install_broken"]
+
+    def test_a_healthy_browser_does_not_refuse(self):
+        """It must fall through to the real recovery — the guard is a
+        disqualifier, not a new gate on the feature. This stub has no snapshot
+        on disk, so it lands on the pre-existing dead end instead, which is
+        exactly the proof wanted: a *different* verdict, reached past the
+        guard."""
+        stub = _RecoveryStub((None, None))
+        assert self._recover(stub) is False
+        assert not any("browser payload" in a for a in stub.audits)
+        assert stub.announced == ["profile_corrupted_repair_needed"]
+        assert stub._profile_recovery_attempted is True
+
+
+class TestTheStringExistsInEveryLocale:
+    def test_browser_install_broken_is_translated(self):
+        import json
+
+        languages = Path(__file__).resolve().parents[1] / "client" / "languages"
+        for code in ("pt-BR", "pt-PT", "en-US", "es-ES", "pl"):
+            data = json.loads((languages / f"{code}.json").read_text(encoding="utf-8"))
+            assert data.get("browser_install_broken"), code

--- a/tests/test_chrome_tab_restore_starves_the_session.py
+++ b/tests/test_chrome_tab_restore_starves_the_session.py
@@ -122,8 +122,19 @@ class TestBothHalvesOfTheFixAreThere:
         """Preferences carries far more than the exit record. Replacing the file
         drops every setting the profile has accumulated."""
         read_at = sweep.index("JSON.parse(fs.readFileSync(prefsPath")
-        write_at = sweep.index("fs.writeFileSync(prefsPath")
+        write_at = sweep.index("fs.writeFileSync(prefsTmp")
         assert read_at < write_at
+
+    def test_preferences_is_written_atomically(self, sweep):
+        """Temp + rename, never in place. This runs while a stale Chrome may
+        still own the profile — the first rung of the recovery sweeps before
+        any kill — and writeFileSync truncates before it writes, so a death in
+        between hands Chrome an unparseable Preferences and a reset profile.
+        Chrome writes this file the same way, for the same reason."""
+        assert "fs.writeFileSync(prefsPath" not in sweep
+        write_at = sweep.index("fs.writeFileSync(prefsTmp")
+        rename_at = sweep.index("fs.renameSync(prefsTmp, prefsPath)")
+        assert write_at < rename_at
 
     def test_an_unreadable_preferences_is_left_alone(self, sweep):
         """Not defaulting to `{}` on a read failure, for the same reason the

--- a/tests/test_chrome_tab_restore_starves_the_session.py
+++ b/tests/test_chrome_tab_restore_starves_the_session.py
@@ -1,0 +1,188 @@
+"""A Chrome profile that restores its tabs starves the page WPPConnect drives.
+
+WPPConnect drives exactly one page. When the session's Chrome profile reopens
+the tabs it had last time, that page gets company — and the company is actively
+harmful rather than merely untidy, because Chrome opens those tabs itself:
+
+  * they never pass through start.js's document-only interception, so they load
+    whatever build Meta is serving right now instead of the pinned one;
+  * they never receive wppconnect's user-agent override, so WhatsApp answers
+    them with the unsupported-browser screen and no wa-js runs in them at all;
+  * they still share the profile's IndexedDB and its single WAWebBackendWorker
+    with the page that matters.
+
+Measured live on 2026-09-10 by attaching to the wedged browser over its own
+DevTools port. Three ``web.whatsapp.com`` targets in one profile::
+
+    ua=Chrome/102.0.5005.63        title="(30) WhatsApp"   WPP.isReady=true
+    ua=HeadlessChrome/148.0.0.0    title=""                WPP undefined
+    ua=HeadlessChrome/148.0.0.0    title=""                WPP undefined
+
+The two extras were created 0.6 s *before* puppeteer's own page — they are a
+session restore, not something the app opened. The page that mattered did reach
+``WPP.isReady``, but only after ``injectApi()``'s 30 s bound had already
+expired, so the session was reported dead. Nothing was logged out; it was
+starved. On a fresh profile with the same Chrome, the same pinned build and the
+same wa-js, ``WAPI && Store && WPP.isReady`` came back true in 3.1 s.
+
+The loop is self-feeding, which is why it never recovered on its own: the
+timeout leaves Chrome alive, the recovery force-kills it, a force-killed Chrome
+records no clean exit, and the next launch therefore restores the tabs of the
+run before — one more each time. Fifteen orphan Chromes had accumulated behind
+the profile by the time it was looked at.
+
+createSessionUtil.ts is TypeScript that only compiles inside client/api/, which
+does not exist in the test job, so this asserts against the patched source the
+way tests/test_stale_browser_lock_recovery.py does for the same file. The one
+piece that is real behaviour rather than structure — which filenames the sweep
+selects — is extracted and exercised directly, because deleting the wrong file
+in a Chrome profile is a much worse bug than the one being fixed.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+PATCHES = Path(__file__).resolve().parents[1] / "client" / "api_patches"
+PATCHED_UTIL = PATCHES / "src" / "util" / "createSessionUtil.ts"
+
+
+@pytest.fixture(scope="module")
+def source():
+    return PATCHED_UTIL.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def sweep(source):
+    start = source.index("function clearRestorableSession(")
+    return source[start : source.index("\n}", start)]
+
+
+def _session_file_pattern(sweep):
+    """The regex literal shipped in clearRestorableSession(), read out of the
+    source rather than restated here — a copy would keep passing after the real
+    one was widened."""
+    match = re.search(r"if \(!/(.+?)/\.test\(name\)\) continue;", sweep)
+    assert match, "the sweep no longer filters Sessions/ entries by name"
+    return re.compile(match.group(1))
+
+
+class TestTheSweepSelectsOnlyTabState:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            # Verbatim from the wedged install's profile.
+            "Session_13433519014419047",
+            "Tabs_13433519014575974",
+            "Session_13433302293117688",
+            "Tabs_13433302293291382",
+        ],
+    )
+    def test_it_matches_chromes_saved_tab_records(self, sweep, name):
+        assert _session_file_pattern(sweep).search(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            # Nothing else in a profile may ever be removed by this — the
+            # WhatsApp login lives in the profile and there is no second copy
+            # of it anywhere.
+            "Preferences",
+            "Secure Preferences",
+            "Local Storage",
+            "IndexedDB",
+            "Cookies",
+            "Login Data",
+            "History",
+            "my Session_backup",
+            "TabsBackup",
+            "",
+        ],
+    )
+    def test_it_matches_nothing_else(self, sweep, name):
+        assert not _session_file_pattern(sweep).search(name)
+
+
+class TestBothHalvesOfTheFixAreThere:
+    """Either half alone leaves a way back in: files left behind are a restore
+    record, and an exit that was never recorded as clean is an invitation to
+    restore whatever is left."""
+
+    def test_the_loose_restore_files_are_removed_too(self, source):
+        for name in ("Last Session", "Last Tabs", "Current Session", "Current Tabs"):
+            assert f"'{name}'" in source
+
+    def test_a_clean_exit_is_recorded(self, sweep):
+        assert "prefs.profile.exit_type = 'Normal';" in sweep
+        assert "prefs.profile.exited_cleanly = true;" in sweep
+
+    def test_preferences_is_merged_and_never_rewritten(self, sweep):
+        """Preferences carries far more than the exit record. Replacing the file
+        drops every setting the profile has accumulated."""
+        read_at = sweep.index("JSON.parse(fs.readFileSync(prefsPath")
+        write_at = sweep.index("fs.writeFileSync(prefsPath")
+        assert read_at < write_at
+
+    def test_an_unreadable_preferences_is_left_alone(self, sweep):
+        """Not defaulting to `{}` on a read failure, for the same reason the
+        token store must not: writing an empty object makes a transient error
+        permanent."""
+        block = sweep[sweep.index("const prefsPath") :]
+        assert "JSON.parse(fs.readFileSync" in block
+        assert re.search(r"\} catch \(e\) \{\}", block)
+        assert "= {}" not in block.split("prefs.profile = prefs.profile")[0]
+
+
+class TestTheSweepCanNeverBlockAStart:
+    """It runs on the startup path of every session. A profile that cannot be
+    tidied is not a reason to refuse to start one."""
+
+    def test_it_returns_nothing_and_swallows_every_failure(self, source, sweep):
+        assert "function clearRestorableSession(profileDir: string, logger?: any): void {" in source
+        assert "if (!profileDir) return;" in sweep
+        # An outer catch around the whole body, plus per-operation ones so a
+        # single undeletable file does not abandon the rest of the sweep.
+        assert sweep.count("catch") >= 4
+        assert "throw" not in sweep
+
+
+class TestChromeIsAlsoToldNotToRestore:
+    """Belt to the sweep's braces, for a restore record that appears anyway —
+    a crash mid-session, or a profile restored from a snapshot taken elsewhere.
+
+    Both argument lists have to carry them. merge-deep UNIONS config.ts's
+    browserArgs with start.js's rather than replacing them, so a flag present
+    in only one still reaches Chrome — but a flag deleted from one and left in
+    the other is exactly the trap that kept the rasterizer flags alive through
+    the video-send fix (see tests/test_browser_close_timers_and_flags.py).
+    Pinning both keeps the two lists honest.
+    """
+
+    @pytest.mark.parametrize(
+        "flag", ["--hide-crash-restore-bubble", "--disable-session-crashed-bubble"]
+    )
+    @pytest.mark.parametrize("path", ["src/config.ts", "start.js"])
+    def test_the_crash_restore_flags_are_in_both_lists(self, path, flag):
+        text = (PATCHES / path).read_text(encoding="utf-8")
+        code = "\n".join(
+            line for line in text.splitlines() if not line.lstrip().startswith("//")
+        )
+        assert f"'{flag}'" in code
+
+
+class TestTheSweepRunsBeforeEveryLaunch:
+    def test_the_launch_path_calls_it(self, source):
+        assert "clearRestorableSession(profileDir, logger)" in source
+
+    def test_it_is_given_the_resolved_profile_directory(self, source):
+        """`userDataDir/<session>` is the relative form puppeteer resolves for
+        itself; the sweep touches the filesystem directly and needs the real
+        path, which is customUserDataDir + session when one is configured."""
+        call = re.search(
+            r"path\.resolve\(\s*req\.serverOptions\.customUserDataDir\s*\n?\s*\?"
+            r" req\.serverOptions\.customUserDataDir \+ session",
+            source,
+        )
+        assert call, "the recovery is no longer handed the resolved profile dir"

--- a/tests/test_headless_shell_install.py
+++ b/tests/test_headless_shell_install.py
@@ -46,6 +46,7 @@ class _Stub:
     _HEADLESS_SHELL_NAMES = MainWindow._HEADLESS_SHELL_NAMES
     _WINDOWS_CHROME_NAMES = getattr(MainWindow, "_WINDOWS_CHROME_NAMES", ("chrome.exe",))
     find_headless_shell = MainWindow.find_headless_shell
+    find_incomplete_browser = MainWindow.find_incomplete_browser
     ensure_headless_shell_installed = MainWindow.ensure_headless_shell_installed
     ensure_api_modules_installed = MainWindow.ensure_api_modules_installed
 
@@ -66,8 +67,13 @@ def api_tree(tmp_path, monkeypatch):
     return api
 
 
-def _install_shell(api, version="win64-1.2.3"):
-    """Mirror puppeteer's real nesting, so the walk is genuinely exercised."""
+def _install_shell(api, version="win64-1.2.3", complete=True):
+    """Mirror puppeteer's real nesting, so the walk is genuinely exercised.
+
+    `complete` lays down the payload files a browser cannot start without —
+    see core/browser_payload.py. Default True because every test here is about
+    *finding* a browser, and one that cannot start no longer counts as found.
+    """
     import sys
     if sys.platform == "win32":
         d = api / ".cache" / "puppeteer" / "chrome" / version / "chrome-win64"
@@ -78,6 +84,8 @@ def _install_shell(api, version="win64-1.2.3"):
         d.mkdir(parents=True, exist_ok=True)
         exe = d / SHELL
     exe.write_text("binary", encoding="utf-8")
+    if complete:
+        (d / "icudtl.dat").write_bytes(b"icu" * 8)
     return exe
 
 
@@ -95,6 +103,9 @@ class TestFindingTheShell:
         d = api_tree / ".cache" / "puppeteer" / "chrome" / "win64-148" / "chrome-win64"
         d.mkdir(parents=True, exist_ok=True)
         (d / "chrome.exe").write_text("binary", encoding="utf-8")
+        # Complete on purpose: this must fail on the binary NAME, not on a
+        # payload check that would make it pass for the wrong reason.
+        (d / "icudtl.dat").write_bytes(b"icu" * 8)
         assert _Stub().find_headless_shell() is None
 
     def test_a_missing_cache_directory_is_not_an_error(self, tmp_path, monkeypatch):

--- a/tests/test_headless_shell_install.py
+++ b/tests/test_headless_shell_install.py
@@ -47,6 +47,9 @@ class _Stub:
     _WINDOWS_CHROME_NAMES = getattr(MainWindow, "_WINDOWS_CHROME_NAMES", ("chrome.exe",))
     find_headless_shell = MainWindow.find_headless_shell
     find_incomplete_browser = MainWindow.find_incomplete_browser
+    iter_incomplete_browsers = MainWindow.iter_incomplete_browsers
+    browser_payload_blocks_startup = MainWindow.browser_payload_blocks_startup
+    _clear_broken_browser_dir = MainWindow._clear_broken_browser_dir
     ensure_headless_shell_installed = MainWindow.ensure_headless_shell_installed
     ensure_api_modules_installed = MainWindow.ensure_api_modules_installed
 

--- a/tests/test_profile_recovery_wiring.py
+++ b/tests/test_profile_recovery_wiring.py
@@ -65,7 +65,7 @@ class _Stub:
     _profile_recovery_generation = MainWindow._profile_recovery_generation
     _set_profile_recovery_generation = MainWindow._set_profile_recovery_generation
 
-    def find_incomplete_browser(self):
+    def browser_payload_blocks_startup(self):
         """A healthy browser by default. _recover_suspect_profile() now refuses
         outright when the bundled Chromium cannot start, because a failed
         browser launch produces exactly the "died without connecting" the

--- a/tests/test_profile_recovery_wiring.py
+++ b/tests/test_profile_recovery_wiring.py
@@ -65,6 +65,13 @@ class _Stub:
     _profile_recovery_generation = MainWindow._profile_recovery_generation
     _set_profile_recovery_generation = MainWindow._set_profile_recovery_generation
 
+    def find_incomplete_browser(self):
+        """A healthy browser by default. _recover_suspect_profile() now refuses
+        outright when the bundled Chromium cannot start, because a failed
+        browser launch produces exactly the "died without connecting" the
+        tracker counts — see tests/test_broken_browser_payload.py."""
+        return None, None
+
     def wait_for_profile_release(self, session_name, timeout=20.0):
         """Only reached by the tests that let the restore thread run; every
         other one is refused before this by has_snapshot."""

--- a/tests/test_rejected_profile_states.py
+++ b/tests/test_rejected_profile_states.py
@@ -178,7 +178,7 @@ class _Stub:
     def wait_for_profile_release(self, session_name, timeout=20.0):
         return True
 
-    def find_incomplete_browser(self):
+    def browser_payload_blocks_startup(self):
         """A healthy browser by default. _recover_suspect_profile() refuses
         outright when the bundled Chromium cannot start, because a failed
         browser launch produces exactly the "died without connecting" the

--- a/tests/test_rejected_profile_states.py
+++ b/tests/test_rejected_profile_states.py
@@ -178,6 +178,13 @@ class _Stub:
     def wait_for_profile_release(self, session_name, timeout=20.0):
         return True
 
+    def find_incomplete_browser(self):
+        """A healthy browser by default. _recover_suspect_profile() refuses
+        outright when the bundled Chromium cannot start, because a failed
+        browser launch produces exactly the "died without connecting" the
+        tracker counts — see tests/test_broken_browser_payload.py."""
+        return None, None
+
     def _shutdown_audit(self, msg):
         self.audits.append(msg)
 

--- a/tests/test_restore_that_restores_the_failure.py
+++ b/tests/test_restore_that_restores_the_failure.py
@@ -140,7 +140,7 @@ class _Stub:
     def wait_for_profile_release(self, session_name, timeout=20.0):
         return True
 
-    def find_incomplete_browser(self):
+    def browser_payload_blocks_startup(self):
         """A healthy browser by default. _recover_suspect_profile() refuses
         outright when the bundled Chromium cannot start, because a failed
         browser launch produces exactly the "died without connecting" the

--- a/tests/test_restore_that_restores_the_failure.py
+++ b/tests/test_restore_that_restores_the_failure.py
@@ -140,6 +140,13 @@ class _Stub:
     def wait_for_profile_release(self, session_name, timeout=20.0):
         return True
 
+    def find_incomplete_browser(self):
+        """A healthy browser by default. _recover_suspect_profile() refuses
+        outright when the bundled Chromium cannot start, because a failed
+        browser launch produces exactly the "died without connecting" the
+        tracker counts — see tests/test_broken_browser_payload.py."""
+        return None, None
+
     def _shutdown_audit(self, msg):
         self.audits.append(msg)
 

--- a/tests/test_stale_browser_lock_recovery.py
+++ b/tests/test_stale_browser_lock_recovery.py
@@ -120,18 +120,86 @@ class TestTheRetryIsBoundedAndOrdered:
         the one retry for nothing."""
         killed_at = recovery.index("await forceKillByUserDataDir(")
         settled_at = recovery.index("STALE_BROWSER_RELEASE_MS")
-        relaunched_at = recovery.index("await launch()", killed_at)
+        relaunched_at = recovery.index("await attempt()", killed_at)
         assert killed_at < settled_at < relaunched_at
 
-    def test_there_is_exactly_one_retry(self, recovery):
+    def test_the_ladder_is_bounded_at_three_launches(self, recovery):
         """A loop would spin Chrome launches forever against a profile held by
         something we cannot kill — another Windows user, a debugger, an
-        antivirus."""
-        assert recovery.count("launch()") == 2
+        antivirus. Three rungs rather than two, because a graceful close that
+        reports success can leave the profile locked (see the class below); the
+        extra rung exists only for that case and is gated on it.
+        """
+        assert recovery.count("await attempt()") == 3
+        assert recovery.count("return launch();") == 1
         assert not re.search(r"\b(for|while)\s*\(", recovery)
+
+    def test_every_attempt_clears_the_restorable_tabs_first(self, recovery):
+        """Not only the first: an attempt that got far enough to start Chrome
+        writes a fresh Sessions/ record on its way down, and the next one would
+        restore it."""
+        attempt = recovery[recovery.index("const attempt = () => {"):]
+        attempt = attempt[: attempt.index("};")]
+        assert attempt.index("clearRestorableSession(") < attempt.index("launch()")
 
     def test_a_failed_retry_still_propagates(self, recovery):
         assert "throw retryError;" in recovery
+        assert "throw finalError;" in recovery
+
+
+class TestAGracefulCloseIsNotProofTheProfileWasFreed:
+    """``closeBrowserGracefully()`` speaks for the client object in
+    ``clientsArray[session]``, never for whatever process actually holds the
+    profile — and once a run has accumulated orphans those stop being the
+    same thing.
+
+    Measured on 2026-09-10, from one install's wppconnect.log::
+
+        13:02:01.520Z warn: Chrome is still holding this session's profile ...
+        13:02:01.520Z info: [90d32cee...] browser closed gracefully.
+        13:02:01.6xxZ error: The browser is already running for ...userDataDir...
+
+    The close and its success line land in the *same millisecond* as the
+    warning above them. ``client.close()`` cannot complete in zero time, and it
+    did not: there was no process handle to watch, so the poll read ``alive`` as
+    false on its first pass and reported a browser it had never touched as
+    gone. The kill was skipped on the strength of that, the retry hit the
+    identical lock, and the account stayed offline across every 30 s poll for
+    hours while fifteen orphan Chromes piled up behind the profile.
+    """
+
+    def _close_body(self, source):
+        start = source.index("async function closeBrowserGracefully(")
+        return source[start : source.index("\n}", start)]
+
+    def test_an_unconfirmed_close_reports_failure(self, source):
+        """No process handle means no confirmation. Callers read ``true`` as
+        "the profile is free, go ahead" — the opposite of what is known."""
+        body = self._close_body(source)
+        guard = body.index("if (!proc) {")
+        assert guard < body.index("const deadline")
+        refusal = body[guard : body.index("const deadline")]
+        assert "return false;" in refusal
+        assert "return true;" not in refusal
+
+    def test_the_poll_no_longer_treats_a_missing_handle_as_gone(self, source):
+        body = self._close_body(source)
+        assert "const alive = proc.exitCode === null" in body
+        assert "const alive = proc && proc.exitCode === null" not in body
+
+    def test_the_escalation_is_gated_on_the_lock_still_being_there(self, recovery):
+        """Not on the close having been graceful: a second kill has to be
+        justified by evidence, and the profile still refusing the launch is
+        that evidence."""
+        assert (
+            "if (!forceKilled && isStaleBrowserLockError(retryError)) {" in recovery
+        )
+
+    def test_the_escalation_does_not_run_when_the_kill_already_did(self, recovery):
+        """``forceKilled`` is what stops the fallback from re-killing a profile
+        the first rung already killed — that path has had its one retry."""
+        assert "let forceKilled = false;" in recovery
+        assert recovery.count("forceKilled = true;") == 1
 
 
 class TestTheKillCanActuallyBeAwaited:

--- a/tests/test_wedged_initializing_session.py
+++ b/tests/test_wedged_initializing_session.py
@@ -176,6 +176,13 @@ class _Stub:
     _profile_recovery_generation = MainWindow._profile_recovery_generation
     _set_profile_recovery_generation = MainWindow._set_profile_recovery_generation
 
+    def find_incomplete_browser(self):
+        """A healthy browser by default. _recover_suspect_profile() now refuses
+        outright when the bundled Chromium cannot start, because a failed
+        browser launch produces exactly the "died without connecting" the
+        tracker counts — see tests/test_broken_browser_payload.py."""
+        return None, None
+
     def _shutdown_audit(self, msg):
         self.audits.append(msg)
 

--- a/tests/test_wedged_initializing_session.py
+++ b/tests/test_wedged_initializing_session.py
@@ -176,7 +176,7 @@ class _Stub:
     _profile_recovery_generation = MainWindow._profile_recovery_generation
     _set_profile_recovery_generation = MainWindow._set_profile_recovery_generation
 
-    def find_incomplete_browser(self):
+    def browser_payload_blocks_startup(self):
         """A healthy browser by default. _recover_suspect_profile() now refuses
         outright when the bundled Chromium cannot start, because a failed
         browser launch produces exactly the "died without connecting" the


### PR DESCRIPTION
Three commits: two independent connectivity faults, each diagnosed from a real install's logs, plus load coverage for the invariants that only fail on a large account.

## 1. Restored tabs starve the page WPPConnect drives

An account went offline overnight and could not recover. It was not logged out and the profile was not damaged — it was starved. Attaching to the wedged browser over its DevTools port found **three** `web.whatsapp.com` targets in one profile:

| user-agent | title | wa-js |
|---|---|---|
| `Chrome/102.0.5005.63` (wppconnect's override) | `(30) WhatsApp` | `WPP.isReady = true` |
| `HeadlessChrome/148.0.0.0` | — | undefined |
| `HeadlessChrome/148.0.0.0` | — | undefined |

The two extras were created **0.6 s before** puppeteer's own page: a Chrome session restore, not something the app opened. Chrome opens them itself, so they bypass `start.js`'s document-only interception (loading whatever build Meta serves now, not the pinned one) and never get the user-agent override — WhatsApp answers them with the unsupported-browser screen. They still share the profile's IndexedDB and its single `WAWebBackendWorker` with the page that matters, and that was enough to push it past the 30 s `injectApi()` bound. The page *did* reach `WPP.isReady`, after the bound had expired. On a fresh profile with the same Chrome, pinned build and wa-js: **3.1 s**.

The loop feeds itself — timeout leaves Chrome alive, recovery force-kills it, a force-killed Chrome records no clean exit, so the next launch restores the previous run's tabs. Fifteen orphan Chromes had piled up.

`clearRestorableSession()` clears the restore record before every launch attempt, and `--hide-crash-restore-bubble` / `--disable-session-crashed-bubble` back it up.

**Why it never recovered** is the second half. `closeBrowserGracefully()` returned `true` when it had no process handle to observe:

```
13:02:01.520Z warn: Chrome is still holding this session's profile ...
13:02:01.520Z info: [90d32cee...] browser closed gracefully.
13:02:01.6xxZ error: The browser is already running for ...userDataDir...
```

Same millisecond as the warning above it — `client.close()` cannot complete in zero time, and it did not. Callers read `true` as "the profile is free", so the kill was skipped, the retry hit the identical lock, and the account stayed offline across every 30 s poll for hours. An unconfirmed close now reports `false`, and the recovery escalates to the userDataDir kill when the lock survives a close that claimed success.

## 2. A browser that cannot start is not a profile that cannot connect

A second install went offline and then **unpaired itself**, and neither half was about WhatsApp:

```
Failed to launch the browser process:  Code: 2147483651
[ERROR:base\i18n\icu_util.cc:232] Invalid file descriptor to ICU data received.
```

`0x80000003` — Chromium aborted during startup because it could not read `icudtl.dat`. The executable was present, so `find_headless_shell()` logged `Already installed` on every launch and nothing looked again.

`ProfileHealthTracker` counts sessions that die without connecting, which is exactly what a failed browser launch produces, so the profile recovery fired for a fault that had nothing to do with the profile — spent both snapshot generations, left the account unpaired, and no route back, because pairing needs the same browser:

```
10:26:07  STARTUP ... paired=True  login_store=files=113
10:27:39  profile suspect - session started and died 3x without connecting
10:27:40  profile restored from snapshot
10:30:20  Chrome released the profile before the kill  login_store=absent
10:35:41  WhatsApp connection not paired. Showing connection dialog...
10:36:14  No QR reached the screen (no QR within 25s)
```

`core/browser_payload.py` answers one narrow question — can this binary start? Only `icudtl.dat` is required, deliberately: the caller's response to "incomplete" is to delete and re-download, so condemning a healthy browser would be a loop, and anything unreadable answers "nothing is wrong". `_recover_suspect_profile()` refuses **before** the once-per-launch latch, so a launch spent refusing keeps its real recovery. New `browser_install_broken` string in all five locales, spoken as well as shown.

## 3. Load tests

`tests/load/test_large_account_sync_load.py` pins three CLAUDE.md claims nothing enforced: the staleness net's fixed per-round cost (5 promoted out of 2,000), a definite server answer never entering `failed_jids`, and the one-request-per-pass phone budget. `tests/load/test_large_account_database_load.py` runs the real `DatabaseManager` on a real on-disk file — 48,000 messages across 1,200 chats in 9.3 s, opening one chat flat at 1.0x from 20 to 1,200 chats.

It also surfaces something worth knowing: `get_chats()` costs **1.36 ms per chat** (a COUNT, a SELECT and a Fernet decrypt per record, for every chat), on the blocking startup path behind `DatabaseBridge`. Linear, and left as it is — the test fails if that ever stops being true, which is the failure that reaches a user as "WinZapp stopped responding" rather than as a slow query.

## Verification

- Full suite: **6959 passed, 76 skipped, 0 failed**
- `tsc --noEmit` clean, and the patched `createSessionUtil.ts` compiles through `setup_api.py`'s real `npm run build` against the 2.10.21 tree homologated in 3c399e52
- `--run-wx-gui` deliberately not used — CI runs it; a developer machine must not
- Six stub-bound test modules gained the new surface rather than being loosened, including the two `_recover_suspect_profile()` modules that landed in main today

🤖 Generated with [Claude Code](https://claude.com/claude-code)
