### PR TITLE
Quote the live status model instead of a rebuilt copy of it

### DIFF
--- a/client/api_patches/src/controller/messageController.ts
+++ b/client/api_patches/src/controller/messageController.ts
@@ -1274,14 +1274,77 @@ async function replyToStatusMessage(
           matchedPoster,
           quotedIsStatusV3: Boolean(quoted.isStatusV3),
         });
+
+        // Quote by handing wa-js the LIVE model, and only fall back to a
+        // serialised payload.
+        //
+        // It used to be payload-only, and that is why status replies keep
+        // breaking and un-breaking across WhatsApp Web builds. wa-js's own
+        // contract for `quotedMsgPayload` is "the JSON string representation
+        // of a RAW message ... obtained when using getMessageById or
+        // getMessages" — a model's `toJSON()` is a different shape, and what
+        // wa-js does with it is `rehydrateMessage(payload)`, i.e. rebuild a
+        // MsgModel out of whatever fields happen to be in there. It then
+        // finishes with `quotedMsg.msgContextInfo(chatId)`, which reads the
+        // quoted message's own getters. Any field the rehydration did not
+        // carry across is undefined by the time a getter asks for it, and the
+        // getter does not return undefined — it throws.
+        //
+        // Measured 2026-09-10, a status reply that failed every attempt:
+        //
+        //   error: "Getter was called with undefined data."
+        //   stack: ... getIsBroadcast ... at t.prepareRawMessage
+        //   matchedPoster: 68904344899801@lid, statusMessagesSeen: 1
+        //
+        // The status WAS found; rebuilding it is what failed. A live model
+        // needs no rebuilding, so this whole class of breakage does not apply
+        // to it: wa-js takes `quotedMsg` as `string | MsgKey | MsgModel` and
+        // passes a MsgModel straight through to msgContextInfo().
+        //
+        // The payload stays as the second rung rather than being deleted,
+        // because it is not strictly weaker: wa-js skips its
+        // `canReplyMsg(quotedMsg)` gate when a payload was supplied, so a
+        // status whose model does not satisfy that check can still go out
+        // that way. That is also why the live model is tried FIRST — the
+        // fallback's permissiveness is exactly what let this failure reach
+        // `msgContextInfo` instead of being refused by name.
+        const attempts: any[] = [];
         const quotedPayload = JSON.stringify(
           typeof quoted.toJSON === 'function' ? quoted.toJSON() : quoted
         );
-        const sendResult = await WPP.chat.sendTextMessage(to, content, {
-          quotedMsgPayload: quotedPayload,
-          linkPreview: false,
-          waitForAck: true,
-        });
+        const strategies: { via: string; options: any }[] = [
+          { via: 'live-model', options: { quotedMsg: quoted } },
+          { via: 'payload', options: { quotedMsgPayload: quotedPayload } },
+        ];
+        let sendResult: any = null;
+        let usedVia = '';
+        for (const strategy of strategies) {
+          try {
+            sendResult = await WPP.chat.sendTextMessage(to, content, {
+              ...strategy.options,
+              linkPreview: false,
+              waitForAck: true,
+            });
+            usedVia = strategy.via;
+            break;
+          } catch (attemptError) {
+            attempts.push({
+              via: strategy.via,
+              error: String(
+                (attemptError as any)?.message || attemptError
+              ),
+            });
+          }
+        }
+        // Recorded whether or not a later rung succeeded: a first rung that
+        // starts failing is how the next regression announces itself, and
+        // without this the log would only ever show the one that worked.
+        Object.assign(probe, { quotedVia: usedVia, quotedAttempts: attempts });
+        if (!sendResult) {
+          throw new Error(
+            `Every status reply strategy failed: ${JSON.stringify(attempts)}`
+          );
+        }
         const sentId =
           typeof sendResult?.id === 'string'
             ? sendResult.id

--- a/tests/test_status_reply_quotes_the_live_model.py
+++ b/tests/test_status_reply_quotes_the_live_model.py
@@ -1,0 +1,132 @@
+"""Replying to a status must quote the live model, not a rebuilt copy of it.
+
+This feature keeps breaking and un-breaking across WhatsApp Web builds, and the
+reason is structural rather than bad luck. The reply was sent with wa-js's
+``quotedMsgPayload``, whose own contract is "the JSON string representation of a
+RAW message ... obtained when using getMessageById or getMessages" — while what
+was passed is a *model's* ``toJSON()``, a different shape. wa-js answers
+``quotedMsgPayload`` with ``rehydrateMessage(payload)``: it rebuilds a MsgModel
+out of whichever fields happen to be present, then finishes
+``prepareRawMessage`` with ``quotedMsg.msgContextInfo(chatId)``, which reads the
+quoted message's getters. A field the rebuild did not carry across is undefined
+by the time a getter asks for it — and the getter does not return undefined, it
+throws. Every WhatsApp Web build that moves a field moves the breakage with it.
+
+Measured 2026-09-10, from a reply that failed every attempt::
+
+    error: "Getter was called with undefined data."
+    stack: ... getIsBroadcast ... at t.prepareRawMessage
+    matchedPoster: 68904344899801@lid, statusMessagesSeen: 1, quotedIsStatusV3: false
+
+The status was found. Rebuilding it is what failed — so the fix is to stop
+rebuilding it: wa-js accepts ``quotedMsg`` as ``string | MsgKey | MsgModel`` and
+hands a MsgModel straight to ``msgContextInfo()``.
+
+The payload stays as a second rung rather than being deleted, because it is not
+strictly weaker: wa-js skips its ``canReplyMsg()`` gate when a payload was
+supplied, so a status whose model fails that check can still go out that way.
+That permissiveness is also why the live model goes first — it is what let this
+failure reach ``msgContextInfo`` instead of being refused by name.
+
+Asserted against the source, like tests/test_status_text_ack_static.py: the code
+under test is a string evaluated inside a real WhatsApp Web page, so there is no
+seam to call it through.
+"""
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTROLLER = (
+    ROOT / "client" / "api_patches" / "src" / "controller" / "messageController.ts"
+)
+
+
+@pytest.fixture(scope="module")
+def source() -> str:
+    return CONTROLLER.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def reply_block(source: str) -> str:
+    """Just the status-reply evaluate, so a match elsewhere in this very large
+    controller cannot pass for one here."""
+    start = source.index("winzapp_status_reply_")
+    end = source.index("stored status reply result", start)
+    return source[start:end]
+
+
+class TestTheLiveModelIsTheFirstChoice:
+    def test_the_model_is_quoted_directly(self, reply_block):
+        assert "quotedMsg: quoted" in reply_block, (
+            "the reply is quoting a rebuilt copy again — every field the "
+            "rehydration drops becomes a getter that throws"
+        )
+
+    def test_it_is_tried_before_the_payload(self, reply_block):
+        live = reply_block.index("quotedMsg: quoted")
+        payload = reply_block.index("quotedMsgPayload: quotedPayload")
+        assert live < payload, (
+            "the payload path skips wa-js's canReplyMsg() gate, so trying it "
+            "first is what turns a named refusal into a crash inside "
+            "msgContextInfo()"
+        )
+
+    def test_the_payload_is_still_available_as_a_fallback(self, reply_block):
+        assert "quotedMsgPayload: quotedPayload" in reply_block, (
+            "the payload rung is not strictly weaker — it is the only route "
+            "for a status whose model fails canReplyMsg()"
+        )
+
+
+class TestAFailedRungDoesNotEndTheReply:
+    def test_each_attempt_is_caught(self, reply_block):
+        """A throw from the first strategy must reach the second, not the
+        caller. Before this there was one call and any throw was terminal."""
+        strategies = reply_block.index("const strategies")
+        assert "catch (attemptError)" in reply_block[strategies:]
+
+    def test_exhausting_every_rung_still_fails_loudly(self, reply_block):
+        """Silently returning no result would be worse than the crash it
+        replaces: the send contract reads a missing id as a real failure only
+        because something raises here."""
+        assert "Every status reply strategy failed" in reply_block
+
+    def test_no_send_result_is_never_treated_as_success(self, reply_block):
+        assert "if (!sendResult) {" in reply_block
+
+
+class TestTheNextRegressionIsSelfDiagnosing:
+    def test_the_winning_strategy_is_recorded(self, reply_block):
+        assert "quotedVia: usedVia" in reply_block
+
+    def test_failed_attempts_are_recorded_even_when_a_later_rung_wins(
+            self, reply_block):
+        """A first rung that starts failing is how the next WhatsApp Web
+        change announces itself. Recording only the winner would hide it until
+        both rungs were broken — which is exactly how long this one went
+        unnoticed."""
+        assert "quotedAttempts: attempts" in reply_block
+        assign = reply_block.index("quotedVia: usedVia")
+        guard = reply_block.index("if (!sendResult) {")
+        assert assign < guard, (
+            "the attempts must be recorded before the all-failed throw, or "
+            "the total-failure case reports nothing about why"
+        )
+
+    def test_the_existing_status_probe_fields_are_kept(self, reply_block):
+        """These named the poster and proved the status was found, which is
+        what made this diagnosable at all."""
+        for field in ("statusModelsSeen", "statusMessagesSeen",
+                      "matchedPoster", "quotedIsStatusV3"):
+            assert field in reply_block
+
+
+def test_the_two_copies_of_the_controller_agree():
+    """setup_api.py restores api_patches over client/api. A fix that lands in
+    only one of them ships the other."""
+    live = ROOT / "client" / "api" / "src" / "controller" / "messageController.ts"
+    if not live.is_file():
+        pytest.skip("client/api is not installed in this checkout")
+    assert live.read_text(encoding="utf-8") == CONTROLLER.read_text(encoding="utf-8")


### PR DESCRIPTION
## Por que este bug volta de tempos em tempos

Ele não é azar — é estrutural. E o probe que já existe nesse caminho entregou o diagnóstico inteiro:

```
matchedPoster: 68904344899801@lid
statusMessagesSeen: 1
quotedIsStatusV3: false
error: "Getter was called with undefined data."
stack: ... getIsBroadcast ... at t.prepareRawMessage
```

**O status FOI encontrado.** O que falhou foi reconstruí-lo.

A resposta era enviada com `quotedMsgPayload` do wa-js, cujo próprio contrato diz: *"a representação em JSON de uma mensagem **RAW** ... obtida via `getMessageById` ou `getMessages`"* — e o que passávamos era o `toJSON()` de um **modelo**, outra forma.

O que o wa-js faz com `quotedMsgPayload` é `rehydrateMessage(payload)`: remonta um `MsgModel` com os campos que por acaso estiverem ali, e depois encerra o `prepareRawMessage` com `quotedMsg.msgContextInfo(chatId)`, que lê os getters da mensagem citada. Qualquer campo que a remontagem não carregou está indefinido quando um getter o pede — e o getter não devolve `undefined`, ele **lança**.

Cada build do WhatsApp Web que move um campo move a quebra junto. É exatamente a parte do "volta de tempos em tempos".

## A correção

Parar de reconstruir. O wa-js aceita `quotedMsg` como `string | MsgKey | MsgModel` e repassa um `MsgModel` direto para o `msgContextInfo()` — então o modelo vivo, vindo da coleção de status, pula a reidratação inteira.

O payload **fica** como segundo degrau em vez de ser removido, porque não é estritamente mais fraco: o wa-js pula o portão `canReplyMsg()` quando um payload é fornecido, então um status cujo modelo não passa nessa checagem ainda consegue sair por ali.

Essa permissividade é também a razão de o modelo vivo vir **primeiro** — foi ela que deixou esta falha chegar até o `msgContextInfo()` em vez de ser recusada com nome próprio.

## Para a próxima vez

Os dois degraus registram o que fizeram (`quotedVia`, `quotedAttempts`). Um primeiro degrau que começa a falhar enquanto o segundo ainda funciona é como a próxima mudança do WhatsApp Web vai se anunciar — e registrar só o vencedor esconderia isso até os dois estarem quebrados, que é justamente quanto tempo este passou despercebido.

## Verificação

`tsc --noEmit` contra a árvore `client/api` instalada, não só contra a cópia em `api_patches` — e um teste garante que as duas cópias concordam, já que o `setup_api.py` restaura uma sobre a outra.

10 testes novos; suíte completa em 6991 passando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)