### PR TITLE
Measure the load tests' scaling from the floor, not from one sample

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,60 @@ from cryptography.fernet import Fernet
 _WX_GUI_OPT_IN_ENV = "WINZAPP_RUN_WX_GUI_TESTS"
 
 
+#: Repeats behind fastest_of()/fastest_of_async(). Enough to find the floor
+#: without making a load test noticeably slower.
+TIMING_REPEATS = 7
+
+
+def fastest_of(call, repeats: int = TIMING_REPEATS) -> float:
+    """Seconds taken by the quickest of *repeats* runs of ``call``.
+
+    The load tests assert that doubling the data does not more than double the
+    work. Timing a single run makes that assertion unreliable in exactly one
+    direction: noise is one-sided — a sample can only ever come out slower than
+    the truth, never faster — so one unlucky garbage collection inside the
+    larger measurement inflates the ratio without any code having changed.
+
+    Measured in a full suite run on 2026-09-10: the 2,000-chat planning call
+    was recorded at 69.9 ms against a median of 6.5 ms on the same machine,
+    while the 500-chat call was recorded at its clean 1.6 ms — "44.1x for 4x
+    the chats", failing the build over an implementation that is perfectly
+    linear (3.2 microseconds per chat, flat from 250 to 4,000 chats).
+
+    That is worth a helper rather than a local fix, because a red run is not
+    the worst outcome: release.yml's reject-on-test-failure DELETES a stable
+    release whose test job failed, so a test that fails at random can throw
+    away a good release.
+
+    The minimum is the right statistic precisely because of the one-sidedness:
+    it converges on the cost of the work itself, and it still grows when the
+    work genuinely grows, which is all these assertions read.
+    """
+    best = None
+    for _ in range(repeats):
+        started = time.perf_counter()
+        call()
+        elapsed = time.perf_counter() - started
+        if best is None or elapsed < best:
+            best = elapsed
+    return best
+
+
+async def fastest_of_async(make_awaitable, repeats: int = TIMING_REPEATS) -> float:
+    """fastest_of() for async work. ``make_awaitable`` is called once per
+    repeat and must return a FRESH awaitable — an already-created coroutine
+    cannot be awaited twice, and a factory also lets a caller vary anything
+    that must differ between runs (a fresh chat id per insert, say)."""
+    best = None
+    for index in range(repeats):
+        started = time.perf_counter()
+        await make_awaitable(index)
+        elapsed = time.perf_counter() - started
+        if best is None or elapsed < best:
+            best = elapsed
+    return best
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--run-wx-gui",

--- a/tests/load/test_large_account_database_load.py
+++ b/tests/load/test_large_account_database_load.py
@@ -39,6 +39,8 @@ import time
 import pytest
 from cryptography.fernet import Fernet
 
+from tests.conftest import fastest_of_async
+
 
 pytestmark = pytest.mark.load
 
@@ -179,10 +181,10 @@ class TestCostStaysProportionalToTheData:
         """
         quarter = max(2, CHAT_COUNT // 4)
         await _populate(disk_db, quarter, PER_CHAT)
-        await disk_db.get_chats()
-        started = time.perf_counter()
-        await disk_db.get_chats()
-        small_elapsed = max(time.perf_counter() - started, 1e-6)
+        await disk_db.get_chats()          # warm the page cache
+        # Quickest of several, not one sample — see conftest.fastest_of().
+        small_elapsed = max(
+            await fastest_of_async(lambda _i: disk_db.get_chats()), 1e-6)
 
         for index in range(quarter, CHAT_COUNT):
             jid = _jid(index)
@@ -191,11 +193,9 @@ class TestCostStaysProportionalToTheData:
             await disk_db.upsert_chat(jid, _chat(jid, messages[-1]))
 
         await disk_db.get_chats()
-        started = time.perf_counter()
-        chats = await disk_db.get_chats()
-        large_elapsed = time.perf_counter() - started
+        large_elapsed = await fastest_of_async(lambda _i: disk_db.get_chats())
 
-        assert len(chats) == CHAT_COUNT
+        assert len(await disk_db.get_chats()) == CHAT_COUNT
         ratio = large_elapsed / small_elapsed
         print(
             f"\n[load] get_chats() — {quarter} chats: {small_elapsed:.3f}s | "
@@ -212,27 +212,31 @@ class TestCostStaysProportionalToTheData:
         """The shape that would fail this: re-reading a chat's stored messages
         to insert one more (_with_known_video_duration is called per message
         and does touch the table), or a per-batch full scan."""
-        jid_small, jid_large = _jid(90_001), _jid(90_002)
-        small_batch = [_message(jid_small, n) for n in range(PER_CHAT)]
-        large_batch = [_message(jid_large, n) for n in range(PER_CHAT * 4)]
+        # A fresh chat per repeat: inserting the same batch into the same chat
+        # twice measures an update, not an insert. Quickest of several runs —
+        # see conftest.fastest_of().
+        def _insert(base, count):
+            async def _run(index):
+                jid = _jid(base + index)
+                await disk_db.insert_messages_batch(
+                    jid, [_message(jid, n) for n in range(count)])
+            return _run
 
         # Warm-up so neither measurement pays for connection setup.
-        await disk_db.insert_messages_batch(_jid(90_000), small_batch)
+        warm = _jid(90_000)
+        await disk_db.insert_messages_batch(
+            warm, [_message(warm, n) for n in range(PER_CHAT)])
 
-        started = time.perf_counter()
-        await disk_db.insert_messages_batch(jid_small, small_batch)
-        small_elapsed = max(time.perf_counter() - started, 1e-6)
-
-        started = time.perf_counter()
-        await disk_db.insert_messages_batch(jid_large, large_batch)
-        large_elapsed = time.perf_counter() - started
+        small_elapsed = max(
+            await fastest_of_async(_insert(91_000, PER_CHAT)), 1e-6)
+        large_elapsed = await fastest_of_async(_insert(92_000, PER_CHAT * 4))
 
         ratio = large_elapsed / small_elapsed
         print(
             f"\n[load] insert {PER_CHAT} msgs: {small_elapsed:.4f}s | "
             f"{PER_CHAT * 4} msgs: {large_elapsed:.4f}s | ratio {ratio:.1f}x"
         )
-        assert await disk_db.get_message_count(jid_large) == PER_CHAT * 4
+        assert await disk_db.get_message_count(_jid(92_000)) == PER_CHAT * 4
         # Linear is 4x. The ceiling absorbs timer noise on a loaded machine
         # while still failing a quadratic, which lands near 16x.
         assert ratio < 12, (

--- a/tests/load/test_large_account_sync_load.py
+++ b/tests/load/test_large_account_sync_load.py
@@ -41,7 +41,7 @@ import time
 import pytest
 
 from main import MainWindow
-from tests.conftest import warm_cached_chat
+from tests.conftest import fastest_of, warm_cached_chat
 
 
 pytestmark = pytest.mark.load
@@ -134,6 +134,13 @@ class TestTheStalenessNetCostsTheSameAtAnySize:
         assert not full and not incremental
         assert skipped == CHAT_COUNT
 
+    @staticmethod
+    def _fastest_plan(stub, baseline):
+        """The quickest of several planning runs — see conftest.fastest_of()
+        for why a single sample is not usable here."""
+        stub._plan_message_sync(baseline)      # warm-up: lazily-built state
+        return fastest_of(lambda: stub._plan_message_sync(baseline))
+
     def test_planning_cost_grows_no_faster_than_the_account(self):
         """An accidental O(n^2) — a nested scan over self.chats, a per-chat
         rebuild of the verified-at map — is invisible on the 2-chat fixtures
@@ -144,17 +151,8 @@ class TestTheStalenessNetCostsTheSameAtAnySize:
         large = _PlanStub(CHAT_COUNT, verified_now=False)
         small_baseline, large_baseline = small.baseline(), large.baseline()
 
-        # One warm-up each: first call pays for lazily-built module state.
-        small._plan_message_sync(small_baseline)
-        large._plan_message_sync(large_baseline)
-
-        started = time.perf_counter()
-        small._plan_message_sync(small_baseline)
-        small_elapsed = max(time.perf_counter() - started, 1e-6)
-
-        started = time.perf_counter()
-        large._plan_message_sync(large_baseline)
-        large_elapsed = time.perf_counter() - started
+        small_elapsed = max(self._fastest_plan(small, small_baseline), 1e-6)
+        large_elapsed = self._fastest_plan(large, large_baseline)
 
         ratio = large_elapsed / small_elapsed
         print(


### PR DESCRIPTION
Resultado da revisão do que entrou na #226.

## O defeito

A suíte completa falhou em:

```
planning scaled 44.1x for 4x the chats — that is not linear
[load] plan 500 chats: 0.0016s | 2000 chats: 0.0699s
```

E o mesmo teste passa isolado. Medido direito, o planner é **linear**: 3,2 µs por chat, constante de 250 a 4.000 chats.

| chats | mediana | µs/chat |
|---|---|---|
| 250 | 0,806 ms | 3,22 |
| 500 | 1,596 ms | 3,19 |
| 1000 | 3,170 ms | 3,17 |
| 2000 | 6,455 ms | 3,23 |
| 4000 | 13,562 ms | 3,39 |

Os 2.000 chats levam 6,5 ms; a amostra que derrubou o build marcou 69,9 ms — uma coleta de lixo caiu dentro dela.

Ruído de temporização é **unilateral**: uma amostra só pode sair mais lenta que a verdade, nunca mais rápida. Então o mínimo de várias execuções é o estimador que essas asserções querem, e uma amostra única é o que elas não podem usar. O denominador piora: a medição pequena é ~1,6 ms, então qualquer inflação do numerador entra inteira na razão.

## Por que corrigir em vez de re-rodar

Um build vermelho não é o pior desfecho. O `reject-on-test-failure` do `release.yml` **apaga uma release estável** cujo job de teste falhou — e o marcador `load` não é desmarcado por nenhum dos workflows. Um teste que falha aleatoriamente pode jogar fora uma release boa.

## A correção

`conftest.fastest_of()` / `fastest_of_async()` como mecanismo único, aplicado às **três** asserções de razão e não só à que falhou — as outras duas são a construção idêntica e estavam latentes.

A variante async recebe uma *fábrica* e não um awaitable: uma corrotina não pode ser aguardada duas vezes, e o teste de inserção precisa de um chat novo por repetição (inserir o mesmo lote no mesmo chat mede um update, não um insert).

Depois: `get_chats` 4,2x · `insert` 3,7x · `plan` 4,0x para 4x os dados — todos no ideal linear, com os tetos de 10-12x agora carregando folga real em vez de absorver ruído.

🤖 Generated with [Claude Code](https://claude.com/claude-code)