### PR TITLE
Add a search field to the archived-chats panel

### DIFF
--- a/client/languages/en-US.json
+++ b/client/languages/en-US.json
@@ -26,6 +26,7 @@
     "main_nav": "&Main navigation",
     "conversations": "Chats",
     "search_conversations": "Search chats",
+    "search_archived_conversations": "Search archived chats",
     "chat_retrieval_failed": "Failed to retrieve the chat list from the server.",
     "chat_load_failed": "Could not load your local message file. Restart the program and try again.",
     "contact_load_failed": "Could not load the local contact list.",

--- a/client/languages/es-ES.json
+++ b/client/languages/es-ES.json
@@ -26,6 +26,7 @@
     "main_nav": "&Navegación principal",
     "conversations": "Conversaciones",
     "search_conversations": "Buscar en conversaciones",
+    "search_archived_conversations": "Buscar en conversaciones archivadas",
     "chat_retrieval_failed": "Error al obtener la lista de conversaciones del servidor.",
     "chat_load_failed": "No se pudo cargar el archivo local de mensajes. Reinicia el programa e inténtalo de nuevo.",
     "contact_load_failed": "No se pudo cargar la lista de contactos local.",

--- a/client/languages/pl.json
+++ b/client/languages/pl.json
@@ -26,6 +26,7 @@
     "main_nav": "&Nawigacja główna",
     "conversations": "Rozmowy",
     "search_conversations": "Szukaj rozmów",
+    "search_archived_conversations": "Szukaj w zarchiwizowanych rozmowach",
     "chat_retrieval_failed": "Nie udało się pobrać listy rozmów z serwera.",
     "chat_load_failed": "Nie udało się wczytać lokalnego pliku wiadomości. Uruchom program ponownie i spróbuj jeszcze raz.",
     "contact_load_failed": "Nie udało się wczytać lokalnej listy kontaktów.",

--- a/client/languages/pt-BR.json
+++ b/client/languages/pt-BR.json
@@ -26,6 +26,7 @@
     "main_nav": "&Navegação principal",
     "conversations": "Conversas",
     "search_conversations": "Pesquisar nas conversas",
+    "search_archived_conversations": "Pesquisar nas conversas arquivadas",
     "chat_retrieval_failed": "Falha ao obter a lista de conversas do servidor.",
     "chat_load_failed": "Não foi possível carregar o seu arquivo local de mensagens. Reinicie o programa e tente novamente.",
     "contact_load_failed": "Não foi possível carregar a lista de contatos local.",

--- a/client/languages/pt-PT.json
+++ b/client/languages/pt-PT.json
@@ -26,6 +26,7 @@
     "main_nav": "&Navegação principal",
     "conversations": "Conversas",
     "search_conversations": "Procurar nas conversas",
+    "search_archived_conversations": "Procurar nas conversas arquivadas",
     "chat_retrieval_failed": "Não foi possível recuperar a lista de conversas do servidor.",
     "chat_load_failed": "Não foi possível carregar o seu ficheiro de mensagens local. Reinicie a aplicação e tente novamente.",
     "contact_load_failed": "Não foi possível carregar a lista de contactos local.",

--- a/client/main.py
+++ b/client/main.py
@@ -28683,6 +28683,37 @@ class MainWindow(wx.Frame):
                     parts.append(status_text)
         return " ".join(parts)
 
+    @staticmethod
+    def _filter_archived_chats(chats: list, names: list, conv_filter: str,
+                               search: str, fold_mode: str) -> "tuple[list, list]":
+        """Return (chats, names) after applying the archived panel's own
+        filter tabs and its own search field.
+
+        Extracted so this can be tested directly without instantiating
+        ArchivedConversationsPanel or MainWindow (both require a running
+        wx.App) — mirrors why _conversation_search_candidates() above is a
+        staticmethod. *search* and *fold_mode* are already normalized by the
+        caller (normalize_for_search()/self._search_normalization_mode()),
+        same as add_chats_to_ui() does for the main list's own search field —
+        this one never reaches outside the archived list it filters.
+        """
+        displayed_chats: list = []
+        displayed_names: list = []
+        for i, chat in enumerate(chats):
+            chat_jid = chat.get("remoteJid", "")
+            if conv_filter == 'unread' and effective_unread_count(chat) == 0:
+                continue
+            if conv_filter == 'groups' and not chat_jid.endswith("@g.us"):
+                continue
+            if conv_filter == 'individual' and chat_jid.endswith("@g.us"):
+                continue
+            name = names[i] if i < len(names) else ""
+            if search and search not in normalize_for_search(name, fold_mode):
+                continue
+            displayed_chats.append(chat)
+            displayed_names.append(name)
+        return displayed_chats, displayed_names
+
     def _refresh_archived_chats_in_ui(self, arch_focused_jid: "str | None" = None):
         """Update the archived conversations list using SetItem when possible.
 
@@ -28696,21 +28727,20 @@ class MainWindow(wx.Frame):
         arch_full_names = list(getattr(panel, '_all_chat_names', panel.chat_names))
         arch_lst = panel.conversations_list
         arch_filter = getattr(panel, '_conv_filter', 'all')
+        _fold = self._search_normalization_mode()
+        arch_search = normalize_for_search(
+            panel.search_field.GetValue().strip() if hasattr(panel, "search_field") else "",
+            _fold,
+        )
+        filtered_chats, filtered_names = self._filter_archived_chats(
+            arch_full_chats, arch_full_names, arch_filter, arch_search, _fold
+        )
 
         new_arch_chats: list = []
         new_arch_names: list = []
         new_arch_texts: list = []
-        for i, chat in enumerate(arch_full_chats):
-            chat_jid = chat.get("remoteJid", "")
-            unread_count = effective_unread_count(chat)
-            if arch_filter == 'unread' and unread_count == 0:
-                continue
-            if arch_filter == 'groups' and not chat_jid.endswith("@g.us"):
-                continue
-            if arch_filter == 'individual' and chat_jid.endswith("@g.us"):
-                continue
-            name = arch_full_names[i] if i < len(arch_full_names) else ""
-            unread = unread_count
+        for chat, name in zip(filtered_chats, filtered_names):
+            unread = effective_unread_count(chat)
             unread_str = (
                 f" {unread} " + (self.i18n.t("unread_messages") if unread > 1 else self.i18n.t("unread_message"))
                 if unread > 0 else ""

--- a/client/ui/conversations.py
+++ b/client/ui/conversations.py
@@ -16350,6 +16350,25 @@ class ArchivedConversationsPanel(wx.Panel):
         self._filter_radio.Bind(wx.EVT_RADIOBOX, self._on_filter_changed)
         sizer.Add(self._filter_radio, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 5)
 
+        # ── Search ──────────────────────────────────────────────────────────
+        # Mirrors ConversationsPanel's own search field (same Ctrl+F shortcut,
+        # same Down-arrow-to-first-result behavior) but placed after the
+        # filter tabs rather than before them — there is no "Nova conversa"
+        # button here to separate the two — and scoped to only this panel's
+        # own list: unlike the main panel's search field, which merges in
+        # archived results (see MainWindow._conversation_search_candidates()),
+        # this one never reaches outside the archived list it sits in.
+        self.search_label = wx.StaticText(
+            self, label=i18n.t("search_archived_conversations")
+        )
+        sizer.Add(self.search_label, 0, wx.LEFT | wx.TOP, 5)
+
+        self.search_field = wx.TextCtrl(self, style=wx.TE_DONTWRAP)
+        self.search_field.Bind(wx.EVT_TEXT, self.on_search_query_changed)
+        self.search_field.Bind(wx.EVT_KEY_DOWN, self._on_search_field_key_down)
+        self.search_field.SetAccessible(AccessibleSearchConversations("Ctrl+F"))
+        sizer.Add(self.search_field, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 5)
+
         self.conversations_list = wx.ListCtrl(
             self, style=wx.LC_REPORT | wx.LC_SINGLE_SEL
         )
@@ -16386,13 +16405,17 @@ class ArchivedConversationsPanel(wx.Panel):
         applied to this panel instead. The archived list used to have none of
         these at all — Delete and Ctrl+Shift+L (clear) worked in the normal
         list but silently did nothing here, and the row context menu was
-        missing everything except unarchive/clear/delete. Ctrl+F (search) and
-        Ctrl+N (new conversation) are left out: this panel has no search field
-        of its own, and Ctrl+W (close conversation) doesn't apply — there is no
-        split conversation view to close from this list. Ctrl+Shift+Q always
+        missing everything except unarchive/clear/delete. Ctrl+F now focuses
+        this panel's own search field (see _init_ui()), scoped to archived
+        chats only — never the main panel's, which additionally merges in
+        archived results on a non-empty query. Ctrl+N (new conversation) is
+        still left out — there is nowhere to create a conversation from this
+        list — and Ctrl+W (close conversation) doesn't apply either: there is
+        no split conversation view to close from here. Ctrl+Shift+Q always
         means "unarchive" here rather than toggling, since every row is
         archived by definition.
         """
+        self.ID_CTRL_F           = wx.NewIdRef()
         self.ID_DELETE_CONV      = wx.NewIdRef()
         self.ID_ALT_SHIFT_C_LIST = wx.NewIdRef()
         self.ID_CONV_DATA_LIST   = wx.NewIdRef()
@@ -16405,6 +16428,7 @@ class ArchivedConversationsPanel(wx.Panel):
         CS = wx.ACCEL_CTRL | wx.ACCEL_SHIFT
         AS = wx.ACCEL_ALT | wx.ACCEL_SHIFT
         accel_tbl = wx.AcceleratorTable([
+            (wx.ACCEL_CTRL,   ord("F"),        self.ID_CTRL_F),
             (wx.ACCEL_NORMAL, wx.WXK_DELETE, self.ID_DELETE_CONV),
             (AS,              ord("C"),      self.ID_ALT_SHIFT_C_LIST),
             (CS,              ord("D"),      self.ID_CONV_DATA_LIST),
@@ -16416,6 +16440,7 @@ class ArchivedConversationsPanel(wx.Panel):
             (wx.ACCEL_CTRL,   ord("P"),      self.ID_PIN_LIST),
         ])
         self.SetAcceleratorTable(accel_tbl)
+        self.Bind(wx.EVT_MENU, self.on_ctrl_f,                    id=self.ID_CTRL_F)
         self.Bind(wx.EVT_MENU, self._on_accel_delete,             id=self.ID_DELETE_CONV)
         self.Bind(wx.EVT_MENU, self._on_accel_copy_number,        id=self.ID_ALT_SHIFT_C_LIST)
         self.Bind(wx.EVT_MENU, self._on_accel_conversation_data,  id=self.ID_CONV_DATA_LIST)
@@ -16520,6 +16545,29 @@ class ArchivedConversationsPanel(wx.Panel):
             self._on_pin(jid)
 
     # ── Events ────────────────────────────────────────────────────────────────
+
+    def on_search_query_changed(self, event):
+        """Mirrors ConversationsPanel.on_search_query_changed(): route through
+        add_chats_to_ui() (never _refresh_archived_chats_in_ui() directly) so
+        the active filter and this field's own query are applied together and
+        every other consequence of a rebuild (focus/selection restore) is
+        the one already exercised by the filter tabs above."""
+        self.main_window.add_chats_to_ui()
+
+    def on_ctrl_f(self, event):
+        self.search_field.SetFocus()
+
+    def _on_search_field_key_down(self, event):
+        """Down arrow in the search field moves focus to the first archived
+        conversation — mirrors ConversationsPanel._on_search_field_key_down()."""
+        if event.GetKeyCode() == wx.WXK_DOWN:
+            lst = self.conversations_list
+            if lst.GetItemCount() > 0:
+                lst.SetFocus()
+                lst.Focus(0)
+                lst.Select(0)
+            return
+        event.Skip()
 
     def _on_filter_changed(self, event):
         """Update the active conversation filter and rebuild the list."""
@@ -16782,6 +16830,8 @@ class ArchivedConversationsPanel(wx.Panel):
         self.conversations_list.SetColumn(0, col)
         if getattr(self, "_list_accessible", None) is not None:
             self._list_accessible._label = i18n.t("archived_chats")
+        if hasattr(self, "search_label"):
+            self.search_label.SetLabel(i18n.t("search_archived_conversations"))
 
         if hasattr(self, "_filter_radio"):
             self._filter_radio.SetLabel(i18n.t("conv_filter_label"))

--- a/tests/test_archived_chats_search.py
+++ b/tests/test_archived_chats_search.py
@@ -1,0 +1,273 @@
+"""Tests for the search field added to the archived-chats panel.
+
+Mirrors ConversationsPanel's own search field (same Ctrl+F shortcut, same
+Down-arrow-to-first-result behavior, same "route through the rebuilder rather
+than touch the list directly" wiring), but scoped to the archived list only:
+this field must never reach chats outside ArchivedConversationsPanel, unlike
+the main panel's field, which merges in archived results on a non-empty query
+(see MainWindow._conversation_search_candidates(), tests/test_conversation_search_candidates.py).
+
+MainWindow and ArchivedConversationsPanel are a wx.Frame/wx.Panel and cannot be
+instantiated without a running wx.App, so both the filtering logic and the
+event handlers are exercised as plain functions against stubs — same approach
+as tests/test_search_normalization.py and tests/test_archived_chats.py.
+"""
+
+import wx
+
+from main import MainWindow
+from ui.conversations import ArchivedConversationsPanel
+
+GROUP = "120363151058129530@g.us"
+ANA = "5511999999999@s.whatsapp.net"
+BEL = "5511888888888@s.whatsapp.net"
+
+
+def _chat(jid, unread=0):
+    chat = {"remoteJid": jid, "unreadCount": unread}
+    if unread:
+        # effective_unread_count() suppresses a reported count to 0 unless at
+        # least one local message record backs it up (core/utils.py) — give
+        # every "unread" fixture one, or the unread-filter tests below would
+        # be exercising the suppression instead of the filter.
+        chat["messages"] = {"messages": {"records": [{"key": {"id": "m1"}}]}}
+    return chat
+
+
+class TestFilterArchivedChats:
+    """MainWindow._filter_archived_chats() — the staticmethod _refresh_archived_chats_in_ui()
+    delegates to, combining the filter tabs with this panel's own search field."""
+
+    def test_no_filter_no_search_keeps_everything(self):
+        chats = [_chat(ANA), _chat(GROUP)]
+        names = ["Ana", "Grupo"]
+        out_chats, out_names = MainWindow._filter_archived_chats(
+            chats, names, "all", "", "off"
+        )
+        assert out_names == ["Ana", "Grupo"]
+        assert out_chats == chats
+
+    def test_search_matches_by_name_case_insensitively(self):
+        chats = [_chat(ANA), _chat(BEL)]
+        names = ["Ana", "Beatriz"]
+        out_chats, out_names = MainWindow._filter_archived_chats(
+            chats, names, "all", "ana", "off"
+        )
+        assert out_names == ["Ana"]
+        assert out_chats == [chats[0]]
+
+    def test_search_with_no_match_returns_nothing(self):
+        chats = [_chat(ANA)]
+        names = ["Ana"]
+        out_chats, out_names = MainWindow._filter_archived_chats(
+            chats, names, "all", "carlos", "off"
+        )
+        assert out_chats == [] and out_names == []
+
+    def test_filter_and_search_combine(self):
+        """A group named "Ana" must not survive the 'individual' filter even
+        though the search matches it — both conditions apply together."""
+        chats = [_chat(ANA), _chat(GROUP)]
+        names = ["Ana", "Ana e amigos"]
+        out_chats, _ = MainWindow._filter_archived_chats(
+            chats, names, "individual", "ana", "off"
+        )
+        assert out_chats == [chats[0]]
+
+    def test_unread_filter_still_applies_with_search_active(self):
+        chats = [_chat(ANA, unread=0), _chat(BEL, unread=2)]
+        names = ["Ana", "Ana Beatriz"]
+        out_chats, _ = MainWindow._filter_archived_chats(
+            chats, names, "unread", "ana", "off"
+        )
+        assert out_chats == [chats[1]]
+
+    def test_search_folding_mode_is_honoured(self):
+        """The archived search reuses the same Unicode-normalization setting
+        as every other search in the app (Settings > Geral)."""
+        chats = [_chat(ANA)]
+        names = ["Reunião"]
+        assert MainWindow._filter_archived_chats(chats, names, "all", "reuniao", "off")[0] == []
+        assert MainWindow._filter_archived_chats(chats, names, "all", "reuniao", "nfd")[0] == chats
+
+    def test_empty_search_does_not_filter_by_name_at_all(self):
+        """An empty query is not "match the empty string" — it means the
+        search box is inert and only the filter tabs apply."""
+        chats = [_chat(ANA)]
+        names = [""]
+        out_chats, _ = MainWindow._filter_archived_chats(chats, names, "all", "", "off")
+        assert out_chats == chats
+
+
+class _FakeAccessible:
+    def __init__(self, shortcut=None):
+        self.shortcut = shortcut
+
+
+class _FakeSearchField:
+    def __init__(self, value=""):
+        self._value = value
+        self.focused = False
+        self._accessible = None
+
+    def GetValue(self):
+        return self._value
+
+    def SetFocus(self):
+        self.focused = True
+
+    def SetAccessible(self, acc):
+        self._accessible = acc
+
+    def Bind(self, *a, **kw):
+        pass
+
+
+class _FakeConversationsList:
+    def __init__(self, count=0):
+        self._count = count
+        self.focused = False
+        self.focused_row = None
+        self.selected_row = None
+
+    def GetItemCount(self):
+        return self._count
+
+    def SetFocus(self):
+        self.focused = True
+
+    def Focus(self, row):
+        self.focused_row = row
+
+    def Select(self, row):
+        self.selected_row = row
+
+
+class _FakeKeyEvent:
+    def __init__(self, key_code):
+        self._key_code = key_code
+        self.skipped = False
+
+    def GetKeyCode(self):
+        return self._key_code
+
+    def Skip(self):
+        self.skipped = True
+
+
+class _FakeMainWindow:
+    def __init__(self):
+        self.add_chats_to_ui_calls = 0
+
+    def add_chats_to_ui(self):
+        self.add_chats_to_ui_calls += 1
+
+
+class _ArchivedStub:
+    """Binds the unbound ArchivedConversationsPanel methods under test onto a
+    plain stub — ArchivedConversationsPanel is a wx.Panel and needs a live
+    wx.App to construct."""
+
+    on_search_query_changed = ArchivedConversationsPanel.on_search_query_changed
+    on_ctrl_f = ArchivedConversationsPanel.on_ctrl_f
+    _on_search_field_key_down = ArchivedConversationsPanel._on_search_field_key_down
+
+    def __init__(self, list_count=1):
+        self.main_window = _FakeMainWindow()
+        self.search_field = _FakeSearchField()
+        self.conversations_list = _FakeConversationsList(list_count)
+
+
+class TestSearchFieldWiring:
+    def test_typing_routes_through_add_chats_to_ui(self):
+        """Never a direct call to _refresh_archived_chats_in_ui(): routing
+        through add_chats_to_ui() is what keeps the active filter tab and
+        this query applied together, exactly like the main panel's own field."""
+        panel = _ArchivedStub()
+
+        panel.on_search_query_changed(None)
+
+        assert panel.main_window.add_chats_to_ui_calls == 1
+
+    def test_ctrl_f_focuses_the_search_field(self):
+        panel = _ArchivedStub()
+
+        panel.on_ctrl_f(None)
+
+        assert panel.search_field.focused is True
+
+    def test_down_arrow_moves_focus_to_the_first_result(self):
+        panel = _ArchivedStub(list_count=3)
+        event = _FakeKeyEvent(wx.WXK_DOWN)
+
+        panel._on_search_field_key_down(event)
+
+        assert panel.conversations_list.focused is True
+        assert panel.conversations_list.focused_row == 0
+        assert panel.conversations_list.selected_row == 0
+        assert event.skipped is False
+
+    def test_down_arrow_does_nothing_when_there_are_no_results(self):
+        panel = _ArchivedStub(list_count=0)
+        event = _FakeKeyEvent(wx.WXK_DOWN)
+
+        panel._on_search_field_key_down(event)
+
+        assert panel.conversations_list.focused is False
+        # Still consumed (matches ConversationsPanel._on_search_field_key_down,
+        # which also returns without calling event.Skip() on WXK_DOWN).
+        assert event.skipped is False
+
+    def test_other_keys_are_not_consumed(self):
+        panel = _ArchivedStub(list_count=3)
+        event = _FakeKeyEvent(ord("A"))
+
+        panel._on_search_field_key_down(event)
+
+        assert event.skipped is True
+        assert panel.conversations_list.focused is False
+
+
+class TestSearchFieldSourceWiring:
+    """Source-level checks for what a stub can't exercise: the widget's
+    placement, its accessible shortcut, the accelerator table entry, and the
+    label being kept in sync on a language change — mirrors the style of
+    TestArchivedPanelAccessibility in tests/test_archived_chats.py."""
+
+    def test_search_field_is_created_after_the_filter_radio_and_before_the_list(self):
+        import inspect
+
+        src = inspect.getsource(ArchivedConversationsPanel._init_ui)
+        filter_pos = src.index("self._filter_radio")
+        search_pos = src.index("self.search_field")
+        list_pos = src.index("self.conversations_list = wx.ListCtrl")
+        assert filter_pos < search_pos < list_pos
+
+    def test_search_field_reports_ctrl_f_as_its_shortcut(self):
+        import inspect
+
+        src = inspect.getsource(ArchivedConversationsPanel._init_ui)
+        assert 'AccessibleSearchConversations("Ctrl+F")' in src
+        assert "search_field.SetAccessible" in src
+
+    def test_search_label_uses_the_archived_specific_key(self):
+        import inspect
+
+        src = inspect.getsource(ArchivedConversationsPanel._init_ui)
+        assert '"search_archived_conversations"' in src
+        # And not the plain conversations key, which would misdescribe scope
+        # (this field only searches archived chats) to a screen-reader user.
+        assert '"search_conversations"' not in src
+
+    def test_ctrl_f_is_wired_in_the_accelerator_table(self):
+        import inspect
+
+        src = inspect.getsource(ArchivedConversationsPanel.create_accelerator_table)
+        assert 'ord("F")' in src
+        assert "self.on_ctrl_f" in src
+
+    def test_relabelling_updates_the_search_label_too(self):
+        import inspect
+
+        src = inspect.getsource(ArchivedConversationsPanel.refresh_labels)
+        assert "search_archived_conversations" in src

--- a/tests/test_archived_context_menu.py
+++ b/tests/test_archived_context_menu.py
@@ -14,8 +14,10 @@ deliberate differences: Archive/Unarchive always shows "Desarquivar" (every
 row here is archived by definition, nothing to toggle), and "Close
 conversation" is left out (there is no split conversation view to close from
 this list). create_accelerator_table() gives it the same key combos as the
-normal list's, minus Ctrl+F/Ctrl+N (no search field here) and Ctrl+W (not
-applicable), with Ctrl+Q hardwired to unarchive instead of toggling.
+normal list's, minus Ctrl+N (nowhere to create a conversation from this list)
+and Ctrl+W (not applicable), with Ctrl+Q hardwired to unarchive instead of
+toggling. Ctrl+F is bound too, now that this panel has its own search field
+(scoped to archived chats only — see tests/test_archived_chats_search.py).
 
 Both panels are wx.Panel subclasses and cannot be instantiated without a
 running wx.App, so the menu-building methods (which construct real wx.Menu
@@ -126,13 +128,20 @@ class TestAcceleratorTableParity:
         ):
             assert combo in src, f"{combo} missing from the archived list's accelerator table"
 
-    def test_search_and_new_conversation_and_close_are_not_bound(self):
-        """No search field and no split conversation view on this panel —
-        binding these would either do nothing or crash."""
+    def test_new_conversation_and_close_are_not_bound(self):
+        """Nowhere to create a conversation from, and no split conversation
+        view on this panel — binding these would either do nothing or crash."""
         src = inspect.getsource(ArchivedConversationsPanel.create_accelerator_table)
-        assert 'ord("F")' not in src
         assert 'ord("N")' not in src
         assert 'ord("W")' not in src
+
+    def test_ctrl_f_focuses_this_panels_own_search_field(self):
+        """This panel gained its own search field (scoped to archived chats
+        only) — Ctrl+F must focus it, distinct from ConversationsPanel's,
+        which additionally merges in archived results on a non-empty query."""
+        src = inspect.getsource(ArchivedConversationsPanel.create_accelerator_table)
+        assert 'ord("F")' in src
+        assert "self.on_ctrl_f" in src
 
     def test_ctrl_q_always_unarchives_never_toggles(self):
         src = inspect.getsource(ArchivedConversationsPanel.create_accelerator_table)


### PR DESCRIPTION
Adds a search field to `ArchivedConversationsPanel`, positioned after the filter tabs and before the list.

- Same behaviors as the main conversations panel's search field: Ctrl+F focuses it ([accessible.py](client/ui/accessible.py)'s `AccessibleSearchConversations`), Down arrow moves focus to the first result, typing routes through `add_chats_to_ui()`.
- Scoped to archived chats only — a new `MainWindow._filter_archived_chats()` staticmethod combines the filter tabs with this field's own query, independent of the main panel's field (which additionally merges in archived results on a non-empty query).
- Label: "Pesquisar nas conversas arquivadas" (`search_archived_conversations`), added to all five locales.
- Updated the two existing tests/comments that documented "no search field on this panel" as a deliberate omission.

Full suite green (7060 passed, 73 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)